### PR TITLE
[SYCL] Rename exec_graph to ext_oneapi_graph

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2521,9 +2521,9 @@ public:
   /// Executes a command_graph.
   ///
   /// \param Graph Executable command_graph to run
-  void graph(ext::oneapi::experimental::command_graph<
-                  ext::oneapi::experimental::graph_state::executable>
-                      Graph);
+  void ext_oneapi_graph(ext::oneapi::experimental::command_graph<
+                        ext::oneapi::experimental::graph_state::executable>
+                            Graph);
 
 private:
   std::shared_ptr<detail::handler_impl> MImpl;

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2521,7 +2521,7 @@ public:
   /// Executes a command_graph.
   ///
   /// \param Graph Executable command_graph to run
-  void exec_graph(ext::oneapi::experimental::command_graph<
+  void graph(ext::oneapi::experimental::command_graph<
                   ext::oneapi::experimental::graph_state::executable>
                       Graph);
 

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -1063,11 +1063,11 @@ public:
   ///
   /// \param Graph the graph of commands to execute
   /// \return an event representing graph execution operation.
-  event graph(ext::oneapi::experimental::command_graph<
-                   ext::oneapi::experimental::graph_state::executable>
-                       Graph) {
+  event ext_oneapi_graph(ext::oneapi::experimental::command_graph<
+                         ext::oneapi::experimental::graph_state::executable>
+                             Graph) {
     const detail::code_location CodeLoc = {};
-    return submit([&](handler &CGH) { CGH.graph(Graph); }, CodeLoc);
+    return submit([&](handler &CGH) { CGH.ext_oneapi_graph(Graph); }, CodeLoc);
   }
 
   /// Shortcut for executing a graph of commands.
@@ -1076,15 +1076,15 @@ public:
   /// \param DepEvent is an event that specifies the graph execution
   /// dependencies.
   /// \return an event representing graph execution operation.
-  event graph(ext::oneapi::experimental::command_graph<
-                       ext::oneapi::experimental::graph_state::executable>
-                       Graph,
-                   event DepEvent) {
+  event ext_oneapi_graph(ext::oneapi::experimental::command_graph<
+                             ext::oneapi::experimental::graph_state::executable>
+                             Graph,
+                         event DepEvent) {
     const detail::code_location CodeLoc = {};
     return submit(
         [&](handler &CGH) {
           CGH.depends_on(DepEvent);
-          CGH.graph(Graph);
+          CGH.ext_oneapi_graph(Graph);
         },
         CodeLoc);
   }
@@ -1095,15 +1095,15 @@ public:
   /// \param DepEvents is a vector of events that specifies the graph
   /// execution dependencies.
   /// \return an event representing graph execution operation.
-  event graph(ext::oneapi::experimental::command_graph<
-                       ext::oneapi::experimental::graph_state::executable>
-                       Graph,
-                   const std::vector<event> &DepEvents) {
+  event ext_oneapi_graph(ext::oneapi::experimental::command_graph<
+                             ext::oneapi::experimental::graph_state::executable>
+                             Graph,
+                         const std::vector<event> &DepEvents) {
     const detail::code_location CodeLoc = {};
     return submit(
         [&](handler &CGH) {
           CGH.depends_on(DepEvents);
-          CGH.graph(Graph);
+          CGH.ext_oneapi_graph(Graph);
         },
         CodeLoc);
   }

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -1063,11 +1063,11 @@ public:
   ///
   /// \param Graph the graph of commands to execute
   /// \return an event representing graph execution operation.
-  event exec_graph(ext::oneapi::experimental::command_graph<
+  event graph(ext::oneapi::experimental::command_graph<
                    ext::oneapi::experimental::graph_state::executable>
                        Graph) {
     const detail::code_location CodeLoc = {};
-    return submit([&](handler &CGH) { CGH.exec_graph(Graph); }, CodeLoc);
+    return submit([&](handler &CGH) { CGH.graph(Graph); }, CodeLoc);
   }
 
   /// Shortcut for executing a graph of commands.
@@ -1076,7 +1076,7 @@ public:
   /// \param DepEvent is an event that specifies the graph execution
   /// dependencies.
   /// \return an event representing graph execution operation.
-  event exec_graph(ext::oneapi::experimental::command_graph<
+  event graph(ext::oneapi::experimental::command_graph<
                        ext::oneapi::experimental::graph_state::executable>
                        Graph,
                    event DepEvent) {
@@ -1084,7 +1084,7 @@ public:
     return submit(
         [&](handler &CGH) {
           CGH.depends_on(DepEvent);
-          CGH.exec_graph(Graph);
+          CGH.graph(Graph);
         },
         CodeLoc);
   }
@@ -1095,7 +1095,7 @@ public:
   /// \param DepEvents is a vector of events that specifies the graph
   /// execution dependencies.
   /// \return an event representing graph execution operation.
-  event exec_graph(ext::oneapi::experimental::command_graph<
+  event graph(ext::oneapi::experimental::command_graph<
                        ext::oneapi::experimental::graph_state::executable>
                        Graph,
                    const std::vector<event> &DepEvents) {
@@ -1103,7 +1103,7 @@ public:
     return submit(
         [&](handler &CGH) {
           CGH.depends_on(DepEvents);
-          CGH.exec_graph(Graph);
+          CGH.graph(Graph);
         },
         CodeLoc);
   }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -699,9 +699,10 @@ void handler::depends_on(const std::vector<event> &Events) {
   }
 }
 
-void handler::graph(ext::oneapi::experimental::command_graph<
-                         ext::oneapi::experimental::graph_state::executable>
-                             Graph) {
+void handler::ext_oneapi_graph(
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::executable>
+        Graph) {
   auto GraphImpl = detail::getSyclObjImpl(Graph);
   GraphImpl->exec_and_wait(MQueue);
 }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -699,7 +699,7 @@ void handler::depends_on(const std::vector<event> &Events) {
   }
 }
 
-void handler::exec_graph(ext::oneapi::experimental::command_graph<
+void handler::graph(ext::oneapi::experimental::command_graph<
                          ext::oneapi::experimental::graph_state::executable>
                              Graph) {
   auto GraphImpl = detail::getSyclObjImpl(Graph);

--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -81,7 +81,7 @@ int main() {
   auto executable_graph = g.finalize(q.get_context());
 
   // Using shortcut for executing a graph of commands
-  q.exec_graph(executable_graph).wait();
+  q.graph(executable_graph).wait();
 
   if (*dotp != host_gold_result()) {
     std::cout << "Error unexpected result!\n";

--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -81,7 +81,7 @@ int main() {
   auto executable_graph = g.finalize(q.get_context());
 
   // Using shortcut for executing a graph of commands
-  q.graph(executable_graph).wait();
+  q.ext_oneapi_graph(executable_graph).wait();
 
   if (*dotp != host_gold_result()) {
     std::cout << "Error unexpected result!\n";

--- a/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
+++ b/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
@@ -26,10 +26,10 @@ int main() {
 
   auto executable_graph = g.finalize(q.get_context());
 
-  auto e1 = q.graph(executable_graph);
-  auto e2 = q.graph(executable_graph, e1);
-  auto e3 = q.graph(executable_graph, e1);
-  q.graph(executable_graph, {e2, e3}).wait();
+  auto e1 = q.ext_oneapi_graph(executable_graph);
+  auto e2 = q.ext_oneapi_graph(executable_graph, e1);
+  auto e3 = q.ext_oneapi_graph(executable_graph, e1);
+  q.ext_oneapi_graph(executable_graph, {e2, e3}).wait();
 
   sycl::free(arr, q);
 

--- a/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
+++ b/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
@@ -26,10 +26,10 @@ int main() {
 
   auto executable_graph = g.finalize(q.get_context());
 
-  auto e1 = q.exec_graph(executable_graph);
-  auto e2 = q.exec_graph(executable_graph, e1);
-  auto e3 = q.exec_graph(executable_graph, e1);
-  q.exec_graph(executable_graph, {e2, e3}).wait();
+  auto e1 = q.graph(executable_graph);
+  auto e2 = q.graph(executable_graph, e1);
+  auto e3 = q.graph(executable_graph, e1);
+  q.graph(executable_graph, {e2, e3}).wait();
 
   sycl::free(arr, q);
 

--- a/sycl/test/graph/graph-explicit-simple.cpp
+++ b/sycl/test/graph/graph-explicit-simple.cpp
@@ -30,7 +30,7 @@ int main() {
 
   auto result_before_exec2 = arr[0];
 
-  q.submit([&](sycl::handler &h) { h.exec_graph(executable_graph); });
+  q.submit([&](sycl::handler &h) { h.graph(executable_graph); });
 
   auto result = arr[0];
 

--- a/sycl/test/graph/graph-explicit-simple.cpp
+++ b/sycl/test/graph/graph-explicit-simple.cpp
@@ -30,7 +30,7 @@ int main() {
 
   auto result_before_exec2 = arr[0];
 
-  q.submit([&](sycl::handler &h) { h.graph(executable_graph); });
+  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });
 
   auto result = arr[0];
 


### PR DESCRIPTION
- In line with recent spec changes, rename handler and queue shortcut functions from exec_graph to graph
- Also updated usage in the examples