### PR TITLE
[SYCL] Minor graph classes refactor

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -154,7 +154,7 @@ class node {
 public:
   template <typename T>
   node(detail::graph_ptr g, T cgf)
-      : MGraph(g), impl(new detail::node_impl(g, cgf)){};
+      : MGraph(g), impl(new detail::node_impl(g, cgf)) {}
   void register_successor(node n) { impl->register_successor(n.impl); }
   void exec(sycl::queue q) { impl->exec(q); }
 

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -156,7 +156,7 @@ public:
   node(detail::graph_ptr g, T cgf)
       : MGraph(g), impl(new detail::node_impl(g, cgf)){};
   void register_successor(node n) { impl->register_successor(n.impl); }
-  void exec(sycl::queue q, sycl::event = sycl::event()) { impl->exec(q); }
+  void exec(sycl::queue q) { impl->exec(q); }
 
 private:
   node(detail::node_ptr Impl) : impl(Impl) {}
@@ -204,17 +204,16 @@ private:
 
 template <> class command_graph<graph_state::executable> {
 public:
-  int MTag;
-  const sycl::context &MCtx;
-
   void exec_and_wait(sycl::queue q);
 
   command_graph() = delete;
 
   command_graph(detail::graph_ptr g, const sycl::context &ctx)
-      : impl(g), MCtx(ctx), MTag(rand()) {}
+      : MTag(rand()), MCtx(ctx), impl(g) {}
 
 private:
+  int MTag;
+  const sycl::context &MCtx;
   detail::graph_ptr impl;
 };
 

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -130,22 +130,45 @@ struct graph_impl {
     MSchedule.clear();
   }
 
+  template <typename T>
+  node_ptr add(graph_ptr impl, T cgf, const std::vector<node_ptr> &dep = {}) {
+    node_ptr nodeImpl = std::make_shared<node_impl>(impl, cgf);
+    if (!dep.empty()) {
+      for (auto n : dep) {
+        n->register_successor(nodeImpl); // register successor
+        this->remove_root(nodeImpl);     // remove receiver from root node
+                                         // list
+      }
+    } else {
+      this->add_root(nodeImpl);
+    }
+    return nodeImpl;
+  }
+
   graph_impl() : MFirst(true) {}
 };
 
 } // namespace detail
 
-struct node {
-  detail::node_ptr MNode;
-  detail::graph_ptr MGraph;
-
+class node {
+public:
   template <typename T>
   node(detail::graph_ptr g, T cgf)
-      : MGraph(g), MNode(new detail::node_impl(g, cgf)){};
-  void register_successor(node n) { MNode->register_successor(n.MNode); }
-  void exec(sycl::queue q, sycl::event = sycl::event()) { MNode->exec(q); }
+      : MGraph(g), impl(new detail::node_impl(g, cgf)){};
+  void register_successor(node n) { impl->register_successor(n.impl); }
+  void exec(sycl::queue q, sycl::event = sycl::event()) { impl->exec(q); }
 
-  void set_root() { MGraph->add_root(MNode); }
+private:
+  node(detail::node_ptr Impl) : impl(Impl) {}
+
+  template <class Obj>
+  friend decltype(Obj::impl)
+  sycl::detail::getSyclObjImpl(const Obj &SyclObject);
+  template <class T>
+  friend T sycl::detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
+
+  detail::node_ptr impl;
+  detail::graph_ptr MGraph;
 };
 
 template <graph_state State = graph_state::modifiable> class command_graph {
@@ -200,22 +223,22 @@ template <typename T>
 inline node
 command_graph<graph_state::modifiable>::add(T cgf,
                                             const std::vector<node> &dep) {
-  node ret_val(impl, cgf);
-  if (!dep.empty()) {
-    for (auto n : dep)
-      this->make_edge(n, ret_val);
-  } else {
-    ret_val.set_root();
+  std::vector<detail::node_ptr> depImpls;
+  for (auto &d : dep) {
+    depImpls.push_back(sycl::detail::getSyclObjImpl(d));
   }
-  return ret_val;
+
+  auto nodeImpl = impl->add(impl, cgf, depImpls);
+  return sycl::detail::createSyclObjFromImpl<node>(nodeImpl);
 }
 
 template <>
 inline void command_graph<graph_state::modifiable>::make_edge(node sender,
                                                               node receiver) {
   sender.register_successor(receiver);     // register successor
-  impl->remove_root(receiver.MNode);       // remove receiver from root node
-                                           // list
+  impl->remove_root(
+      sycl::detail::getSyclObjImpl(receiver)); // remove receiver from root node
+                                               // list
 }
 
 template <>
@@ -227,7 +250,7 @@ command_graph<graph_state::executable> inline command_graph<
 inline void
 command_graph<graph_state::executable>::exec_and_wait(sycl::queue q) {
   impl->exec_and_wait(q);
-};
+}
 
 } // namespace experimental
 } // namespace oneapi

--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -32,10 +32,8 @@ int main() {
       sycl::ext::oneapi::property::queue::lazy_execution{}
     };
 
-    sycl::gpu_selector device_selector;
-    
-    sycl::queue q{device_selector, properties};
-    
+    sycl::queue q{sycl::gpu_selector_v, properties};
+
     sycl::ext::oneapi::experimental::command_graph g;
     
     float *dotp = sycl::malloc_shared<float>(1, q);
@@ -80,7 +78,11 @@ int main() {
     auto exec_graph = g.finalize(q.get_context());
     
     exec_graph.exec_and_wait(q);
-    
+
+    if (*dotp != host_gold_result()) {
+      std::cout << "Error unexpected result!\n";
+    }
+
     sycl::free(dotp, q);
     sycl::free(x, q);
     sycl::free(y, q);


### PR DESCRIPTION
Some minor refactoring to:
- Support the DPC++ pimpl mechanisms: `createSyclObjFromImpl` and `getSyclObjImpl`
- Move some functionality into impl classes where appropriate
- Minor improvements to explicit dotp test to add basic results checking and fix a compiler warning.