### PR TITLE
Resolving naming style mismatch

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -139,7 +139,7 @@ void node_impl::exec(const std::shared_ptr<sycl::detail::queue_impl> &Queue
   for (auto Sender : MPredecessors)
     Deps.push_back(Sender->get_event());
 
-  MEvent = q->submit(wrapper{MBody, deps}, Queue _CODELOCFW(CodeLoc));
+  MEvent = Queue->submit(wrapper{MBody, Deps}, Queue _CODELOCFW(CodeLoc));
 }
 } // namespace detail
 

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -30,7 +30,8 @@ class wrapper {
   std::vector<sycl::event> MDeps;
 
 public:
-  wrapper(T Func, const std::vector<sycl::event> &Deps) : MFunc(Func), MDeps(Deps){};
+  wrapper(T Func, const std::vector<sycl::event> &Deps)
+      : MFunc(Func), MDeps(Deps){};
 
   void operator()(sycl::handler &CGH) {
     CGH.depends_on(MDeps);

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -54,13 +54,13 @@ struct node_impl {
   void exec(const std::shared_ptr<sycl::detail::queue_impl> &q
                 _CODELOCPARAM(&CodeLoc));
 
-  void register_successor(const std::shared_ptr<node_impl> &n) {
-    MSuccessors.push_back(n);
-    n->register_predecessor(std::shared_ptr<node_impl>(this));
+  void register_successor(const std::shared_ptr<node_impl> &Node) {
+    MSuccessors.push_back(Node);
+    Node->register_predecessor(std::shared_ptr<node_impl>(this));
   }
 
-  void register_predecessor(const std::shared_ptr<node_impl> &n) {
-    MPredecessors.push_back(n);
+  void register_predecessor(const std::shared_ptr<node_impl> &Node) {
+    MPredecessors.push_back(Node);
   }
 
   sycl::event get_event(void) const { return MEvent; }


### PR DESCRIPTION
This patch is applying LLVM Coding standards, mainly renaming Variables. Name should be nouns and camel case, starting with an upper letter.