### PR TITLE
[SYCL] Add graph record and replay entry points

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -9,11 +9,17 @@
 #pragma once
 
 #include <sycl/detail/defines_elementary.hpp>
+#include <sycl/queue.hpp>
+
+#include "graph_defines.hpp"
 
 #include <list>
 #include <set>
 
 namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+class queue;
+}
 namespace ext {
 namespace oneapi {
 namespace experimental {
@@ -141,8 +147,6 @@ struct node {
 
   void set_root() { MGraph->add_root(MNode); }
 };
-
-enum class graph_state { modifiable, executable };
 
 template <graph_state State = graph_state::modifiable> class command_graph {
 public:

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -19,7 +19,7 @@
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 class queue;
-}
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
 namespace ext {
 namespace oneapi {
 namespace experimental {

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -19,7 +19,7 @@
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 class queue;
-} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+
 namespace ext {
 namespace oneapi {
 namespace experimental {
@@ -223,5 +223,6 @@ void command_graph<graph_state::executable>::exec_and_wait(sycl::queue q) {
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
 

--- a/sycl/include/sycl/ext/oneapi/experimental/graph_defines.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph_defines.hpp
@@ -16,6 +16,9 @@ enum class graph_state {
   modifiable,
   executable,
 };
+
+/// Forward declaration for command_graph
+template <graph_state State> class command_graph;
 }
 } // namespace oneapi
 } // namespace ext

--- a/sycl/include/sycl/ext/oneapi/experimental/graph_defines.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph_defines.hpp
@@ -1,4 +1,5 @@
-//==--------- graph.hpp --- SYCL graph extension ---------------------------==//
+//==--------- graph_defines.hpp --- SYCL graph extension
+//---------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,6 +10,7 @@
 #pragma once
 
 namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace ext {
 namespace oneapi {
 namespace experimental {
@@ -22,4 +24,5 @@ template <graph_state State> class command_graph;
 }
 } // namespace oneapi
 } // namespace ext
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/graph_defines.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph_defines.hpp
@@ -1,0 +1,22 @@
+//==--------- graph.hpp --- SYCL graph extension ---------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace sycl {
+namespace ext {
+namespace oneapi {
+namespace experimental {
+enum class graph_state {
+  modifiable,
+  executable,
+};
+}
+} // namespace oneapi
+} // namespace ext
+} // namespace sycl

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -74,8 +74,15 @@ static event submitAssertCapture(queue &, event &, queue *,
 #endif
 } // namespace detail
 
-// State of a queue, returned by info::queue::state
+namespace ext {
+namespace oneapi {
+namespace experimental {
+// State of a queue with regards to graph recording,
+// returned by info::queue::state
 enum class queue_state { executing, recording };
+} // namespace experimental
+} // namespace oneapi
+} // namespace ext
 
 /// Encapsulates a single SYCL queue which schedules kernels on a SYCL device.
 ///

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -53,16 +53,6 @@
 #define __SYCL_USE_FALLBACK_ASSERT 0
 #endif
 
-/// Forward declare graphs
-namespace sycl {
-namespace ext {
-namespace oneapi {
-namespace experimental {
-template <graph_state state> class command_graph;
-}
-} // namespace oneapi
-} // namespace ext
-} // namespace sycl
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -1085,18 +1085,22 @@ public:
 
 public:
   /// Places the queue into command_graph recording mode.
-  /// Returns true if the queue was not already in recording mode.
-  bool begin_recording(
-      sycl::ext::oneapi::experimental::command_graph<
-          sycl::ext::oneapi::experimental::graph_state::modifiable> &graph);
+  ///
+  /// \return true if the queue was not already in recording mode.
+  bool
+  begin_recording(ext::oneapi::experimental::command_graph<
+                  ext::oneapi::experimental::graph_state::modifiable> &graph);
 
   /// Ends recording mode on the queue and returns to the normal state.
-  /// Returns true if the queue was already in recording mode.
+  ///
+  /// \return true if the queue was already in recording mode.
   bool end_recording();
 
   /// Submits an executable command_graph for execution on this queue
-  event submit(sycl::ext::oneapi::experimental::command_graph<
-               sycl::ext::oneapi::experimental::graph_state::executable>
+  ///
+  /// \return an event representing the execution of the command_graph
+  event submit(ext::oneapi::experimental::command_graph<
+               ext::oneapi::experimental::graph_state::executable>
                    graph);
 
 private:

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -230,7 +230,7 @@ bool queue::end_recording() {
 event queue::submit(ext::oneapi::experimental::command_graph<
              ext::oneapi::experimental::graph_state::executable>
                  graph) {
-  // Empty implementation
+  graph.exec_and_wait(*this);
   return {};
 }
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -215,19 +215,19 @@ bool queue::device_has(aspect Aspect) const {
   return impl->getDeviceImplPtr()->has(Aspect);
 }
 
-bool begin_recording(
+bool queue::begin_recording(
     ext::oneapi::experimental::command_graph<
         ext::oneapi::experimental::graph_state::modifiable> &graph) {
   // Empty Implementation
   return true;
 }
 
-bool end_recording() {
+bool queue::end_recording() {
   // Empty Implementation
   return true;
 }
 
-event submit(ext::oneapi::experimental::command_graph<
+event queue::submit(ext::oneapi::experimental::command_graph<
              ext::oneapi::experimental::graph_state::executable>
                  graph) {
   // Empty implementation

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -216,8 +216,8 @@ bool queue::device_has(aspect Aspect) const {
 }
 
 bool begin_recording(
-    sycl::ext::oneapi::experimental::command_graph<
-        sycl::ext::oneapi::experimental::graph_state::modifiable> &graph) {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable> &graph) {
   // Empty Implementation
   return true;
 }
@@ -227,10 +227,11 @@ bool end_recording() {
   return true;
 }
 
-event submit(sycl::ext::oneapi::experimental::command_graph<
-             sycl::ext::oneapi::experimental::graph_state::executable>
+event submit(ext::oneapi::experimental::command_graph<
+             ext::oneapi::experimental::graph_state::executable>
                  graph) {
-  return sycl::event{};
+  // Empty implementation
+  return {};
 }
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -15,6 +15,8 @@
 #include <sycl/queue.hpp>
 #include <sycl/stl.hpp>
 
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
 #include <algorithm>
 
 namespace sycl {
@@ -211,6 +213,24 @@ buffer<detail::AssertHappened, 1> &queue::getAssertHappenedBuffer() {
 bool queue::device_has(aspect Aspect) const {
   // avoid creating sycl object from impl
   return impl->getDeviceImplPtr()->has(Aspect);
+}
+
+bool begin_recording(
+    sycl::ext::oneapi::experimental::command_graph<
+        sycl::ext::oneapi::experimental::graph_state::modifiable> &graph) {
+  // Empty Implementation
+  return true;
+}
+
+bool end_recording() {
+  // Empty Implementation
+  return true;
+}
+
+event submit(sycl::ext::oneapi::experimental::command_graph<
+             sycl::ext::oneapi::experimental::graph_state::executable>
+                 graph) {
+  return sycl::event{};
 }
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/test/graph/graph-record-simple.cpp
+++ b/sycl/test/graph/graph-record-simple.cpp
@@ -1,0 +1,46 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+const size_t n = 10;
+
+int main() {
+
+  sycl::property_list properties{
+      sycl::property::queue::in_order(),
+      sycl::ext::oneapi::property::queue::lazy_execution{}};
+
+  sycl::queue q{sycl::gpu_selector_v, properties};
+
+  sycl::ext::oneapi::experimental::command_graph g;
+
+  float *arr = sycl::malloc_shared<float>(n, q);
+
+  q.begin_recording(g);
+
+  q.submit([&](sycl::handler &h) {
+    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> idx) {
+      size_t i = idx;
+      arr[i] = 1;
+    });
+  });
+
+  q.end_recording();
+
+  auto result_before_exec1 = arr[0];
+
+  auto exec_graph = g.finalize(q.get_context());
+
+  auto result_before_exec2 = arr[0];
+
+  q.submit(exec_graph);
+
+  auto result = arr[0];
+
+  std::cout << "done.\n";
+
+  return 0;
+}


### PR DESCRIPTION
- Add entry points to queue for graph record and replay (empty implementation)
- Add queue_state enum (currently unused)
- Move graph_state enum into separate header.

Note: Targeting the sycl-graph-poc-v2 branch for now until #5 is merged.