### PR TITLE
Update graph recording mechanism

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -67,6 +67,40 @@ public:
   command_graph<graph_state::executable>
   finalize(const sycl::context &syclContext) const;
 
+  /// Change the state of a queue to be recording and associate this graph with
+  /// it.
+  /// @param recordingQueue The queue to change state on and associate this
+  /// graph with.
+  /// @return True if the queue had its state changed from executing to
+  /// recording.
+  bool begin_recording(queue recordingQueue);
+
+  /// Change the state of multiple queues to be recording and associate this
+  /// graph with each of them.
+  /// @param recordingQueues The queues to change state on and associate this
+  /// graph with.
+  /// @return True if any queue had its state changed from executing to
+  /// recording.
+  bool begin_recording(const std::vector<queue> &recordingQueues);
+
+  /// Set all queues currently recording to this graph to the executing state.
+  /// @return True if any queue had its state changed from recording to
+  /// executing.
+  bool end_recording();
+
+  /// Set a queues currently recording to this graph to the executing state.
+  /// @param recordingQueue The queue to change state on.
+  /// @return True if the queue had its state changed from recording to
+  /// executing.
+  bool end_recording(queue recordingQueue);
+
+  /// Set multiple queues currently recording to this graph to the executing
+  /// state.
+  /// @param recordingQueue The queues to change state on.
+  /// @return True if any queue had its state changed from recording to
+  /// executing.
+  bool end_recording(const std::vector<queue> &recordingQueues);
+
 private:
   command_graph(detail::graph_ptr Impl) : impl(Impl) {}
 

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -17,6 +17,7 @@ namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 
 class handler;
+class queue;
 namespace ext {
 namespace oneapi {
 namespace experimental {

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -1128,19 +1128,6 @@ public:
   /// \return the backend associated with this queue.
   backend get_backend() const noexcept;
 
-public:
-  /// Places the queue into command_graph recording mode.
-  ///
-  /// \return true if the queue was not already in recording mode.
-  bool
-  begin_recording(ext::oneapi::experimental::command_graph<
-                  ext::oneapi::experimental::graph_state::modifiable> &graph);
-
-  /// Ends recording mode on the queue and returns to the normal state.
-  ///
-  /// \return true if the queue was already in recording mode.
-  bool end_recording();
-
 private:
   pi_native_handle getNative() const;
 

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -125,6 +125,26 @@ struct graph_impl {
                const std::vector<node_ptr> &dep = {});
 
   graph_impl() : MFirst(true) {}
+
+  /// Add a queue to the set of queues which are currently recording to this
+  /// graph.
+  void add_queue(sycl::detail::queue_ptr recordingQueue) {
+    MRecordingQueues.insert(recordingQueue);
+  }
+
+  /// Remove a queue from the set of queues which are currently recording to
+  /// this graph.
+  void remove_queue(sycl::detail::queue_ptr recordingQueue) {
+    MRecordingQueues.erase(recordingQueue);
+  }
+
+  /// Remove all queues which are recording to this graph, also sets all queues
+  /// cleared back to the executing state. \return True if any queues were
+  /// removed.
+  bool clear_queues();
+
+private:
+  std::set<sycl::detail::queue_ptr> MRecordingQueues;
 };
 
 } // namespace detail

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -213,26 +213,6 @@ bool queue::device_has(aspect Aspect) const {
   return impl->getDeviceImplPtr()->has(Aspect);
 }
 
-bool queue::begin_recording(
-    ext::oneapi::experimental::command_graph<
-        ext::oneapi::experimental::graph_state::modifiable> &graph) {
-  using namespace ext::oneapi::experimental;
-  if (!impl->getCommandGraph()) {
-    impl->setCommandGraph(
-        sycl::detail::getSyclObjImpl<command_graph<graph_state::modifiable>>(
-            graph));
-    return true;
-  }
-  return false;
-}
-
-bool queue::end_recording() {
-  if (impl->getCommandGraph()) {
-    impl->setCommandGraph(nullptr);
-    return true;
-  }
-  return false;
-}
 template __SYCL_EXPORT bool
 queue::has_property<ext::oneapi::property::queue::lazy_execution>() const;
 template __SYCL_EXPORT ext::oneapi::property::queue::lazy_execution

--- a/sycl/test/graph/graph-record-dotp-buffer.cpp
+++ b/sycl/test/graph/graph-record-dotp-buffer.cpp
@@ -46,7 +46,7 @@ int main() {
     sycl::buffer yBuf(yData);
     sycl::buffer zBuf(zData);
 
-    q.begin_recording(g);
+    g.begin_recording(q);
 
     /* init data on the device */
     q.submit([&](sycl::handler &h) {
@@ -95,11 +95,11 @@ int main() {
       });
     });
 
-    q.end_recording();
+    g.end_recording();
 
     auto exec_graph = g.finalize(q.get_context());
 
-    q.submit([&](sycl::handler &h) { h.exec_graph(exec_graph); });
+    q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
   }
 
   if (dotpData != host_gold_result()) {

--- a/sycl/test/graph/graph-record-dotp.cpp
+++ b/sycl/test/graph/graph-record-dotp.cpp
@@ -40,7 +40,7 @@ int main() {
   float *y = sycl::malloc_shared<float>(n, q);
   float *z = sycl::malloc_shared<float>(n, q);
 
-  q.begin_recording(g);
+  g.begin_recording(q);
 
   /* init data on the device */
   q.submit([&](sycl::handler &h) {
@@ -79,11 +79,11 @@ int main() {
     });
   });
 
-  q.end_recording();
+  g.end_recording();
 
   auto exec_graph = g.finalize(q.get_context());
 
-  q.submit([&](sycl::handler &h) { h.exec_graph(exec_graph); });
+  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
 
   if (dotp[0] != host_gold_result()) {
     std::cout << "Error unexpected result!\n";


### PR DESCRIPTION
- Updates graph recording behaviour to match the spec by adding begin and end recording to the graph object. 
- `graph_impl` class now maintains an awareness of any queues which are recording to it.
- Removes those methods from the queue.
- Update examples to use new methods (and also `handler::ext_oneapi_graph()` change.
- Unit tests for begin and end recording added.