### PR TITLE
[SYCL] Fix reductions not working inside graph

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3842,6 +3842,10 @@ pi_result piQueueFlush(pi_queue Queue) {
     std::unique_lock<pi_shared_mutex> ContextsLock(
       Queue->Device->Platform->ContextsMutex, std::defer_lock);
 
+    // TODO: Following code is duplicated from _pi_queue::executeCommandList to
+    // ensure graph submission has a host visible event. This should be
+    // addressed in a way that such large duplication is not required in future.
+
     // In this mode all inner-batch events have device visibility only,
     // and we want the last command in the batch to signal a host-visible
     // event that anybody waiting for any event in the batch will


### PR DESCRIPTION
Graph submission now properly creates a host visible event on the command list allowing auxilliary resources to be cleaned up. 
~~Code is taken from `_pi_queue::executeCommandList`, copy pasting a decent amount of code like that is not ideal but there isn't an immediately obvious solution to let us actually use that function when flushing.~~

Updated to remove code duplication, instead relying on the `OKtoBatchCommand` parameter to `executeCommandList` to let us determine when to actually submit the command list and when to block execution.

This will at least make the examples that use reductions run, though it doesn't solve related problems with buffers and other regular operations on the queue.

Closes #24 