### PR TITLE
Improve testing

### DIFF
--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <sycl/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 

--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -83,16 +83,15 @@ int main() {
   // Using shortcut for executing a graph of commands
   q.ext_oneapi_graph(executable_graph).wait();
 
-  if (*dotp != host_gold_result()) {
-    std::cout << "Error unexpected result!\n";
-  }
+  if (*dotp == host_gold_result())
+    std::cout << "Dot product explicit graph test passed." << std::endl;
+  else
+    std::cout << "Dot product explicit graph test failed." << std::endl;
 
   sycl::free(dotp, q);
   sycl::free(x, q);
   sycl::free(y, q);
   sycl::free(z, q);
-
-  std::cout << "done.\n";
 
   return 0;
 }

--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -83,10 +83,7 @@ int main() {
   // Using shortcut for executing a graph of commands
   q.ext_oneapi_graph(executable_graph).wait();
 
-  if (*dotp == host_gold_result())
-    std::cout << "Dot product explicit graph test passed." << std::endl;
-  else
-    std::cout << "Dot product explicit graph test failed." << std::endl;
+  assert(*dotp == host_gold_result());
 
   sycl::free(dotp, q);
   sycl::free(x, q);

--- a/sycl/test/graph/graph-explicit-node-ordering.cpp
+++ b/sycl/test/graph/graph-explicit-node-ordering.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <sycl/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 
@@ -43,7 +43,9 @@ int main() {
 
   auto executable_graph = g.finalize(q.get_context());
 
-  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); }).wait();
+  q.submit([&](sycl::handler &h) {
+     h.ext_oneapi_graph(executable_graph);
+   }).wait();
 
   for (int i = 0; i < n; i++)
     assert(x[i] == 8.0f);

--- a/sycl/test/graph/graph-explicit-node-ordering.cpp
+++ b/sycl/test/graph/graph-explicit-node-ordering.cpp
@@ -45,16 +45,8 @@ int main() {
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); }).wait();
 
-  bool check = true;
-  for (int i = 0; i < n; i++) {
-    if (x[i] != 8.0f)
-      check = false;
-  }
-
-  if (check)
-    std::cout << "Node ordering explicit graph test passed." << std::endl;
-  else
-    std::cout << "Node ordering explicit graph test failed." << std::endl;
+  for (int i = 0; i < n; i++)
+    assert(x[i] == 8.0f);
 
   sycl::free(x, q);
 

--- a/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
+++ b/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <sycl/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 
@@ -35,7 +35,7 @@ int main() {
 
   for (int i = 0; i < n; i++)
     assert(arr[i] == 1);
-  
+
   sycl::free(arr, q);
 
   return 0;

--- a/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
+++ b/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
+++ b/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
@@ -33,9 +33,18 @@ int main() {
   auto e3 = q.ext_oneapi_graph(executable_graph, e1);
   q.ext_oneapi_graph(executable_graph, {e2, e3}).wait();
 
-  sycl::free(arr, q);
+  bool check = true;
+  for (int i = 0; i < n; i++) {
+    if (arr[i] != 1)
+      check = false;
+  }
 
-  std::cout << "done " << arr[0] << std::endl;
+  if (check)
+    std::cout << "Queue shortcuts explicit graph test passed." << std::endl;
+  else
+    std::cout << "Queue shortcuts explicit graph test failed." << std::endl;
+  
+  sycl::free(arr, q);
 
   return 0;
 }

--- a/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
+++ b/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
@@ -33,16 +33,8 @@ int main() {
   auto e3 = q.ext_oneapi_graph(executable_graph, e1);
   q.ext_oneapi_graph(executable_graph, {e2, e3}).wait();
 
-  bool check = true;
-  for (int i = 0; i < n; i++) {
-    if (arr[i] != 1)
-      check = false;
-  }
-
-  if (check)
-    std::cout << "Queue shortcuts explicit graph test passed." << std::endl;
-  else
-    std::cout << "Queue shortcuts explicit graph test failed." << std::endl;
+  for (int i = 0; i < n; i++)
+    assert(arr[i] == 1);
   
   sycl::free(arr, q);
 

--- a/sycl/test/graph/graph-explicit-reduction.cpp
+++ b/sycl/test/graph/graph-explicit-reduction.cpp
@@ -26,7 +26,8 @@ int main() {
                    [=](sycl::id<1> idx, auto &sum) { sum += input[idx]; });
   });
 
-  e.wait();
+  auto executable_graph = g.finalize(q.get_context());
+  q.ext_oneapi_graph(executable_graph).wait();
 
   if (*output == 45)
     std::cout << "Reduction explicit graph test passed." << std::endl;

