### PR TITLE
[SYCL] Improve record and replay edge determination

### DIFF
--- a/sycl/include/sycl/stream.hpp
+++ b/sycl/include/sycl/stream.hpp
@@ -912,6 +912,11 @@ private:
 
   friend class handler;
 
+  friend void processArgImpl(std::vector<sycl::_V1::detail::ArgDesc> &,
+                             const detail::NDRDescT &, void *,
+                             const detail::kernel_param_kind_t &, const int,
+                             const size_t, size_t &, bool, bool);
+
   friend const stream &operator<<(const stream &, const char);
   friend const stream &operator<<(const stream &, const char *);
   template <typename ValueType>

--- a/sycl/include/sycl/stream.hpp
+++ b/sycl/include/sycl/stream.hpp
@@ -912,11 +912,6 @@ private:
 
   friend class handler;
 
-  friend void processArgImpl(std::vector<sycl::_V1::detail::ArgDesc> &,
-                             const detail::NDRDescT &, void *,
-                             const detail::kernel_param_kind_t &, const int,
-                             const size_t, size_t &, bool, bool);
-
   friend const stream &operator<<(const stream &, const char);
   friend const stream &operator<<(const stream &, const char *);
   template <typename ValueType>

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -57,14 +57,14 @@ void graph_impl::remove_root(node_ptr n) {
 // Recursive check if a graph node or its successors contains a given kernel
 // argument.
 //
-// @param arg The kernel argument to check for.
-// @param currentNode The current graph node being checked.
-// @param deps The unique list of dependencies which have been identified for
-// this arg.
-// @param dereferencePtr if true arg comes direct from the handler in which case
-// it will need to be deferenced to check actual value.
+// @param[in] arg The kernel argument to check for.
+// @param[in] currentNode The current graph node being checked.
+// @param[in,out] deps The unique list of dependencies which have been
+// identified for this arg.
+// @param[in] dereferencePtr if true arg comes direct from the handler in which
+// case it will need to be deferenced to check actual value.
 //
-// @returns True if a dependency was added in this node of any of it's
+// @returns True if a dependency was added in this node of any of its
 // successors.
 bool check_for_arg(const sycl::detail::ArgDesc &arg, node_ptr currentNode,
                    std::set<node_ptr> &deps, bool dereferencePtr = false) {

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -537,6 +537,9 @@ private:
                     const SubmitPostProcessF *PostProcess) {
     event Event = detail::createSyclObjFromImpl<event>(
         std::make_shared<detail::event_impl>());
+    handler Handler(Self, PrimaryQueue, SecondaryQueue, MHostQueue);
+    Handler.saveCodeLoc(Loc);
+    CGF(Handler);
     if (auto graphImpl = Self->getCommandGraph(); graphImpl != nullptr) {
 
       // TODO: Simple implementation schedules all recorded nodes in order with
@@ -546,11 +549,8 @@ private:
       if (auto lastNode = graphImpl->getLastNode(); lastNode != nullptr) {
         deps.push_back(lastNode);
       }
-      graphImpl->add(graphImpl, CGF, deps);
+      graphImpl->add(graphImpl, CGF, Handler.MArgs, deps);
     } else {
-      handler Handler(Self, PrimaryQueue, SecondaryQueue, MHostQueue);
-      Handler.saveCodeLoc(Loc);
-      CGF(Handler);
 
       // Scheduler will later omit events, that are not required to execute
       // tasks. Host and interop tasks, however, are not submitted to low-level

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -541,15 +541,9 @@ private:
     Handler.saveCodeLoc(Loc);
     CGF(Handler);
     if (auto graphImpl = Self->getCommandGraph(); graphImpl != nullptr) {
-
-      // TODO: Simple implementation schedules all recorded nodes in order with
-      // each having a dependency on the previous node. This should be improved
-      // to correctly determine edges and dependencies.
-      std::vector<ext::oneapi::experimental::detail::node_ptr> deps;
-      if (auto lastNode = graphImpl->getLastNode(); lastNode != nullptr) {
-        deps.push_back(lastNode);
-      }
-      graphImpl->add(graphImpl, CGF, Handler.MArgs, deps);
+      // Pass the args obtained by the handler to the graph to use in
+      // determining edges between this node and previously submitted nodes.
+      graphImpl->add(graphImpl, CGF, Handler.MArgs, {});
     } else {
 
       // Scheduler will later omit events, that are not required to execute

--- a/sycl/test/graph/graph-record-dotp-buffer.cpp
+++ b/sycl/test/graph/graph-record-dotp-buffer.cpp
@@ -1,0 +1,112 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <thread>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+const size_t n = 10;
+
+float host_gold_result() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  float sum = 0.0f;
+
+  for (size_t i = 0; i < n; ++i) {
+    sum += (alpha * 1.0f + beta * 2.0f) * (gamma * 3.0f + beta * 2.0f);
+  }
+
+  return sum;
+}
+
+int main() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  sycl::property_list properties{
+      sycl::property::queue::in_order(),
+      sycl::ext::oneapi::property::queue::lazy_execution{}};
+
+  sycl::queue q{sycl::gpu_selector_v, properties};
+
+  sycl::ext::oneapi::experimental::command_graph g;
+
+  float dotpData = 0.f;
+  std::vector<float> xData(n);
+  std::vector<float> yData(n);
+  std::vector<float> zData(n);
+
+  {
+    sycl::buffer dotpBuf(&dotpData, sycl::range<1>(1));
+
+    sycl::buffer xBuf(xData);
+    sycl::buffer yBuf(yData);
+    sycl::buffer zBuf(zData);
+
+    q.begin_recording(g);
+
+    /* init data on the device */
+    q.submit([&](sycl::handler &h) {
+      auto x = xBuf.get_access(h);
+      auto y = yBuf.get_access(h);
+      auto z = zBuf.get_access(h);
+      h.parallel_for(n, [=](sycl::id<1> it) {
+        const size_t i = it[0];
+        x[i] = 1.0f;
+        y[i] = 2.0f;
+        z[i] = 3.0f;
+      });
+    });
+
+    q.submit([&](sycl::handler &h) {
+      auto x = xBuf.get_access(h);
+      auto y = yBuf.get_access(h);
+      h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+        const size_t i = it[0];
+        x[i] = alpha * x[i] + beta * y[i];
+      });
+    });
+
+    q.submit([&](sycl::handler &h) {
+      auto y = yBuf.get_access(h);
+      auto z = zBuf.get_access(h);
+      h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+        const size_t i = it[0];
+        z[i] = gamma * z[i] + beta * y[i];
+      });
+    });
+
+    q.submit([&](sycl::handler &h) {
+      auto dotp = dotpBuf.get_access(h);
+      auto x = xBuf.get_access(h);
+      auto z = zBuf.get_access(h);
+      h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+        const size_t i = it[0];
+        // Doing a manual reduction here because reduction objects cause issues
+        // with graphs.
+        if (i == 0) {
+          for (size_t j = 0; j < n; j++) {
+            dotp[0] += x[j] * z[j];
+          }
+        }
+      });
+    });
+
+    q.end_recording();
+
+    auto exec_graph = g.finalize(q.get_context());
+
+    q.submit([&](sycl::handler &h) { h.exec_graph(exec_graph); });
+  }
+
+  if (dotpData != host_gold_result()) {
+    std::cout << "Error unexpected result!\n";
+  }
+
+  std::cout << "done.\n";
+
+  return 0;
+}


### PR DESCRIPTION
Improves the way that edges are detected in recorded graph nodes so that now edges should be correctly determined. Currently only tested with pointer edges (for USM pointers).

Also adds a buffer based dotp example using record and replay but this currently throws with the same error as #24.