### PR TITLE
[SYCL] Add explicit update API to graph spec

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -353,7 +353,7 @@ public:
     command_graph() = delete;
     void update(const command_graph<graph_state::modifiable>& graph);
     template <typename T>
-    void update_parameter(const T& from, const T& to);
+    void update_memory_parameter(const T& from, const T& to);
 };
 }  // namespace ext::oneapi::experimental
 
@@ -468,9 +468,11 @@ outputs of the modifiable graph, a technique called _Whole Graph Update_. The
 modifiable graph must have the same topology as the graph originally used to
 create the executable graphs, with the nodes added in the same order.
 
-Individual input parameters to the executable graph can also be updated
-using the `command_graph::update_parameter()` method. This can be useful
-if only a small number of parameters require updating.
+Individual buffer and USM parameters to the executable graph can also be updated
+using the `command_graph::update_memory_parameter()` method. This can be useful
+if only a small number of inputs & outputs require updating. It is not possible
+to update scalar parameters as they are considered to be captured by value in
+command group scope, so due to the copy there is no basis for a comparison.
 
 ==== Graph Member Functions
 
@@ -856,12 +858,12 @@ Exceptions:
 ----
 using namespace ext::oneapi::experimental;
 template <typename T>
-void command_graph<graph_state::executable> 
-update_parameter(const T& from, const T& to);
+void command_graph<graph_state::executable>
+update_memory_parameter(const T& from, const T& to);
 ----
 
-|Updates a parameter across the executable graph such that all nodes in the
-graph which use `from` as a parameter will have that parameter replaced by
+|Updates a memory parameter across the executable graph such that all nodes in
+the graph which use `from` as a parameter will have that parameter replaced by
 `to`.
 
 Preconditions:

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -860,14 +860,15 @@ void command_graph<graph_state::executable>
 update_parameter(const T& from, const T& to);
 ----
 
-|Updates a parameter across the executable graph. All nodes which
-use the parameter will be updated.
+|Updates a parameter across the executable graph such that all nodes in the
+graph which use `from` as a parameter will have that parameter replaced by
+`to`.
 
 Preconditions:
 
 * This member function is only available when the `command_graph` state is
   `graph_state::executable`.
-* T must be either a Buffer or a raw pointer to a USM allocation.
+* T must be either a buffer or a raw pointer to a USM allocation.
 
 Parameters:
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -352,6 +352,8 @@ class command_graph<graph_state::executable> {
 public:
     command_graph() = delete;
     void update(const command_graph<graph_state::modifiable>& graph);
+    template <typename T>
+    void update_parameter(const T& from, const T& to);
 };
 }  // namespace ext::oneapi::experimental
 
@@ -465,6 +467,10 @@ modifiable state and updates the executable graph to use the node input &
 outputs of the modifiable graph, a technique called _Whole Graph Update_. The
 modifiable graph must have the same topology as the graph originally used to
 create the executable graphs, with the nodes added in the same order.
+
+Individual input parameters to the executable graph can also be updated
+using the `command_graph::update_parameter()` method. This can be useful
+if only a small number of parameters required updating.
 
 ==== Graph Member Functions
 
@@ -844,6 +850,34 @@ Exceptions:
 * Throws synchronously with error code `invalid` if the topology of `graph` is
   not the same as the existing graph topology, or if the nodes were not added in
   the same order.
+
+  |
+[source, c++]
+----
+using namespace ext::oneapi::experimental;
+template <typename T>
+void command_graph<graph_state::executable> 
+update_parameter(const T& from, const T& to);
+----
+
+|Updates a parameter across the executable graph. All nodes which
+use the parameter will be updated.
+
+Preconditions:
+
+* This member function is only available when the `command_graph` state is
+  `graph_state::executable`.
+* T must be either a Buffer or a raw pointer to a USM allocation.
+
+Parameters:
+
+* `from` - The parameter within the graph to be updated.
+* `to` - The new value to use for this parameter.
+
+Exceptions:
+
+* Throws synchronously with error code `invalid` if `from` is not found within the graph
+or if `to` is not compatible with `from`.
 |===
 
 === Queue Class Modifications

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -470,7 +470,7 @@ create the executable graphs, with the nodes added in the same order.
 
 Individual input parameters to the executable graph can also be updated
 using the `command_graph::update_parameter()` method. This can be useful
-if only a small number of parameters required updating.
+if only a small number of parameters require updating.
 
 ==== Graph Member Functions
 


### PR DESCRIPTION
- Add an explicit update API to the graph specification.

Based on feedback from the specification PR. Originally we had argued for a more detailed API where the user would get information about parameters and then set them on the graph. This is similar to how things are done in CUDA but when actually developing the API in that direction it became clear there were numerous issues:
- When users would query information about parameters we would be unable to provide them actual information about the type of a buffer or USM allocation. Users could compare pointer values for USM to let them find out which parameter they actually want to update but this does not work for buffers because we would only have access to the `syclMemObjT` which carries no information other than the size of the buffer. CUDA deals purely in pointers so this is less of an issue.
- Likely the user would be required to do some kind of bookkeeping to keep track of what parameter is what.
- However, in CUDA users explicitly set parameters in an array and CUDA guarantees and requires that that order be maintained when getting or updating parameters. In SYCL we cannot guarantee the order of lambda captures which makes book keeping for the user very difficult if not impossible.

The original suggestion on the specification PR is seen in this PR as it avoids the user having to book keep (other than to keep the original parameters around). 

I don't believe supporting updating scalar parameters captured by SYCL kernels is possible here though. Since ultimately the type information is lost and we will almost certainly need to take a copy of the scalar data in the implementation in future we would have no basis for comparison. However, since these parameters are considered to be captured by value in command group scope and are not a formal concept in SYCL, I don't believe this is an issue.

I've marked this PR as a draft for now to facilitate discussion about the approach taken.