--- a/sycl/test/graph/graph-explicit-reduction.cpp
+++ b/sycl/test/graph/graph-explicit-reduction.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-explicit-reduction.cpp
+++ b/sycl/test/graph/graph-explicit-reduction.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <sycl/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 

--- a/sycl/test/graph/graph-explicit-reduction.cpp
+++ b/sycl/test/graph/graph-explicit-reduction.cpp
@@ -29,10 +29,7 @@ int main() {
   auto executable_graph = g.finalize(q.get_context());
   q.ext_oneapi_graph(executable_graph).wait();
 
-  if (*output == 45)
-    std::cout << "Reduction explicit graph test passed." << std::endl;
-  else
-    std::cout << "Reduction explicit graph test failed." << std::endl;
+  assert(*output == 45);
 
   sycl::free(input, q);
   sycl::free(output, q);

--- a/sycl/test/graph/graph-explicit-reduction.cpp
+++ b/sycl/test/graph/graph-explicit-reduction.cpp
@@ -28,10 +28,13 @@ int main() {
 
   e.wait();
 
+  if (*output == 45)
+    std::cout << "Reduction explicit graph test passed." << std::endl;
+  else
+    std::cout << "Reduction explicit graph test failed." << std::endl;
+
   sycl::free(input, q);
   sycl::free(output, q);
-
-  std::cout << "done\n";
 
   return 0;
 }

--- a/sycl/test/graph/graph-explicit-repeated-exec.cpp
+++ b/sycl/test/graph/graph-explicit-repeated-exec.cpp
@@ -49,17 +49,8 @@ int main() {
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });
 
-  for (int i = 0; i < n; i++) {
-    if (arr[i] != 2)
-      check = false;
-  }
-
-  if (check)
-    std::cout << "Repeated execution of an explicit graph test passed."
-              << std::endl;
-  else
-    std::cout << "Repeated execution of an explicit graph test failed."
-              << std::endl;
+    for (int i = 0; i < n; i++)
+    assert(arr[i] == 2);
 
   sycl::free(arr, q);
 

--- a/sycl/test/graph/graph-explicit-repeated-exec.cpp
+++ b/sycl/test/graph/graph-explicit-repeated-exec.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <sycl/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 
@@ -49,7 +49,7 @@ int main() {
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });
 
-    for (int i = 0; i < n; i++)
+  for (int i = 0; i < n; i++)
     assert(arr[i] == 2);
 
   sycl::free(arr, q);

--- a/sycl/test/graph/graph-explicit-repeated-exec.cpp
+++ b/sycl/test/graph/graph-explicit-repeated-exec.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-explicit-repeated-exec.cpp
+++ b/sycl/test/graph/graph-explicit-repeated-exec.cpp
@@ -23,7 +23,7 @@ int main() {
   g.add([&](sycl::handler &h) {
     h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> idx) {
       size_t i = idx;
-      arr[i] = 1;
+      arr[i] += 1;
     });
   });
 
@@ -47,10 +47,19 @@ int main() {
       check = false;
   }
 
+  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });
+
+  for (int i = 0; i < n; i++) {
+    if (arr[i] != 2)
+      check = false;
+  }
+
   if (check)
-    std::cout << "Single node explicit graph test passed." << std::endl;
+    std::cout << "Repeated execution of an explicit graph test passed."
+              << std::endl;
   else
-    std::cout << "Single node explicit graph test failed." << std::endl;
+    std::cout << "Repeated execution of an explicit graph test failed."
+              << std::endl;
 
   sycl::free(arr, q);
 

--- a/sycl/test/graph/graph-explicit-saxpy.cpp
+++ b/sycl/test/graph/graph-explicit-saxpy.cpp
@@ -40,10 +40,19 @@ int main() {
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); }).wait();
 
+  bool check = true;
+  for (int i = 0; i < n; i++) {
+    if (y[i] != 5.0f)
+      check = false;
+  }
+
+  if (check)
+    std::cout << "SAXPY explicit graph test passed." << std::endl;
+  else
+    std::cout << "SAXPY explicit graph test failed." << std::endl;
+
   sycl::free(x, q);
   sycl::free(y, q);
-
-  std::cout << "done.\n";
 
   return 0;
 }

--- a/sycl/test/graph/graph-explicit-saxpy.cpp
+++ b/sycl/test/graph/graph-explicit-saxpy.cpp
@@ -40,16 +40,8 @@ int main() {
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); }).wait();
 
