### PR TITLE
[SYCL] Enable submitting sub-graphs

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -33,11 +33,18 @@ void graph_impl::exec(sycl::detail::queue_ptr q) {
 }
 
 void graph_impl::exec_and_wait(sycl::detail::queue_ptr q) {
+  bool isSubGraph = q->getIsGraphSubmitting();
+  if (!isSubGraph) {
+    q->setIsGraphSubmitting(true);
+  }
   if (MFirst) {
     exec(q);
     MFirst = false;
   }
-  q->wait();
+  if (!isSubGraph) {
+    q->setIsGraphSubmitting(false);
+    q->wait();
+  }
 }
 
 void graph_impl::add_root(node_ptr n) {

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -453,6 +453,14 @@ public:
     return MAssertHappenedBuffer;
   }
 
+  // Sets the flag for if a command graph is currently
+  // submitting to this queue.
+  void setIsGraphSubmitting(bool value) { MIsGraphSubmitting = value; }
+
+  // Get the flag which tells us whether the queue is currently
+  // receiving submissions from a command graph
+  bool getIsGraphSubmitting() const { return MIsGraphSubmitting; }
+
 protected:
   // template is needed for proper unit testing
   template <typename HandlerType = handler>
@@ -629,6 +637,11 @@ private:
   // able to discard events, because the final decision is made right before the
   // operation itself.
   const bool MHasDiscardEventsSupport;
+
+  // This flag is set to true if a command_graph is currently submitting
+  // commands to this queue. Used by subgraphs to determine if they are part of
+  // a larger command graph submission.
+  bool MIsGraphSubmitting = false;
 };
 
 } // namespace detail

--- a/sycl/test/graph/graph-explicit-subgraph.cpp
+++ b/sycl/test/graph/graph-explicit-subgraph.cpp
@@ -1,0 +1,103 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+
+// Modified version of the dotp example which submits part of the graph as a
+// sub-graph
+#include <CL/sycl.hpp>
+#include <iostream>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+const size_t n = 10;
+
+float host_gold_result() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  float sum = 0.0f;
+
+  for (size_t i = 0; i < n; ++i) {
+    sum += (alpha * 1.0f + beta * 2.0f) * (gamma * 3.0f + beta * 2.0f);
+  }
+
+  return sum;
+}
+
+int main() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  sycl::property_list properties{
+      sycl::property::queue::in_order{},
+      sycl::ext::oneapi::property::queue::lazy_execution{}};
+
+  sycl::queue q{sycl::gpu_selector_v, properties};
+
+  sycl::ext::oneapi::experimental::command_graph g;
+  sycl::ext::oneapi::experimental::command_graph subGraph;
+
+  float *dotp = sycl::malloc_shared<float>(1, q);
+
+  float *x = sycl::malloc_shared<float>(n, q);
+  float *y = sycl::malloc_shared<float>(n, q);
+  float *z = sycl::malloc_shared<float>(n, q);
+
+  /* init data on the device */
+  auto n_i = g.add([&](sycl::handler &h) {
+    h.parallel_for(n, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      x[i] = 1.0f;
+      y[i] = 2.0f;
+      z[i] = 3.0f;
+    });
+  });
+
+  auto node_a = subGraph.add([&](sycl::handler &h) {
+    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      x[i] = alpha * x[i] + beta * y[i];
+    });
+  });
+
+  auto node_b = subGraph.add([&](sycl::handler &h) {
+    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      z[i] = gamma * z[i] + beta * y[i];
+    });
+  });
+
+  auto subGraphExec = subGraph.finalize(q.get_context());
+
+  auto node_sub =
+      g.add([&](sycl::handler &h) { h.exec_graph(subGraphExec); }, {n_i});
+
+  auto node_c = g.add(
+      [&](sycl::handler &h) {
+        h.parallel_for(sycl::range<1>{n},
+                       sycl::reduction(dotp, 0.0f, std::plus()),
+                       [=](sycl::id<1> it, auto &sum) {
+                         const size_t i = it[0];
+                         sum += x[i] * z[i];
+                       });
+      },
+      {node_sub});
+
+  auto executable_graph = g.finalize(q.get_context());
+
+  // Using shortcut for executing a graph of commands
+  q.exec_graph(executable_graph).wait();
+
+  if (*dotp != host_gold_result()) {
+    std::cout << "Error unexpected result!\n";
+  }
+
+  sycl::free(dotp, q);
+  sycl::free(x, q);
+  sycl::free(y, q);
+  sycl::free(z, q);
+
+  std::cout << "done.\n";
+
+  return 0;
+}


### PR DESCRIPTION
- Enable submitting a sub-graph as part of a larger command_graph
- Flag added to queue_impl to enable graph to be aware it is a sub-graph and delay flush
- Adds an example which uses a subgraph in the middle of a command_graph

Note the example will currently fail at runtime without the changes from #50 