### PR TITLE
Pass property_list to modifiable graph constructor and finalize APIs

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -9,9 +9,11 @@
 #pragma once
 
 #include <memory>
+#include <vector>
+
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/defines_elementary.hpp>
-#include <vector>
+#include <sycl/property_list.hpp>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
@@ -51,7 +53,7 @@ private:
 template <graph_state State = graph_state::modifiable>
 class __SYCL_EXPORT command_graph {
 public:
-  command_graph();
+  command_graph(const property_list &propList = {});
 
   // Adding empty node with [0..n] predecessors:
   node add(const std::vector<node> &dep = {});
@@ -65,7 +67,8 @@ public:
   void make_edge(node sender, node receiver);
 
   command_graph<graph_state::executable>
-  finalize(const sycl::context &syclContext) const;
+  finalize(const sycl::context &syclContext,
+           const property_list &propList = {}) const;
 
 private:
   command_graph(detail::graph_ptr Impl) : impl(Impl) {}

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -88,7 +88,8 @@ void node_impl::exec(sycl::detail::queue_ptr q) {
 } // namespace detail
 
 template <>
-command_graph<graph_state::modifiable>::command_graph()
+command_graph<graph_state::modifiable>::command_graph(
+    const sycl::property_list &)
     : impl(std::make_shared<detail::graph_impl>()) {}
 
 template <>
@@ -116,7 +117,7 @@ void command_graph<graph_state::modifiable>::make_edge(node sender,
 template <>
 command_graph<graph_state::executable>
 command_graph<graph_state::modifiable>::finalize(
-    const sycl::context &ctx) const {
+    const sycl::context &ctx, const sycl::property_list &) const {
   return command_graph<graph_state::executable>{this->impl, ctx};
 }
 

--- a/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
+++ b/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
@@ -12,7 +12,9 @@ int main() {
 
   sycl::queue q{sycl::gpu_selector_v, properties};
 
-  sycl::ext::oneapi::experimental::command_graph g;
+  // Test passing empty property list, which is the default
+  sycl::property_list empty_properties;
+  sycl::ext::oneapi::experimental::command_graph g(empty_properties);
 
   const size_t n = 10;
   float *arr = sycl::malloc_shared<float>(n, q);
@@ -24,7 +26,7 @@ int main() {
     });
   });
 
-  auto executable_graph = g.finalize(q.get_context());
+  auto executable_graph = g.finalize(q.get_context(), empty_properties);
 
   auto e1 = q.ext_oneapi_graph(executable_graph);
   auto e2 = q.ext_oneapi_graph(executable_graph, e1);


### PR DESCRIPTION
Adds the `sycl::property_list` to the constructor of `command_graph<modifiable>()` and `finalize()` to match spec change https://github.com/reble/llvm/pull/67