-  bool check = true;
-  for (int i = 0; i < n; i++) {
-    if (y[i] != 5.0f)
-      check = false;
-  }
-
-  if (check)
-    std::cout << "SAXPY explicit graph test passed." << std::endl;
-  else
-    std::cout << "SAXPY explicit graph test failed." << std::endl;
+  for (int i = 0; i < n; i++)
+    assert(y[i] == 5.0f);
 
   sycl::free(x, q);
   sycl::free(y, q);

--- a/sycl/test/graph/graph-explicit-saxpy.cpp
+++ b/sycl/test/graph/graph-explicit-saxpy.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <sycl/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 
@@ -38,7 +38,9 @@ int main() {
 
   auto executable_graph = g.finalize(q.get_context());
 
-  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); }).wait();
+  q.submit([&](sycl::handler &h) {
+     h.ext_oneapi_graph(executable_graph);
+   }).wait();
 
   for (int i = 0; i < n; i++)
     assert(y[i] == 5.0f);

--- a/sycl/test/graph/graph-explicit-single-node.cpp
+++ b/sycl/test/graph/graph-explicit-single-node.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-explicit-single-node.cpp
+++ b/sycl/test/graph/graph-explicit-single-node.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <sycl/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 

--- a/sycl/test/graph/graph-explicit-single-node.cpp
+++ b/sycl/test/graph/graph-explicit-single-node.cpp
@@ -42,15 +42,8 @@ int main() {
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });
 
-  for (int i = 0; i < n; i++) {
-    if (arr[i] != 1)
-      check = false;
-  }
-
-  if (check)
-    std::cout << "Single node explicit graph test passed." << std::endl;
-  else
-    std::cout << "Single node explicit graph test failed." << std::endl;
+  for (int i = 0; i < n; i++)
+    assert(arr[i] == 1);
 
   sycl::free(arr, q);
 

--- a/sycl/test/graph/graph-explicit-subgraph.cpp
+++ b/sycl/test/graph/graph-explicit-subgraph.cpp
@@ -2,8 +2,8 @@
 
 // Modified version of the dotp example which submits part of the graph as a
 // sub-graph
-#include <sycl/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 

--- a/sycl/test/graph/graph-explicit-subgraph.cpp
+++ b/sycl/test/graph/graph-explicit-subgraph.cpp
@@ -70,7 +70,7 @@ int main() {
   auto subGraphExec = subGraph.finalize(q.get_context());
 
   auto node_sub =
-      g.add([&](sycl::handler &h) { h.exec_graph(subGraphExec); }, {n_i});
+      g.add([&](sycl::handler &h) { h.ext_oneapi_graph(subGraphExec); }, {n_i});
 
   auto node_c = g.add(
       [&](sycl::handler &h) {
@@ -86,18 +86,17 @@ int main() {
   auto executable_graph = g.finalize(q.get_context());
 
   // Using shortcut for executing a graph of commands
-  q.exec_graph(executable_graph).wait();
+  q.ext_oneapi_graph(executable_graph).wait();
 
-  if (*dotp != host_gold_result()) {
-    std::cout << "Error unexpected result!\n";
-  }
+  if (*dotp == host_gold_result())
+    std::cout << "Subgraph explicit graph test passed." << std::endl;
+  else
+    std::cout << "Subgraph explicit graph test failed." << std::endl;
 
   sycl::free(dotp, q);
   sycl::free(x, q);
   sycl::free(y, q);
   sycl::free(z, q);
-
-  std::cout << "done.\n";
 
   return 0;
 }

--- a/sycl/test/graph/graph-explicit-subgraph.cpp
+++ b/sycl/test/graph/graph-explicit-subgraph.cpp
@@ -88,10 +88,7 @@ int main() {
   // Using shortcut for executing a graph of commands
   q.ext_oneapi_graph(executable_graph).wait();
 
-  if (*dotp == host_gold_result())
-    std::cout << "Subgraph explicit graph test passed." << std::endl;
-  else
-    std::cout << "Subgraph explicit graph test failed." << std::endl;
+  assert(*dotp == host_gold_result());
 
   sycl::free(dotp, q);
   sycl::free(x, q);

--- a/sycl/test/graph/graph-explicit-subgraph.cpp
+++ b/sycl/test/graph/graph-explicit-subgraph.cpp
@@ -2,7 +2,7 @@
 
 // Modified version of the dotp example which submits part of the graph as a
 // sub-graph
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>


### PR DESCRIPTION
This PR tries to improve the current testing by:

1. Adding correctness checks to all tests.
2. Fixing the missing `finalize()` and `ext_oneapi_graph()` calls for the reduction test.
3. Adding a test to verify that the nodes are correctly ordered by `make_edge()` dependencies.