### PR TITLE
[SYCL] Remove CGF reuse in graph nodes

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -376,6 +376,14 @@ private:
           std::shared_ptr<detail::queue_impl> PrimaryQueue,
           std::shared_ptr<detail::queue_impl> SecondaryQueue, bool IsHost);
 
+  /// Constructs SYCL handler from Graph.
+  ///
+  /// The hander will add the command-group as a node to the graph rather than
+  /// enqueueing it straight away.
+  ///
+  /// \param Graph is a SYCL command_graph
+  handler(std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> Graph);
+
   /// Stores copy of Arg passed to the MArgsStorage.
   template <typename T, typename F = typename detail::remove_const_t<
                             typename detail::remove_reference_t<T>>>
@@ -2532,6 +2540,8 @@ public:
 private:
   std::shared_ptr<detail::handler_impl> MImpl;
   std::shared_ptr<detail::queue_impl> MQueue;
+  std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> MGraph;
+
   /// The storage for the arguments passed.
   /// We need to store a copy of values that are passed explicitly through
   /// set_arg, require and so on, because we need them to be alive after

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -79,6 +79,10 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 class handler;
 template <typename T, int Dimensions, typename AllocatorT, typename Enable>
 class buffer;
+
+namespace ext::oneapi::experimental::detail {
+class graph_impl;
+}
 namespace detail {
 
 class handler_impl;
@@ -2610,6 +2614,8 @@ private:
 
   friend class ::MockHandler;
   friend class detail::queue_impl;
+
+  friend class ext::oneapi::experimental::detail::graph_impl;
 
   bool DisableRangeRounding();
 

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -71,8 +71,9 @@ void graph_impl::remove_root(const std::shared_ptr<node_impl> &Root) {
 //
 // @returns True if a dependency was added in this node of any of its
 // successors.
-bool check_for_arg(const sycl::detail::ArgDesc &arg, const std::shared_ptr<node_impl> & currentNode,
-                   std::set<const std::shared_ptr<node_impl> &> &deps) {
+bool check_for_arg(const sycl::detail::ArgDesc &arg,
+                   const std::shared_ptr<node_impl> &currentNode,
+                   std::set<std::shared_ptr<node_impl>> &deps) {
   bool successorAddedDep = false;
   for (auto &successor : currentNode->MSuccessors) {
     successorAddedDep |= check_for_arg(arg, successor, deps);
@@ -86,9 +87,11 @@ bool check_for_arg(const sycl::detail::ArgDesc &arg, const std::shared_ptr<node_
   return SuccessorAddedDep;
 }
 
-const std::shared_ptr<node_impl> & graph_impl::add(const std::shared_ptr<graph_impl> &impl, std::function<void(handler &)> cgf,
-                         const std::vector<sycl::detail::ArgDesc> &args,
-                         const std::vector<const std::shared_ptr<node_impl> &> &dep) {
+std::shared_ptr<node_impl>
+graph_impl::add(const std::shared_ptr<graph_impl> &impl,
+                std::function<void(handler &)> cgf,
+                const std::vector<sycl::detail::ArgDesc> &args,
+                const std::vector<std::shared_ptr<node_impl>> &dep) {
   sycl::queue TempQueue{};
   auto QueueImpl = sycl::detail::getSyclObjImpl(TempQueue);
   QueueImpl->setCommandGraph(impl);
@@ -101,15 +104,16 @@ const std::shared_ptr<node_impl> & graph_impl::add(const std::shared_ptr<graph_i
                    Handler.MRequirements, Handler.MArgs, {});
 }
 
-const std::shared_ptr<node_impl> & graph_impl::add(
-    const std::shared_ptr<graph_impl> &impl, std::shared_ptr<sycl::detail::kernel_impl> Kernel,
+std::shared_ptr<node_impl> graph_impl::add(
+    const std::shared_ptr<graph_impl> &impl,
+    std::shared_ptr<sycl::detail::kernel_impl> Kernel,
     sycl::detail::NDRDescT NDRDesc, sycl::detail::OSModuleHandle OSModuleHandle,
     std::string KernelName,
     const std::vector<sycl::detail::AccessorImplPtr> &AccStorage,
     const std::vector<sycl::detail::LocalAccessorImplPtr> &LocalAccStorage,
     const std::vector<sycl::detail::AccessorImplHost *> &Requirements,
     const std::vector<sycl::detail::ArgDesc> &args,
-    const std::vector<const std::shared_ptr<node_impl> &> &dep) {
+    const std::vector<std::shared_ptr<node_impl>> &dep) {
   const std::shared_ptr<node_impl> & nodeImpl = std::make_shared<node_impl>(
       impl, Kernel, NDRDesc, OSModuleHandle, KernelName, AccStorage,
       LocalAccStorage, Requirements, args);

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -90,10 +90,7 @@ graph_impl::add(const std::shared_ptr<graph_impl> &Impl,
                 std::function<void(handler &)> CGF,
                 const std::vector<sycl::detail::ArgDesc> &Args,
                 const std::vector<std::shared_ptr<node_impl>> &Dep) {
-  sycl::queue TempQueue{};
-  auto QueueImpl = sycl::detail::getSyclObjImpl(TempQueue);
-  QueueImpl->setCommandGraph(Impl);
-  sycl::handler Handler{QueueImpl, false};
+  sycl::handler Handler{Impl};
   CGF(Handler);
 
   return this->add(Impl, Handler.MKernel, Handler.MNDRDesc,

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -118,9 +118,10 @@ std::shared_ptr<node_impl> graph_impl::add(
   // Copy deps so we can modify them
   auto Deps = Dep;
   // A unique set of dependencies obtained by checking kernel arguments
+  // for accessors
   std::set<std::shared_ptr<node_impl>> UniqueDeps;
   for (auto &Arg : Args) {
-    if (Arg.MType != sycl::detail::kernel_param_kind_t::kind_pointer) {
+    if (Arg.MType != sycl::detail::kernel_param_kind_t::kind_accessor) {
       continue;
     }
     // Look through the graph for nodes which share this argument
@@ -129,7 +130,7 @@ std::shared_ptr<node_impl> graph_impl::add(
     }
   }
 
-  // Add any deps determined from arguments into the dependency list
+  // Add any deps determined from accessor arguments into the dependency list
   Deps.insert(Deps.end(), UniqueDeps.begin(), UniqueDeps.end());
   if (!Deps.empty()) {
     for (auto N : Deps) {

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -67,7 +67,7 @@ struct node_impl {
 
   /// Store arg descriptors for the kernel arguments
   std::vector<sycl::detail::ArgDesc> MArgs;
-  // We need to store local copies of the values pointed to by MArgssince they
+  // We need to store local copies of the values pointed to by MArgs since they
   // may go out of scope before execution.
   std::vector<std::vector<std::byte>> MArgStorage;
 

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -127,8 +127,8 @@ struct node_impl {
       if (arg.MType == nodeArg.MType && arg.MSize == nodeArg.MSize) {
         // Args are actually void** so we need to dereference them to compare
         // actual values
-        void *incomingPtr = *(void **)arg.MPtr;
-        void *argPtr = *(void **)nodeArg.MPtr;
+        void *incomingPtr = *static_cast<void **>(arg.MPtr);
+        void *argPtr = *static_cast<void **>(nodeArg.MPtr);
         if (incomingPtr == argPtr) {
           return true;
         }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -86,14 +86,15 @@ struct node_impl {
   sycl::event get_event(void) const { return MEvent; }
 
   node_impl(
-      const std::shared_ptr<graph_impl> &g, std::shared_ptr<sycl::detail::kernel_impl> Kernel,
+      const std::shared_ptr<graph_impl> &Graph,
+      std::shared_ptr<sycl::detail::kernel_impl> Kernel,
       sycl::detail::NDRDescT NDRDesc,
       sycl::detail::OSModuleHandle OSModuleHandle, std::string KernelName,
       const std::vector<sycl::detail::AccessorImplPtr> &AccStorage,
       const std::vector<sycl::detail::LocalAccessorImplPtr> &LocalAccStorage,
       const std::vector<sycl::detail::AccessorImplHost *> &Requirements,
       const std::vector<sycl::detail::ArgDesc> &args)
-      : MScheduled(false), MGraph(g), MKernel(Kernel), MNDRDesc(NDRDesc),
+      : MScheduled(false), MGraph(Graph), MKernel(Kernel), MNDRDesc(NDRDesc),
         MOSModuleHandle(OSModuleHandle), MKernelName(KernelName),
         MAccStorage(AccStorage), MLocalAccStorage(LocalAccStorage),
         MRequirements(Requirements), MArgs(args), MArgStorage() {
@@ -121,15 +122,14 @@ struct node_impl {
     Schedule.push_front(std::shared_ptr<node_impl>(this));
   }
 
-
-  bool has_arg(const sycl::detail::ArgDesc &arg) {
-    for (auto &nodeArg : MArgs) {
-      if (arg.MType == nodeArg.MType && arg.MSize == nodeArg.MSize) {
+  bool has_arg(const sycl::detail::ArgDesc &Arg) {
+    for (auto &NodeArg : MArgs) {
+      if (Arg.MType == NodeArg.MType && Arg.MSize == NodeArg.MSize) {
         // Args are actually void** so we need to dereference them to compare
         // actual values
-        void *incomingPtr = *static_cast<void **>(arg.MPtr);
-        void *argPtr = *static_cast<void **>(nodeArg.MPtr);
-        if (incomingPtr == argPtr) {
+        void *IncomingPtr = *static_cast<void **>(Arg.MPtr);
+        void *ArgPtr = *static_cast<void **>(NodeArg.MPtr);
+        if (IncomingPtr == ArgPtr) {
           return true;
         }
       }
@@ -153,19 +153,21 @@ struct graph_impl {
   void remove_root(const std::shared_ptr<node_impl> &);
 
   std::shared_ptr<node_impl>
-
-  add(const std::shared_ptr<graph_impl> &impl, std::shared_ptr<sycl::detail::kernel_impl> Kernel,
+  add(const std::shared_ptr<graph_impl> &Impl,
+      std::shared_ptr<sycl::detail::kernel_impl> Kernel,
       sycl::detail::NDRDescT NDRDesc,
       sycl::detail::OSModuleHandle OSModuleHandle, std::string KernelName,
       const std::vector<sycl::detail::AccessorImplPtr> &AccStorage,
       const std::vector<sycl::detail::LocalAccessorImplPtr> &LocalAccStorage,
       const std::vector<sycl::detail::AccessorImplHost *> &Requirements,
-      const std::vector<sycl::detail::ArgDesc> &args,
-      const std::vector<std::shared_ptr<node_impl>> &dep = {});
+      const std::vector<sycl::detail::ArgDesc> &Args,
+      const std::vector<std::shared_ptr<node_impl>> &Dep = {});
 
-  std::shared_ptr<node_impl> add(const std::shared_ptr<graph_impl> &impl, std::function<void(handler &)> cgf,
-               const std::vector<sycl::detail::ArgDesc> &args,
-               const std::vector<std::shared_ptr<node_impl>> &dep = {});
+  std::shared_ptr<node_impl>
+  add(const std::shared_ptr<graph_impl> &Impl,
+      std::function<void(handler &)> CGF,
+      const std::vector<sycl::detail::ArgDesc> &Args,
+      const std::vector<std::shared_ptr<node_impl>> &Dep = {});
 
   graph_impl() : MFirst(true) {}
 

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -9,9 +9,13 @@
 #pragma once
 
 #include <sycl/detail/cg_types.hpp>
+#include <sycl/detail/os_util.hpp>
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 #include <sycl/handler.hpp>
 
+#include <detail/kernel_impl.hpp>
+
+#include <cstring>
 #include <functional>
 #include <list>
 #include <set>
@@ -48,9 +52,24 @@ struct node_impl {
   std::vector<std::shared_ptr<node_impl>> MSuccessors;
   std::vector<std::shared_ptr<node_impl>> MPredecessors;
 
-  std::function<void(sycl::handler &)> MBody;
+  /// Kernel to be executed by this node
+  std::shared_ptr<sycl::detail::kernel_impl> MKernel;
+  /// Description of the kernel global and local sizes as well as offset
+  sycl::detail::NDRDescT MNDRDesc;
+  /// Module handle for the kernel to be executed.
+  sycl::detail::OSModuleHandle MOSModuleHandle =
+      sycl::detail::OSUtil::ExeModuleHandle;
+  /// Kernel name inside the module
+  std::string MKernelName;
+  std::vector<sycl::detail::AccessorImplPtr> MAccStorage;
+  std::vector<sycl::detail::LocalAccessorImplPtr> MLocalAccStorage;
+  std::vector<sycl::detail::AccessorImplHost *> MRequirements;
 
+  /// Store arg descriptors for the kernel arguments
   std::vector<sycl::detail::ArgDesc> MArgs;
+  // We need to store local copies of the values pointed to by MArgssince they
+  // may go out of scope before execution.
+  std::vector<std::vector<std::byte>> MArgStorage;
 
   void exec(const std::shared_ptr<sycl::detail::queue_impl> &Queue
                 _CODELOCPARAM(&CodeLoc));
@@ -66,17 +85,29 @@ struct node_impl {
 
   sycl::event get_event(void) const { return MEvent; }
 
-  template <typename T>
-  node_impl(const std::shared_ptr<graph_impl> &Graph, T CGF,
-            const std::vector<sycl::detail::ArgDesc> &Args)
-      : MScheduled(false), MGraph(Graph), MBody(CGF), MArgs(Args) {
+  node_impl(
+      const std::shared_ptr<graph_impl> &g, std::shared_ptr<sycl::detail::kernel_impl> Kernel,
+      sycl::detail::NDRDescT NDRDesc,
+      sycl::detail::OSModuleHandle OSModuleHandle, std::string KernelName,
+      const std::vector<sycl::detail::AccessorImplPtr> &AccStorage,
+      const std::vector<sycl::detail::LocalAccessorImplPtr> &LocalAccStorage,
+      const std::vector<sycl::detail::AccessorImplHost *> &Requirements,
+      const std::vector<sycl::detail::ArgDesc> &args)
+      : MScheduled(false), MGraph(g), MKernel(Kernel), MNDRDesc(NDRDesc),
+        MOSModuleHandle(OSModuleHandle), MKernelName(KernelName),
+        MAccStorage(AccStorage), MLocalAccStorage(LocalAccStorage),
+        MRequirements(Requirements), MArgs(args), MArgStorage() {
+
+    // Need to copy the arg values to node local storage so that they don't go
+    // out of scope before execution
     for (size_t i = 0; i < MArgs.size(); i++) {
-      if (MArgs[i].MType == sycl::detail::kernel_param_kind_t::kind_pointer) {
-        // Make sure we are storing the actual USM pointer for comparison
-        // purposes, note we couldn't actually submit using these copies of the
-        // args if subsequent code expects a void**.
-        MArgs[i].MPtr = *(void **)(MArgs[i].MPtr);
-      }
+      auto &CurrentArg = MArgs[i];
+      MArgStorage.emplace_back(CurrentArg.MSize);
+      auto StoragePtr = MArgStorage.back().data();
+      if (CurrentArg.MPtr)
+        std::memcpy(StoragePtr, CurrentArg.MPtr, CurrentArg.MSize);
+      // Set the arg descriptor to point to the new storage
+      CurrentArg.MPtr = StoragePtr;
     }
   }
 
@@ -90,13 +121,15 @@ struct node_impl {
     Schedule.push_front(std::shared_ptr<node_impl>(this));
   }
 
-  bool has_arg(const sycl::detail::ArgDesc &Arg, bool DereferencePtr = false) {
-    for (auto &NodeArg : MArgs) {
-      if (Arg.MType == NodeArg.MType && Arg.MSize == NodeArg.MSize) {
-        // Args coming directly from the handler will need to be dereferenced
-        // since they are actually void**
-        void *IncomingPtr = DereferencePtr ? *(void **)Arg.MPtr : Arg.MPtr;
-        if (IncomingPtr == NodeArg.MPtr) {
+
+  bool has_arg(const sycl::detail::ArgDesc &arg) {
+    for (auto &nodeArg : MArgs) {
+      if (arg.MType == nodeArg.MType && arg.MSize == nodeArg.MSize) {
+        // Args are actually void** so we need to dereference them to compare
+        // actual values
+        void *incomingPtr = *(void **)arg.MPtr;
+        void *argPtr = *(void **)nodeArg.MPtr;
+        if (incomingPtr == argPtr) {
           return true;
         }
       }
@@ -119,11 +152,20 @@ struct graph_impl {
   void add_root(const std::shared_ptr<node_impl> &);
   void remove_root(const std::shared_ptr<node_impl> &);
 
-  template <typename T>
   std::shared_ptr<node_impl>
-  add(const std::shared_ptr<graph_impl> &Impl, T CGF,
-      const std::vector<sycl::detail::ArgDesc> &Args,
-      const std::vector<std::shared_ptr<node_impl>> &Dep = {});
+
+  add(const std::shared_ptr<graph_impl> &impl, std::shared_ptr<sycl::detail::kernel_impl> Kernel,
+      sycl::detail::NDRDescT NDRDesc,
+      sycl::detail::OSModuleHandle OSModuleHandle, std::string KernelName,
+      const std::vector<sycl::detail::AccessorImplPtr> &AccStorage,
+      const std::vector<sycl::detail::LocalAccessorImplPtr> &LocalAccStorage,
+      const std::vector<sycl::detail::AccessorImplHost *> &Requirements,
+      const std::vector<sycl::detail::ArgDesc> &args,
+      const std::vector<std::shared_ptr<node_impl>> &dep = {});
+
+  std::shared_ptr<node_impl> add(const std::shared_ptr<graph_impl> &impl, std::function<void(handler &)> cgf,
+               const std::vector<sycl::detail::ArgDesc> &args,
+               const std::vector<std::shared_ptr<node_impl>> &dep = {});
 
   graph_impl() : MFirst(true) {}
 

--- a/sycl/source/detail/handler_impl.hpp
+++ b/sycl/source/detail/handler_impl.hpp
@@ -29,6 +29,8 @@ public:
       : MSubmissionPrimaryQueue(std::move(SubmissionPrimaryQueue)),
         MSubmissionSecondaryQueue(std::move(SubmissionSecondaryQueue)){};
 
+  handler_impl() = default;
+
   void setStateExplicitKernelBundle() {
     if (MSubmissionState == HandlerSubmissionState::SPEC_CONST_SET_STATE)
       throw sycl::exception(

--- a/sycl/source/detail/reduction.cpp
+++ b/sycl/source/detail/reduction.cpp
@@ -52,6 +52,12 @@ __SYCL_EXPORT size_t reduComputeWGSize(size_t NWorkItems, size_t MaxWGSize,
 // with the given queue.
 __SYCL_EXPORT uint32_t reduGetMaxNumConcurrentWorkGroups(
     std::shared_ptr<sycl::detail::queue_impl> Queue) {
+  // TODO: Graphs extension explicit API uses a handler with no queue attached,
+  // so return some value here. In the future we should have access to the
+  // device so can remove this.
+  if (Queue == nullptr) {
+    return 8;
+  }
   device Dev = Queue->get_device();
   uint32_t NumThreads = Dev.get_info<sycl::info::device::max_compute_units>();
   // TODO: The heuristics here require additional tuning for various devices
@@ -104,6 +110,12 @@ reduGetMaxWGSize(std::shared_ptr<sycl::detail::queue_impl> Queue,
 
 __SYCL_EXPORT size_t reduGetPreferredWGSize(std::shared_ptr<queue_impl> &Queue,
                                             size_t LocalMemBytesPerWorkItem) {
+  // TODO: Graphs extension explicit API uses a handler with a null queue to
+  // process CGFs, in future we should have access to the device so we can
+  // correctly calculate this.
+  if (Queue == nullptr) {
+    return 32;
+  }
   device Dev = Queue->get_device();
 
   // The maximum WGSize returned by CPU devices is very large and does not

--- a/sycl/source/detail/reduction.cpp
+++ b/sycl/source/detail/reduction.cpp
@@ -55,6 +55,10 @@ __SYCL_EXPORT uint32_t reduGetMaxNumConcurrentWorkGroups(
   // TODO: Graphs extension explicit API uses a handler with no queue attached,
   // so return some value here. In the future we should have access to the
   // device so can remove this.
+  //
+  // The 8 value was chosen as the hardcoded value as it is the returned
+  // value for sycl::info::device::max_compute_units on
+  // Intel HD Graphics devices used as a L0 backend during development.
   if (Queue == nullptr) {
     return 8;
   }
@@ -113,6 +117,10 @@ __SYCL_EXPORT size_t reduGetPreferredWGSize(std::shared_ptr<queue_impl> &Queue,
   // TODO: Graphs extension explicit API uses a handler with a null queue to
   // process CGFs, in future we should have access to the device so we can
   // correctly calculate this.
+  //
+  // The 32 value was chosen as the hardcoded value as it is the returned
+  // value for SYCL_REDUCTION_PREFERRED_WORKGROUP_SIZE on
+  // Intel HD Graphics devices used as a L0 backend during development.
   if (Queue == nullptr) {
     return 32;
   }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -40,6 +40,10 @@ handler::handler(std::shared_ptr<detail::queue_impl> Queue,
                                                    std::move(SecondaryQueue))),
       MQueue(std::move(Queue)), MIsHost(IsHost) {}
 
+handler::handler(
+    std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> Graph)
+    : MImpl(std::make_shared<detail::handler_impl>()), MGraph(Graph) {}
+
 // Sets the submission state to indicate that an explicit kernel bundle has been
 // set. Throws a sycl::exception with errc::invalid if the current state
 // indicates that a specialization constant has been set.

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -93,6 +93,14 @@ event handler::finalize() {
   if (MIsFinalized)
     return MLastEvent;
   MIsFinalized = true;
+  if (auto graphImpl = MQueue->getCommandGraph(); graphImpl != nullptr) {
+    // Extract relevant data from the handler and pass to graph to create a new
+    // node representing this command group.
+    graphImpl->add(graphImpl, MKernel, MNDRDesc, MOSModuleHandle, MKernelName,
+                   MAccStorage, MLocalAccStorage, MRequirements, MArgs, {});
+    return detail::createSyclObjFromImpl<event>(
+        std::make_shared<detail::event_impl>());
+  }
 
   std::shared_ptr<detail::kernel_bundle_impl> KernelBundleImpPtr = nullptr;
   // If there were uses of set_specialization_constant build the kernel_bundle

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -93,10 +93,10 @@ event handler::finalize() {
   if (MIsFinalized)
     return MLastEvent;
   MIsFinalized = true;
-  if (auto graphImpl = MQueue->getCommandGraph(); graphImpl != nullptr) {
+  if (auto GraphImpl = MQueue->getCommandGraph(); GraphImpl != nullptr) {
     // Extract relevant data from the handler and pass to graph to create a new
     // node representing this command group.
-    graphImpl->add(graphImpl, MKernel, MNDRDesc, MOSModuleHandle, MKernelName,
+    GraphImpl->add(GraphImpl, MKernel, MNDRDesc, MOSModuleHandle, MKernelName,
                    MAccStorage, MLocalAccStorage, MRequirements, MArgs, {});
     return detail::createSyclObjFromImpl<event>(
         std::make_shared<detail::event_impl>());

--- a/sycl/test/graph/graph-explicit-subgraph.cpp
+++ b/sycl/test/graph/graph-explicit-subgraph.cpp
@@ -74,12 +74,22 @@ int main() {
 
   auto node_c = g.add(
       [&](sycl::handler &h) {
+#ifdef TEST_GRAPH_REDUCTIONS
         h.parallel_for(sycl::range<1>{n},
                        sycl::reduction(dotp, 0.0f, std::plus()),
                        [=](sycl::id<1> it, auto &sum) {
                          const size_t i = it[0];
                          sum += x[i] * z[i];
                        });
+#else
+        h.single_task([=]() {
+          // Doing a manual reduction here because reduction objects cause
+          // issues with graphs.
+          for (size_t j = 0; j < n; j++) {
+            dotp[0] += x[j] * z[j];
+          }
+        });
+#endif
       },
       {node_sub});
 

--- a/sycl/test/graph/graph-record-dotp.cpp
+++ b/sycl/test/graph/graph-record-dotp.cpp
@@ -67,16 +67,21 @@ int main() {
   });
 
   q.submit([&](sycl::handler &h) {
-    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
-      const size_t i = it[0];
+#ifdef TEST_GRAPH_REDUCTIONS
+    h.parallel_for(sycl::range<1>{n}, sycl::reduction(dotp, 0.0f, std::plus()),
+                   [=](sycl::id<1> it, auto &sum) {
+                     const size_t i = it[0];
+                     sum += x[i] * z[i];
+                   });
+#else
+    h.single_task([=]() {
       // Doing a manual reduction here because reduction objects cause issues
       // with graphs.
-      if (i == 0) {
-        for (size_t j = 0; j < n; j++) {
-          dotp[0] += x[j] * z[j];
-        }
+      for (size_t j = 0; j < n; j++) {
+        dotp[0] += x[j] * z[j];
       }
     });
+#endif
   });
 
   g.end_recording();

--- a/sycl/test/graph/graph-record-temp-scope.cpp
+++ b/sycl/test/graph/graph-record-temp-scope.cpp
@@ -1,0 +1,62 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+const size_t n = 10;
+const float expectedValue = 42.0f;
+
+void run_some_kernel(sycl::queue q, float* data){
+  // data is captured by ref here but will have gone out of scope when the
+  // CGF is later run when the graph is executed.
+  q.submit([&](sycl::handler &h) {
+    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> idx) {
+      size_t i = idx;
+      data[i] = expectedValue;
+    });
+  });
+}
+
+int main() {
+
+  sycl::property_list properties{
+      sycl::property::queue::in_order(),
+      sycl::ext::oneapi::property::queue::lazy_execution{}};
+
+  sycl::queue q{sycl::default_selector_v, properties};
+
+  sycl::ext::oneapi::experimental::command_graph g;
+
+  float *arr = sycl::malloc_shared<float>(n, q);
+
+  g.begin_recording(q);
+  run_some_kernel(q, arr);
+  g.end_recording(q);
+
+  auto exec_graph = g.finalize(q.get_context());
+
+  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
+
+  int errors = 0;
+  // Verify results
+  for (size_t i = 0; i < n; i++) {
+    if (arr[i] != expectedValue) {
+      std::cout << "Test failed: Unexpected result at index: " << i
+                << ", expected: " << expectedValue << " actual: " << arr[i]
+                << "\n";
+      errors++;
+    }
+  }
+
+  if (errors == 0) {
+    std::cout << "Test passed successfuly.\n";
+  }
+
+  std::cout << "done.\n";
+
+  sycl::free(arr, q.get_context());
+
+  return errors;
+}

--- a/sycl/test/graph/graph-record-temp-scope.cpp
+++ b/sycl/test/graph/graph-record-temp-scope.cpp
@@ -1,6 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 
-#include <iostream>
 #include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
@@ -39,24 +38,12 @@ int main() {
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
 
-  int errors = 0;
   // Verify results
   for (size_t i = 0; i < n; i++) {
-    if (arr[i] != expectedValue) {
-      std::cout << "Test failed: Unexpected result at index: " << i
-                << ", expected: " << expectedValue << " actual: " << arr[i]
-                << "\n";
-      errors++;
-    }
+    assert(arr[i] == expectedValue);
   }
-
-  if (errors == 0) {
-    std::cout << "Test passed successfuly.\n";
-  }
-
-  std::cout << "done.\n";
 
   sycl::free(arr, q.get_context());
 
-  return errors;
+  return 0;
 }

--- a/sycl/test/graph/graph-record-temp-scope.cpp
+++ b/sycl/test/graph/graph-record-temp-scope.cpp
@@ -8,7 +8,7 @@
 const size_t n = 10;
 const float expectedValue = 42.0f;
 
-void run_some_kernel(sycl::queue q, float* data){
+void run_some_kernel(sycl::queue q, float *data) {
   // data is captured by ref here but will have gone out of scope when the
   // CGF is later run when the graph is executed.
   q.submit([&](sycl::handler &h) {


### PR DESCRIPTION
- Removes use of the CGF when submitting graph nodes.
- Handler info is extracted and copied into nodes.
- Node execution is now done manually rather than going through the handler.
- Adding nodes in record and replay moved to handler::finalize.
- Workarounds for reduction wg sizes added.

Note reductions are broken by this commit due to missing accessor support which will be addressed in a future PR.