### PR TITLE
Common changes from record & replay API

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -9,11 +9,17 @@
 #pragma once
 
 #include <sycl/detail/defines_elementary.hpp>
+#include <sycl/queue.hpp>
+
+#include "graph_defines.hpp"
 
 #include <list>
 #include <set>
 
 namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+class queue;
+
 namespace ext {
 namespace oneapi {
 namespace experimental {
@@ -142,8 +148,6 @@ struct node {
   void set_root() { MGraph->add_root(MNode); }
 };
 
-enum class graph_state { modifiable, executable };
-
 template <graph_state State = graph_state::modifiable> class command_graph {
 public:
   // Adding empty node with [0..n] predecessors:
@@ -219,5 +223,6 @@ void command_graph<graph_state::executable>::exec_and_wait(sycl::queue q) {
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
 

--- a/sycl/include/sycl/ext/oneapi/experimental/graph_defines.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph_defines.hpp
@@ -1,0 +1,28 @@
+//==--------- graph_defines.hpp --- SYCL graph extension
+//---------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext {
+namespace oneapi {
+namespace experimental {
+enum class graph_state {
+  modifiable,
+  executable,
+};
+
+/// Forward declaration for command_graph
+template <graph_state State> class command_graph;
+}
+} // namespace oneapi
+} // namespace ext
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -23,6 +23,8 @@
 #include <sycl/property_list.hpp>
 #include <sycl/stl.hpp>
 
+#include <sycl/ext/oneapi/experimental/graph_defines.hpp>
+
 // Explicitly request format macros
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS 1
@@ -1067,6 +1069,14 @@ public:
   ///
   /// \return the backend associated with this queue.
   backend get_backend() const noexcept;
+
+public:
+  /// Submits an executable command_graph for execution on this queue
+  ///
+  /// \return an event representing the execution of the command_graph
+  event submit(ext::oneapi::experimental::command_graph<
+               ext::oneapi::experimental::graph_state::executable>
+                   graph);
 
 private:
   pi_native_handle getNative() const;

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -15,6 +15,8 @@
 #include <sycl/queue.hpp>
 #include <sycl/stl.hpp>
 
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
 #include <algorithm>
 
 namespace sycl {
@@ -211,6 +213,13 @@ buffer<detail::AssertHappened, 1> &queue::getAssertHappenedBuffer() {
 bool queue::device_has(aspect Aspect) const {
   // avoid creating sycl object from impl
   return impl->getDeviceImplPtr()->has(Aspect);
+}
+
+event queue::submit(ext::oneapi::experimental::command_graph<
+             ext::oneapi::experimental::graph_state::executable>
+                 graph) {
+  graph.exec_and_wait(*this);
+  return {};
 }
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl


### PR DESCRIPTION
Changes to common code from https://github.com/reble/llvm/pull/6 which has already been reviewed and merged into the `sycl-graph-record-replay` branch.

This patch should not contain anything specific to the record and replay API.