### PR TITLE
State that node class has common reference semantics

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -312,10 +312,14 @@ public:
 
 === Node
 
+:crs: https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:reference-semantics
+
 Node is a class that encapsulates tasks like SYCL kernel functions, device
 memory allocations/frees, or host tasks for deferred execution. A graph has to
 be created first, the structure of a graph is defined second by adding nodes and
 edges.
+
+The `node` class provides the {crs}[common reference semantics].
 
 [source,c++]
 ----
@@ -325,8 +329,6 @@ namespace sycl::ext::oneapi::experimental {
 ----
 
 === Graph
-
-:crs: https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:reference-semantics
 
 This extension adds a new `command_graph` object which follows the
 {crs}[common reference semantics] of other SYCL runtime objects.


### PR DESCRIPTION
SYCL [common reference semantics](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:reference-semantics) define copy, move, destruction, and equality requirements for runtime classes. I couldn't think of a reason why the `node` class shouldn't share the same behaviour for these as other SYCL objects.

Issue https://github.com/reble/llvm/issues/22