### PR TITLE
Implement basic record and replay functionality

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -144,7 +144,12 @@ struct graph_impl {
     } else {
       this->add_root(nodeImpl);
     }
+    MLastNode = nodeImpl;
     return nodeImpl;
+  }
+
+  node_ptr getLastNode() const{
+    return MLastNode;
   }
 
   graph_impl() : MFirst(true) {}

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -91,6 +91,8 @@ struct node_impl {
 };
 
 struct graph_impl {
+  // The last node added to the graph.
+  node_ptr MLastNode;
   std::set<node_ptr> MRoots;
   std::list<node_ptr> MSchedule;
   // TODO: Change one time initialization to per executable object

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -148,9 +148,7 @@ struct graph_impl {
     return nodeImpl;
   }
 
-  node_ptr getLastNode() const{
-    return MLastNode;
-  }
+  node_ptr getLastNode() const { return MLastNode; }
 
   graph_impl() : MFirst(true) {}
 };

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -538,6 +538,10 @@ private:
     event Event = detail::createSyclObjFromImpl<event>(
         std::make_shared<detail::event_impl>());
     if (auto graphImpl = Self->getCommandGraph(); graphImpl != nullptr) {
+
+      // TODO: Simple implementation schedules all recorded nodes in order with
+      // each having a dependency on the previous node. This should be improved
+      // to correctly determine edges and dependencies.
       std::vector<ext::oneapi::experimental::detail::node_ptr> deps;
       if (auto lastNode = graphImpl->getLastNode(); lastNode != nullptr) {
         deps.push_back(lastNode);

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -223,9 +223,9 @@ bool queue::begin_recording(
     impl->setCommandGraph(
         sycl::detail::getSyclObjImpl<command_graph<graph_state::modifiable>>(
             graph));
-    return false;
+    return true;
   }
-  return true;
+  return false;
 }
 
 bool queue::end_recording() {

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -218,13 +218,22 @@ bool queue::device_has(aspect Aspect) const {
 bool queue::begin_recording(
     ext::oneapi::experimental::command_graph<
         ext::oneapi::experimental::graph_state::modifiable> &graph) {
-  // Empty Implementation
+  using namespace ext::oneapi::experimental;
+  if (!impl->getCommandGraph()) {
+    impl->setCommandGraph(
+        sycl::detail::getSyclObjImpl<command_graph<graph_state::modifiable>>(
+            graph));
+    return false;
+  }
   return true;
 }
 
 bool queue::end_recording() {
-  // Empty Implementation
-  return true;
+  if (impl->getCommandGraph()) {
+    impl->setCommandGraph(nullptr);
+    return true;
+  }
+  return false;
 }
 
 event queue::submit(ext::oneapi::experimental::command_graph<

--- a/sycl/test/graph/graph-record-dotp.cpp
+++ b/sycl/test/graph/graph-record-dotp.cpp
@@ -1,0 +1,101 @@
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <thread>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+const size_t n = 10;
+
+float host_gold_result() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  float sum = 0.0f;
+
+  for (size_t i = 0; i < n; ++i) {
+    sum += (alpha * 1.0f + beta * 2.0f) * (gamma * 3.0f + beta * 2.0f);
+  }
+
+  return sum;
+}
+
+int main() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  float *x, *y, *z;
+
+  sycl::property_list properties{
+      sycl::property::queue::in_order(),
+      sycl::ext::oneapi::property::queue::lazy_execution{}};
+
+  sycl::queue q{sycl::gpu_selector_v, properties};
+
+  sycl::ext::oneapi::experimental::command_graph g;
+
+  float *dotp = sycl::malloc_shared<float>(1, q);
+
+  x = sycl::malloc_shared<float>(n, q);
+  y = sycl::malloc_shared<float>(n, q);
+  z = sycl::malloc_shared<float>(n, q);
+
+  q.begin_recording(g);
+
+  /* init data on the device */
+  q.submit([&](sycl::handler &h) {
+    h.parallel_for(n, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      x[i] = 1.0f;
+      y[i] = 2.0f;
+      z[i] = 3.0f;
+    });
+  });
+
+  q.submit([&](sycl::handler &h) {
+    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      x[i] = alpha * x[i] + beta * y[i];
+    });
+  });
+
+  q.submit([&](sycl::handler &h) {
+    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      z[i] = gamma * z[i] + beta * y[i];
+    });
+  });
+
+  q.submit([&](sycl::handler &h) {
+    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      // Doing a manual reduction here because reduction objects cause issues
+      // with graphs.
+      if (i == 0) {
+        for (size_t j = 0; j < n; j++) {
+          dotp[0] += x[j] * z[j];
+        }
+      }
+    });
+  });
+
+  q.end_recording();
+
+  auto exec_graph = g.finalize(q.get_context());
+
+  q.submit(exec_graph);
+
+  if (dotp[0] != host_gold_result()) {
+    std::cout << "Error unexpected result!\n";
+  }
+
+  sycl::free(dotp, q);
+  sycl::free(x, q);
+  sycl::free(y, q);
+  sycl::free(z, q);
+
+  std::cout << "done.\n";
+
+  return 0;
+}

--- a/sycl/test/graph/graph-record-dotp.cpp
+++ b/sycl/test/graph/graph-record-dotp.cpp
@@ -1,3 +1,4 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 #include <CL/sycl.hpp>
 #include <iostream>
 #include <thread>
@@ -25,8 +26,6 @@ int main() {
   float beta = 2.0f;
   float gamma = 3.0f;
 
-  float *x, *y, *z;
-
   sycl::property_list properties{
       sycl::property::queue::in_order(),
       sycl::ext::oneapi::property::queue::lazy_execution{}};
@@ -37,9 +36,9 @@ int main() {
 
   float *dotp = sycl::malloc_shared<float>(1, q);
 
-  x = sycl::malloc_shared<float>(n, q);
-  y = sycl::malloc_shared<float>(n, q);
-  z = sycl::malloc_shared<float>(n, q);
+  float *x = sycl::malloc_shared<float>(n, q);
+  float *y = sycl::malloc_shared<float>(n, q);
+  float *z = sycl::malloc_shared<float>(n, q);
 
   q.begin_recording(g);
 

--- a/sycl/test/graph/graph-record-simple.cpp
+++ b/sycl/test/graph/graph-record-simple.cpp
@@ -7,7 +7,7 @@
 
 int main() {
   const size_t n = 10;
-  const float expectedValue = 1.f;
+  const float expectedValue = 7.f;
 
   sycl::property_list properties{
       sycl::property::queue::in_order(),


### PR DESCRIPTION
Implements a very basic record and replay functionality by intercepting queue submissions and create graph nodes from them instead of executing. Also adds a record and replay version of the `dotp` example test. Both simple tests are passing.

Limitations:
- No edge determination so only simple straightforward examples work as it relies on nodes executing in submission order (which is the current behaviour).