### PR TITLE
Add property_list parameter to finalize.

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -325,7 +325,9 @@ template<>
 class command_graph<graph_state::modifiable> {
 public:
   command_graph(const property_list& propList = {});
-  command_graph<graph_state::executable> finalize(const context& syclContext) const;
+
+  command_graph<graph_state::executable>
+  finalize(const context& syclContext, const property_list& propList = {}) const;
 
   bool begin_recording(queue recordingQueue);
   bool begin_recording(const std::vector<queue>& recordingQueues);
@@ -594,7 +596,8 @@ Exceptions:
 [source,c++]
 ----
 using namespace ext::oneapi::experimental;
-command_graph<graph_state::executable> finalize(const context& syclContext) const;
+command_graph<graph_state::executable>
+finalize(const context& syclContext, const property_list& propList = {}) const;
 ----
 
 |Synchronous operation that creates a new graph in the executable state with a
@@ -613,6 +616,9 @@ Parameters:
 
 * `syclContext` - The context associated with the queues to which the
   executable graph will be able to be submitted.
+
+* `propList` - Optional parameter for passing properties. No finalization
+  properties are defined by this extension.
 
 Returns: A new executable graph object which can be submitted to a queue.
 


### PR DESCRIPTION
Introduces an optional `property_list` parameter when creating an executable graph with finalize.

No properties are defined that could be passed here, but the kernel fusion API `fusion_wrapper::complete_fusion()` takes a property list with properties, which could be relevant for future alignment. Additionally, CUDA has a `cudaGraphInstantiateWithParams()` entry-point that this property list would provide equivalent coverage for.

Using a `property_list` in this way is analogous to how [kernel_bundle](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:interfaces.bundles.overview.synopsis) `compile()`/`link()`/`build()` take a property list and return a new object with different state.