### PR TITLE
Minor spec clarifications

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -256,7 +256,7 @@ system allocations (`malloc`/`new`) are not supported.
 ==== Sub-Graph
 
 A node in a graph can take the form of a nested sub-graph. This occurs when
-a command-group submission that invokes `handler::exec_graph()` with an
+a command-group submission that invokes `handler::graph()` with an
 executable graph object is added to the graph as a node.
 
 === API Modifications
@@ -330,17 +330,17 @@ public:
 
   /* -- graph convenience shortcuts -- */
 
-  event exec_graph(command_graph<graph_state::executable> graph);
-  event exec_graph(command_graph<graph_state::executable> graph,
+  event graph(command_graph<graph_state::executable> graph);
+  event graph(command_graph<graph_state::executable> graph,
                    event depEvent);
-  event exec_graph(command_graph<graph_state::executable> graph,
+  event graph(command_graph<graph_state::executable> graph,
                    const std::vector<event> &depEvents);
 };
 
 // New methods added to the sycl::handler class
 class handler {
 public:
-  void exec_graph(command_graph<graph_state::executable> graph);
+  void graph(command_graph<graph_state::executable> graph);
 }
 
 }  // namespace sycl
@@ -824,33 +824,33 @@ state, `false` otherwise.
 [source,c++]
 ----
 using namespace ext::oneapi::experimental;
-event queue::exec_graph(command_graph<graph_state::executable> graph)
+event queue::graph(command_graph<graph_state::executable> graph)
 ----
 
 |Queue shortcut function that is equivalent to submitting a command-group
-containing `handler::exec_graph(graph)`.
+containing `handler::graph(graph)`.
 
 |
 [source,c++]
 ----
 using namespace ext::oneapi::experimental;
-event queue::exec_graph(command_graph<graph_state::executable> graph,
+event queue::graph(command_graph<graph_state::executable> graph,
                         event depEvent);
 ----
 
 |Queue shortcut function that is equivalent to submitting a command-group
-containing `handler::depends_on(depEvent)` and `handler::exec_graph(graph)`.
+containing `handler::depends_on(depEvent)` and `handler::graph(graph)`.
 
 |
 [source,c++]
 ----
 using namespace ext::oneapi::experimental;
-event queue::exec_graph(command_graph<graph_state::executable> graph,
+event queue::graph(command_graph<graph_state::executable> graph,
                         const std::vector<event> &depEvents);
 ----
 
 |Queue shortcut function that is equivalent to submitting a command-group
-containing `handler::depends_on(depEvents)` and `handler::exec_graph(graph)`.
+containing `handler::depends_on(depEvents)` and `handler::graph(graph)`.
 |===
 
 ==== New Handler Member Functions
@@ -862,7 +862,7 @@ Table 10. Additional member functions of the `sycl::handler` class.
 [source,c++]
 ----
 using namespace ext::oneapi::experimental;
-void handler::exec_graph(command_graph<graph_state::executable> graph)
+void handler::graph(command_graph<graph_state::executable> graph)
 ----
 
 |Invokes the execution of a graph. Support for invoking an executable graph,
@@ -1036,7 +1036,7 @@ int main() {
   auto exec = g.finalize(q.get_context());
 
   // use queue shortcut for graph submission
-  q.exec_graph(exec).wait();
+  q.graph(exec).wait();
 
   // memory can be freed inside or outside the graph
   sycl::free(z, q.get_context());
@@ -1057,7 +1057,7 @@ command-groups submitted to the queue. Once the graph is complete, recording
 finishes on the queue to put it back into the default executing state. The
 graph is then finalized so that no more nodes can be added. Lastly, the graph is
 submitted in its entirety for execution via
-`handler::exec_graph(command_graph<graph_state::executable>)`.
+`handler::graph(command_graph<graph_state::executable>)`.
 
 [source, c++]
 ----
@@ -1126,7 +1126,7 @@ submitted in its entirety for execution via
 
   // Execute graph
   q.submit([&](handler &cgh) {
-    cgh.exec_graph(exec_graph);
+    cgh.graph(exec_graph);
   });
 
 ----

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -157,10 +157,16 @@ example via library function calls. While the explicit API can better express
 what data is internal to the graph for optimization, and dependencies don't need
 to be inferred.
 
-It is valid to combine these two mechanisms sequentially when constructing a
-graph, however it is not valid to use them concurrently. An error will be thrown
-if a user attempts to use the explicit API to add a node to a graph which is
-being recorded to by a queue.
+It is valid to combine these two mechanisms, however it is invalid to modify
+a graph using the explicit API while that graph is currently being recorded to,
+for example:
+
+[source, c++]
+----
+queue.begin_recording(graph);
+graph.add(/*command group*/);    // Invalid as graph is being recorded to
+queue.end_recording();
+----
 
 == Specification
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -568,7 +568,7 @@ using namespace ext::oneapi::experimental;
 command_graph<graph_state::executable> finalize(const context &syclContext) const;
 ----
 
-|Synchronous operation that creates a graph in the executable state with a
+|Synchronous operation that creates a new graph in the executable state with a
 fixed topology that can be submitted for execution on any queue sharing the
 supplied context. It is valid to call this method multiple times to create
 subsequent executable graphs. It is also valid to continue to add new nodes to
@@ -585,7 +585,7 @@ Parameters:
 * `syclContext` - The context associated with the queues to which the
   executable graph will be able to be submitted.
 
-Returns: An executable graph object which can be submitted to a queue.
+Returns: A new executable graph object which can be submitted to a queue.
 
 Exceptions:
 


### PR DESCRIPTION
Addressing some feedback from the PR with a few small changes:
- Rename `exec_graph` to `graph` for both the `handler` and `queue`
- Revise the wording around `finalize()` to better convey a new graph object is being created.
- Clarify the description of mixed usage of the explicit and record and replay APIs.