### PR TITLE
SYCL Graph emulation mode

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -937,8 +937,6 @@ struct _pi_queue : _pi_object {
 
   // Map of all command lists used in this queue.
   pi_command_list_map_t CommandListMap;
-  // TODO: Assign Graph related command lists to command_graph object
-  pi_command_list_map_t LazyCommandListMap;
 
   // Helper data structure to hold all variables related to batching
   typedef struct CommandBatch {

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -33,10 +33,7 @@ void graph_impl::exec(sycl::detail::queue_ptr q) {
 }
 
 void graph_impl::exec_and_wait(sycl::detail::queue_ptr q) {
-  if (MFirst) {
-    exec(q);
-    MFirst = false;
-  }
+  exec(q);
   q->wait();
 }
 

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -81,8 +81,6 @@ struct node_impl {
 struct graph_impl {
   std::set<node_ptr> MRoots;
   std::list<node_ptr> MSchedule;
-  // TODO: Change one time initialization to per executable object
-  bool MFirst;
 
   graph_ptr MParent;
 
@@ -95,7 +93,7 @@ struct graph_impl {
   template <typename T>
   node_ptr add(graph_ptr impl, T cgf, const std::vector<node_ptr> &dep = {});
 
-  graph_impl() : MFirst(true) {}
+  graph_impl() {}
 };
 
 } // namespace detail

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -278,12 +278,6 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
   TelemetryEvent = instrumentationProlog(CodeLoc, Name, StreamID, IId);
 #endif
 
-  if (has_property<ext::oneapi::property::queue::lazy_execution>()) {
-    const detail::plugin &Plugin = getPlugin();
-    if (Plugin.getBackend() == backend::ext_oneapi_level_zero)
-      Plugin.call<detail::PiApiKind::piQueueFlush>(getHandleRef());
-  }
-
   std::vector<std::weak_ptr<event_impl>> WeakEvents;
   std::vector<event> SharedEvents;
   {

--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -83,16 +83,15 @@ int main() {
   // Using shortcut for executing a graph of commands
   q.exec_graph(executable_graph).wait();
 
-  if (*dotp != host_gold_result()) {
-    std::cout << "Error unexpected result!\n";
-  }
+  if (*dotp == host_gold_result())
+    std::cout << "Dot product explicit graph test passed." << std::endl;
+  else
+    std::cout << "Dot product explicit graph test failed." << std::endl;
 
   sycl::free(dotp, q);
   sycl::free(x, q);
   sycl::free(y, q);
   sycl::free(z, q);
-
-  std::cout << "done.\n";
 
   return 0;
 }

--- a/sycl/test/graph/graph-explicit-reduction.cpp
+++ b/sycl/test/graph/graph-explicit-reduction.cpp
@@ -28,10 +28,13 @@ int main() {
 
   e.wait();
 
+  if (*output == 45)
+    std::cout << "Reduction explicit graph test passed." << std::endl;
+  else
+    std::cout << "Reduction explicit graph test failed." << std::endl;
+
   sycl::free(input, q);
   sycl::free(output, q);
-
-  std::cout << "done\n";
 
   return 0;
 }


### PR DESCRIPTION
This PR proposes an emulation mode for SYCL Graph. This provides the APIs of the sycl-graph-poc-v2 branch. The execution of the graph is however emulated by submitting each graph node when executing the graph (repeatedly). This addresses #20.

This provides the first step of merging the SYCL Graph POC into the mainline. The proposed process can be found here: https://github.com/intel/llvm/pull/7627#issuecomment-1335963989