### PR TITLE
Specify error on finalize if a graph has a cycle

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -513,10 +513,17 @@ Preconditions:
 
 Parameters:
 
-* `syclContext` - The context asscociated with the queues to which the
+* `syclContext` - The context associated with the queues to which the
   executable graph will be able to be submitted.
 
 Returns: An executable graph object which can be submitted to a queue.
+
+Exceptions:
+
+* Throws synchronously with error code `invalid` if the graph contains a cycle.
+  A cycle may be introduced to the graph via a call to `make_edge()` that
+  creates a forward dependency.
+
 |===
 
 Memory that is allocated by the following functions is owned by the specific


### PR DESCRIPTION
We define a graph as a DAG, and therefore it is invalid for a graph to contain a cycle. However, it is possible in the API for a user to introduce a cycle via a call to `make_edge` that introduces a forward dependency.

Checking for cycles on `make_edge` itself may have negative performance implications, as the function can be called frequently and on larger graphs a cycle may not be cheap to check for.

Instead, I've specified an error on finalize because this entry-point is already intended to be where to costly work is done. Additionally, this is where the runtime translates the graph to a backend API, and it is unlikely that the backend API will provide a mechanism for defining forward edges. Therefore, the runtime will naturally hit a obstacle in using the backend API and be able to throw an exception at that point.

Issue https://github.com/reble/llvm/issues/12