### PR TITLE
[SYCL] Replace lazy queue property with PI command-buffers.

### DIFF
--- a/sycl/include/sycl/detail/pi.h
+++ b/sycl/include/sycl/detail/pi.h
@@ -52,11 +52,10 @@
 // 10.13 Added new PI_EXT_ONEAPI_QUEUE_DISCARD_EVENTS queue property.
 // 10.14 Add PI_EXT_INTEL_DEVICE_INFO_FREE_MEMORY as an extension for
 // piDeviceGetInfo.
-// 10.15 Add new PI_EXT_ONEAPI_QUEUE_LAZY_EXECUTION queue property
-// 10.16 Add command-buffer extension methods
+// 10.15 Add command-buffer extension methods
 
 #define _PI_H_VERSION_MAJOR 10
-#define _PI_H_VERSION_MINOR 16
+#define _PI_H_VERSION_MINOR 15
 
 #define _PI_STRING_HELPER(a) #a
 #define _PI_CONCAT(a, b) _PI_STRING_HELPER(a.b)
@@ -572,14 +571,6 @@ constexpr pi_queue_properties PI_QUEUE_PROFILING_ENABLE = (1 << 1);
 constexpr pi_queue_properties PI_QUEUE_ON_DEVICE = (1 << 2);
 constexpr pi_queue_properties PI_QUEUE_ON_DEVICE_DEFAULT = (1 << 3);
 constexpr pi_queue_properties PI_EXT_ONEAPI_QUEUE_DISCARD_EVENTS = (1 << 4);
-// In a lazy queue, enqueued commands are not submitted for execution
-// immediately, instead they are submitted for execution once the queue is
-// flushed.
-//
-// This is to enable prototyping of the SYCL_EXT_ONEAPI_GRAPH extension,
-// before a native command-list interface in PI can be designed and
-// implemented.
-constexpr pi_queue_properties PI_EXT_ONEAPI_QUEUE_LAZY_EXECUTION = (1 << 5);
 
 using pi_result = _pi_result;
 using pi_platform_info = _pi_platform_info;

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -27,6 +27,7 @@ namespace experimental {
 namespace detail {
 struct node_impl;
 struct graph_impl;
+class exec_graph_impl;
 
 } // namespace detail
 
@@ -125,18 +126,20 @@ template <> class __SYCL_EXPORT command_graph<graph_state::executable> {
 public:
   command_graph() = delete;
 
-  command_graph(const std::shared_ptr<detail::graph_impl> &g,
-                const sycl::context &ctx)
-      : MTag(rand()), MCtx(ctx), impl(g) {}
+  command_graph(const std::shared_ptr<detail::graph_impl> &Graph,
+                const sycl::context &Ctx);
 
 private:
   template <class Obj>
   friend decltype(Obj::impl)
   sycl::detail::getSyclObjImpl(const Obj &SyclObject);
 
+  // Creates a backend representation of the graph in impl
+  void finalize_impl();
+
   int MTag;
   const sycl::context &MCtx;
-  std::shared_ptr<detail::graph_impl> impl;
+  std::shared_ptr<detail::exec_graph_impl> impl;
 };
 } // namespace experimental
 } // namespace oneapi

--- a/sycl/include/sycl/properties/queue_properties.hpp
+++ b/sycl/include/sycl/properties/queue_properties.hpp
@@ -28,8 +28,6 @@ namespace property {
 namespace queue {
 class discard_events
     : public ::sycl::detail::DataLessProperty<::sycl::detail::DiscardEvents> {};
-class lazy_execution
-    : public ::sycl::detail::DataLessProperty<::sycl::detail::LazyExecution> {};
 } // namespace queue
 } // namespace property
 
@@ -67,9 +65,6 @@ template <>
 struct is_property<ext::oneapi::property::queue::discard_events>
     : std::true_type {};
 template <>
-struct is_property<ext::oneapi::property::queue::lazy_execution>
-    : std::true_type {};
-template <>
 struct is_property<property::queue::cuda::use_default_stream> : std::true_type {
 };
 template <>
@@ -83,9 +78,6 @@ struct is_property_of<property::queue::enable_profiling, queue>
     : std::true_type {};
 template <>
 struct is_property_of<ext::oneapi::property::queue::discard_events, queue>
-    : std::true_type {};
-template <>
-struct is_property_of<ext::oneapi::property::queue::lazy_execution, queue>
     : std::true_type {};
 template <>
 struct is_property_of<property::queue::cuda::use_default_stream, queue>

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1307,49 +1307,6 @@ pi_result resetCommandLists(pi_queue Queue) {
 pi_result _pi_context::getAvailableCommandList(
     pi_queue Queue, pi_command_list_ptr_t &CommandList, bool UseCopyEngine,
     bool AllowBatching, ze_command_queue_handle_t *ForcedCmdQueue) {
-
-#if SYCL_EXT_ONEAPI_GRAPH
-  // This is a hack. TODO: Proper CommandList allocation per Executable Graph.
-  if( Queue->Properties & PI_EXT_ONEAPI_QUEUE_LAZY_EXECUTION ) {
-    // TODO: Create new Command List.
-    if(Queue->LazyCommandListMap.empty()) {
-      const bool UseCopyEngine = false;
-      // Adding createCommandList() to LazyCommandListMap
-      ze_fence_handle_t ZeFence;
-      ZeStruct<ze_fence_desc_t> ZeFenceDesc;
-      ze_command_list_handle_t ZeCommandList;
-
-      uint32_t QueueGroupOrdinal;
-      auto &QGroup = Queue->getQueueGroup(UseCopyEngine);
-      auto &ZeCommandQueue =
-          // ForcedCmdQueue ? *ForcedCmdQueue :
-          QGroup.getZeQueue(&QueueGroupOrdinal);
-      // if (ForcedCmdQueue)
-      //  QueueGroupOrdinal = QGroup.getCmdQueueOrdinal(ZeCommandQueue);
-
-      ZeStruct<ze_command_list_desc_t> ZeCommandListDesc;
-      ZeCommandListDesc.commandQueueGroupOrdinal = QueueGroupOrdinal;
-
-      ZE_CALL(zeCommandListCreate,
-              (Queue->Context->ZeContext, Queue->Device->ZeDevice,
-               &ZeCommandListDesc, &ZeCommandList));
-
-      ZE_CALL(zeFenceCreate, (ZeCommandQueue, &ZeFenceDesc, &ZeFence));
-      std::tie(CommandList, std::ignore) = Queue->LazyCommandListMap.insert(
-          std::pair<ze_command_list_handle_t, pi_command_list_info_t>(
-              ZeCommandList,
-              {ZeFence, false, ZeCommandQueue, QueueGroupOrdinal}));
-
-      Queue->insertActiveBarriers(CommandList, UseCopyEngine);
-      //
-      CommandList->second.ZeFenceInUse = true;
-    } else {
-        CommandList = Queue->LazyCommandListMap.begin();
-    }
-    return PI_SUCCESS;
-  }
-#endif
-    
   // Immediate commandlists have been pre-allocated and are always available.
   if (Queue->Device->useImmediateCommandLists()) {
     CommandList = Queue->getQueueGroup(UseCopyEngine).getImmCmdList();
@@ -1588,13 +1545,6 @@ void _pi_queue::CaptureIndirectAccesses() {
 pi_result _pi_queue::executeCommandList(pi_command_list_ptr_t CommandList,
                                         bool IsBlocking,
                                         bool OKToBatchCommand) {
-  // When executing a Graph, defer execution if this is a command
-  // which could be batched (i.e. likely a kernel submission)
-#if SYCL_EXT_ONEAPI_GRAPH
-  if (this->Properties & PI_EXT_ONEAPI_QUEUE_LAZY_EXECUTION && OKToBatchCommand)
-    return PI_SUCCESS;
-#endif
-
   bool UseCopyEngine = CommandList->second.isCopy(this);
 
   // If the current LastCommandEvent is the nullptr, then it means
@@ -3560,8 +3510,7 @@ pi_result piQueueCreate(pi_context Context, pi_device Device,
   PI_ASSERT(!(Properties & ~(PI_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE |
                              PI_QUEUE_PROFILING_ENABLE | PI_QUEUE_ON_DEVICE |
                              PI_QUEUE_ON_DEVICE_DEFAULT |
-                             PI_EXT_ONEAPI_QUEUE_DISCARD_EVENTS |
-                             PI_EXT_ONEAPI_QUEUE_LAZY_EXECUTION)),
+                             PI_EXT_ONEAPI_QUEUE_DISCARD_EVENTS)),
             PI_ERROR_INVALID_VALUE);
 
   PI_ASSERT(Context, PI_ERROR_INVALID_CONTEXT);
@@ -3835,18 +3784,6 @@ pi_result piQueueFinish(pi_queue Queue) {
 // Flushing cross-queue dependencies is covered by createAndRetainPiZeEventList,
 // so this can be left as a no-op.
 pi_result piQueueFlush(pi_queue Queue) {
-#if SYCL_EXT_ONEAPI_GRAPH
-  if( Queue->Properties & PI_EXT_ONEAPI_QUEUE_LAZY_EXECUTION ) {
-
-    pi_command_list_ptr_t CommandList{};
-    // TODO: 
-    CommandList = Queue->LazyCommandListMap.begin();
-
-    Queue->executeCommandList(CommandList, false, false);
-  }
-#else
-  (void)Queue;
-#endif
   return PI_SUCCESS;
 }
 

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -192,8 +192,7 @@ void exec_graph_impl::create_pi_command_buffers(sycl::device D,
 
   MPiCommandBuffers[D] = OutCommandBuffer;
 
-  // TODO extract logic from enqueueImpKernel
-  MSchedule.size();
+  // TODO extract kernel bundle logic from enqueueImpKernel
   for (auto Node : MSchedule) {
     pi_kernel PiKernel = nullptr;
     std::mutex *KernelMutex = nullptr;
@@ -215,7 +214,7 @@ void exec_graph_impl::create_pi_command_buffers(sycl::device D,
       sycl::detail::SetArgBasedOnType(
           Plugin, PiKernel,
           nullptr /* TODO: Handle spec constants and pass device image here */,
-          nullptr /* TODO: Psss getMemAllocation function for buffers */, Ctx,
+          nullptr /* TODO: Pass getMemAllocation function for buffers */, Ctx,
           false, Arg, ArgIndex);
       ArgIndex++;
     }

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -180,14 +180,7 @@ void find_real_deps(std::vector<pi_ext_sync_point> &Deps,
   if (CurrentNode->is_empty()) {
     for (auto &N : CurrentNode->MPredecessors) {
       auto NodeImpl = N.lock();
-      if (NodeImpl->is_empty()) {
-        find_real_deps(Deps, NodeImpl);
-      } else {
-        // Check if the dependency has already been added.
-        if (std::find(Deps.begin(), Deps.end(), NodeImpl->MPiSyncPoint) ==
-            Deps.end())
-          Deps.push_back(NodeImpl->MPiSyncPoint);
-      }
+      find_real_deps(Deps, NodeImpl);
     }
   } else {
     // Check if the dependency has already been added.

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -33,7 +33,8 @@ sycl::event
 exec_graph_impl::exec(const std::shared_ptr<sycl::detail::queue_impl> &Queue) {
   // TODO: Support subgraphs
   sycl::event RetEvent = enqueue(Queue);
-  // TODO: Why is this still required?
+  // TODO: Remove this queue wait. Currently waiting on the event returned from
+  // graph execution does not work.
   Queue->wait();
   return RetEvent;
 }

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -338,10 +338,11 @@ sycl::event exec_graph_impl::enqueue(
   auto NewEvent = CreateNewEvent();
   pi_event *OutEvent = &NewEvent->getHandleRef();
   auto CommandBuffer = MPiCommandBuffers[Queue->get_device()];
-  Res = Queue->getPlugin()
-            .call_nocheck<sycl::detail::PiApiKind::piextEnqueueCommandBuffer>(
-                CommandBuffer, Queue->getHandleRef(), RawEvents.size(),
-                RawEvents.empty() ? nullptr : &RawEvents[0], OutEvent);
+  pi_result Res =
+      Queue->getPlugin()
+          .call_nocheck<sycl::detail::PiApiKind::piextEnqueueCommandBuffer>(
+              CommandBuffer, Queue->getHandleRef(), RawEvents.size(),
+              RawEvents.empty() ? nullptr : &RawEvents[0], OutEvent);
   if (Res != pi_result::PI_SUCCESS) {
     throw sycl::exception(errc::event,
                           "Failed to enqueue event for node submission");
@@ -497,7 +498,7 @@ command_graph<graph_state::executable>::command_graph(
 void command_graph<graph_state::executable>::finalize_impl() {
   // Create PI command-buffers for each device in the finalized context
   impl->schedule();
-#if SYCLSYCL_EXT_ONEAPI_GRAPH
+#if SYCL_EXT_ONEAPI_GRAPH
   for (auto device : MCtx.get_devices()) {
     impl->create_pi_command_buffers(device, MCtx);
   }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -28,29 +28,15 @@ namespace oneapi {
 namespace experimental {
 namespace detail {
 
-class wrapper {
-  using T = std::function<void(sycl::handler &)>;
-  T MFunc;
-  std::vector<sycl::event> MDeps;
-
-public:
-  wrapper(T Func, const std::vector<sycl::event> &Deps)
-      : MFunc(Func), MDeps(Deps){};
-
-  void operator()(sycl::handler &CGH) {
-    CGH.depends_on(MDeps);
-    std::invoke(MFunc, CGH);
-  }
-};
-
 struct node_impl {
-  bool MScheduled;
-
   std::shared_ptr<graph_impl> MGraph;
-  sycl::event MEvent;
+  /// ID representing this node in the graph
+  /// TODO this should be attached to an executable graph, rather than
+  /// a modifiable graph
+  pi_ext_sync_point MPiSyncPoint;
 
   std::vector<std::shared_ptr<node_impl>> MSuccessors;
-  std::vector<std::shared_ptr<node_impl>> MPredecessors;
+  std::vector<std::weak_ptr<node_impl>> MPredecessors;
 
   /// Kernel to be executed by this node
   std::shared_ptr<sycl::detail::kernel_impl> MKernel;
@@ -71,22 +57,18 @@ struct node_impl {
   // may go out of scope before execution.
   std::vector<std::vector<std::byte>> MArgStorage;
 
-  void exec(const std::shared_ptr<sycl::detail::queue_impl> &Queue
-                _CODELOCPARAM(&CodeLoc));
-
-  void register_successor(const std::shared_ptr<node_impl> &Node) {
+  void register_successor(const std::shared_ptr<node_impl> &Node,
+                          const std::shared_ptr<node_impl> &Prev) {
     MSuccessors.push_back(Node);
-    Node->register_predecessor(std::shared_ptr<node_impl>(this));
+    Node->register_predecessor(Prev);
   }
 
   void register_predecessor(const std::shared_ptr<node_impl> &Node) {
     MPredecessors.push_back(Node);
   }
 
-  sycl::event get_event(void) const { return MEvent; }
-
   node_impl(const std::shared_ptr<graph_impl> &Graph)
-      : MScheduled(false), MGraph(Graph) {}
+      : MGraph(Graph) {}
 
   node_impl(
       const std::shared_ptr<graph_impl> &Graph,
@@ -97,7 +79,7 @@ struct node_impl {
       const std::vector<sycl::detail::LocalAccessorImplPtr> &LocalAccStorage,
       const std::vector<sycl::detail::AccessorImplHost *> &Requirements,
       const std::vector<sycl::detail::ArgDesc> &args)
-      : MScheduled(false), MGraph(Graph), MKernel(Kernel), MNDRDesc(NDRDesc),
+      : MGraph(Graph), MKernel(Kernel), MNDRDesc(NDRDesc),
         MOSModuleHandle(OSModuleHandle), MKernelName(KernelName),
         MAccStorage(AccStorage), MLocalAccStorage(LocalAccStorage),
         MRequirements(Requirements), MArgs(args), MArgStorage() {
@@ -116,14 +98,15 @@ struct node_impl {
   }
 
   // Recursively adding nodes to execution stack:
-  void topology_sort(std::list<std::shared_ptr<node_impl>> &Schedule) {
-    MScheduled = true;
+  void topology_sort(std::shared_ptr<node_impl> NodeImpl,
+                     std::list<std::shared_ptr<node_impl>> &Schedule) {
     for (auto Next : MSuccessors) {
-      if (!Next->MScheduled)
-        Next->topology_sort(Schedule);
+      // Check if we've already scheduled this node
+      if (std::find(Schedule.begin(), Schedule.end(), Next) == Schedule.end())
+        Next->topology_sort(Next, Schedule);
     }
     if (MKernel != nullptr)
-      Schedule.push_front(std::shared_ptr<node_impl>(this));
+    Schedule.push_front(NodeImpl);
   }
 
   bool has_arg(const sycl::detail::ArgDesc &Arg) {
@@ -144,14 +127,8 @@ struct node_impl {
 
 struct graph_impl {
   std::set<std::shared_ptr<node_impl>> MRoots;
-  std::list<std::shared_ptr<node_impl>> MSchedule;
-  // TODO: Change one time initialization to per executable object
-  bool MFirst;
 
   std::shared_ptr<graph_impl> MParent;
-
-  void exec(const std::shared_ptr<sycl::detail::queue_impl> &);
-  void exec_and_wait(const std::shared_ptr<sycl::detail::queue_impl> &);
 
   void add_root(const std::shared_ptr<node_impl> &);
   void remove_root(const std::shared_ptr<node_impl> &);
@@ -165,7 +142,9 @@ struct graph_impl {
       const std::vector<sycl::detail::LocalAccessorImplPtr> &LocalAccStorage,
       const std::vector<sycl::detail::AccessorImplHost *> &Requirements,
       const std::vector<sycl::detail::ArgDesc> &Args,
-      const std::vector<std::shared_ptr<node_impl>> &Dep = {});
+      const std::vector<std::shared_ptr<node_impl>> &Dep = {},
+      const std::vector<std::shared_ptr<sycl::detail::event_impl>> &DepEvents =
+          {});
 
   std::shared_ptr<node_impl>
   add(const std::shared_ptr<graph_impl> &Impl,
@@ -177,7 +156,7 @@ struct graph_impl {
   add(const std::shared_ptr<graph_impl> &Impl,
       const std::vector<std::shared_ptr<node_impl>> &Dep = {});
 
-  graph_impl() : MFirst(true) {}
+  graph_impl() = default;
 
   /// Add a queue to the set of queues which are currently recording to this
   /// graph.
@@ -198,8 +177,45 @@ struct graph_impl {
   /// removed.
   bool clear_queues();
 
+  void add_event_for_node(std::shared_ptr<sycl::detail::event_impl> EventImpl,
+                          std::shared_ptr<node_impl> NodeImpl) {
+    MEventsMap[EventImpl] = NodeImpl;
+  }
+
 private:
   std::set<std::shared_ptr<sycl::detail::queue_impl>> MRecordingQueues;
+  // Map of events to their associated recorded nodes.
+  std::unordered_map<std::shared_ptr<sycl::detail::event_impl>,
+                     std::shared_ptr<node_impl>>
+      MEventsMap;
+};
+
+class exec_graph_impl {
+public:
+  exec_graph_impl(sycl::context Context,
+                  const std::shared_ptr<graph_impl> &GraphImpl)
+      : MSchedule(), MGraphImpl(GraphImpl), MPiCommandBuffers(),
+        MContext(Context) {}
+  ~exec_graph_impl();
+  /// Add nodes to MSchedule
+  void schedule();
+  /// Enqueues the backend objects for the graph to the parametrized queue
+  sycl::event enqueue(const std::shared_ptr<sycl::detail::queue_impl> &);
+  /// Called by handler::ext_oneapi_command_graph() to schedule graph for
+  /// execution
+  sycl::event exec(const std::shared_ptr<sycl::detail::queue_impl> &);
+  /// Turns our internal graph representation into PI command-buffers for a
+  /// device
+  void create_pi_command_buffers(sycl::device D, const sycl::context &Ctx);
+
+private:
+  std::list<std::shared_ptr<node_impl>> MSchedule;
+  // Pointer to the modifiable graph impl associated with this executable graph
+  std::shared_ptr<graph_impl> MGraphImpl;
+  // Map of devices to command buffers
+  std::unordered_map<sycl::device, pi_ext_command_buffer> MPiCommandBuffers;
+  // Context associated with this executable graph
+  sycl::context MContext;
 };
 
 } // namespace detail

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -35,7 +35,10 @@ struct node_impl {
   /// a modifiable graph
   pi_ext_sync_point MPiSyncPoint;
 
+  // List of successors to this node.
   std::vector<std::shared_ptr<node_impl>> MSuccessors;
+  // List of predecessors to this node. Using weak_ptr here to prevent circular
+  // references between nodes.
   std::vector<std::weak_ptr<node_impl>> MPredecessors;
 
   /// Kernel to be executed by this node

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -60,6 +60,8 @@ struct node_impl {
   // may go out of scope before execution.
   std::vector<std::vector<std::byte>> MArgStorage;
 
+  bool MIsEmpty = false;
+
   void register_successor(const std::shared_ptr<node_impl> &Node,
                           const std::shared_ptr<node_impl> &Prev) {
     MSuccessors.push_back(Node);
@@ -71,7 +73,7 @@ struct node_impl {
   }
 
   node_impl(const std::shared_ptr<graph_impl> &Graph)
-      : MGraph(Graph) {}
+      : MGraph(Graph), MIsEmpty(true) {}
 
   node_impl(
       const std::shared_ptr<graph_impl> &Graph,
@@ -108,8 +110,10 @@ struct node_impl {
       if (std::find(Schedule.begin(), Schedule.end(), Next) == Schedule.end())
         Next->topology_sort(Next, Schedule);
     }
-    if (MKernel != nullptr)
-    Schedule.push_front(NodeImpl);
+    // We don't need to schedule empty nodes as they are only used when
+    // calculating dependencies
+    if (!NodeImpl->is_empty())
+      Schedule.push_front(NodeImpl);
   }
 
   bool has_arg(const sycl::detail::ArgDesc &Arg) {
@@ -126,6 +130,8 @@ struct node_impl {
     }
     return false;
   }
+
+  bool is_empty() const { return MIsEmpty; }
 };
 
 struct graph_impl {

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -279,14 +279,6 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
   TelemetryEvent = instrumentationProlog(CodeLoc, Name, StreamID, IId);
 #endif
 
-#if SYCL_EXT_ONEAPI_GRAPH
-  if (has_property<ext::oneapi::property::queue::lazy_execution>()) {
-    const detail::plugin &Plugin = getPlugin();
-    if (Plugin.getBackend() == backend::ext_oneapi_level_zero)
-      Plugin.call<detail::PiApiKind::piQueueFlush>(getHandleRef());
-  }
-#endif
-
   std::vector<std::weak_ptr<event_impl>> WeakEvents;
   std::vector<event> SharedEvents;
   {

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -318,10 +318,7 @@ public:
       // queue property.
       CreationFlags |= PI_EXT_ONEAPI_QUEUE_DISCARD_EVENTS;
     }
-    if (MPropList
-            .has_property<ext::oneapi::property::queue::lazy_execution>()) {
-      CreationFlags |= PI_EXT_ONEAPI_QUEUE_LAZY_EXECUTION;
-    }
+
     RT::PiQueue Queue{};
     RT::PiContext Context = MContext->getHandleRef();
     RT::PiDevice Device = MDevice->getHandleRef();
@@ -652,7 +649,8 @@ private:
 
   // Command graph which is associated with this queue for the purposes of
   // recording commands to it.
-  std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> MGraph;
+  std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> MGraph =
+      nullptr;
   // This flag is set to true if a command_graph is currently submitting
   // commands to this queue. Used by subgraphs to determine if they are part of
   // a larger command graph submission.

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1985,9 +1985,6 @@ static void ReverseRangeDimensionsForKernel(NDRDescT &NDR) {
   }
 }
 
-// Sets arguments for a given kernel and device based on the argument type.
-// Refactored from SetKernelParamsAndLaunch to allow it to be used in the graphs
-// extension.
 void SetArgBasedOnType(
     const detail::plugin &Plugin, RT::PiKernel Kernel,
     const std::shared_ptr<device_image_impl> &DeviceImageImpl,

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1985,6 +1985,9 @@ static void ReverseRangeDimensionsForKernel(NDRDescT &NDR) {
   }
 }
 
+// Sets arguments for a given kernel and device based on the argument type.
+// Refactored from SetKernelParamsAndLaunch to allow it to be used in the graphs
+// extension.
 void SetArgBasedOnType(
     const detail::plugin &Plugin, RT::PiKernel Kernel,
     const std::shared_ptr<device_image_impl> &DeviceImageImpl,

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -84,7 +84,7 @@ static std::string deviceToString(device Device) {
     return "UNKNOWN";
 }
 
-static void applyFuncOnFilteredArgs(
+void applyFuncOnFilteredArgs(
     const ProgramManager::KernelArgMask &EliminatedArgMask,
     std::vector<ArgDesc> &Args,
     std::function<void(detail::ArgDesc &Arg, int NextTrueIndex)> Func) {

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -608,6 +608,11 @@ void SetArgBasedOnType(
     const sycl::context &Context, bool IsHost, detail::ArgDesc &Arg,
     size_t NextTrueIndex);
 
+void applyFuncOnFilteredArgs(
+    const ProgramManager::KernelArgMask &EliminatedArgMask,
+    std::vector<ArgDesc> &Args,
+    std::function<void(detail::ArgDesc &Arg, int NextTrueIndex)> Func);
+
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -601,6 +601,9 @@ private:
   void **MDstPtr = nullptr;
 };
 
+// Sets arguments for a given kernel and device based on the argument type.
+// Refactored from SetKernelParamsAndLaunch to allow it to be used in the graphs
+// extension.
 void SetArgBasedOnType(
     const detail::plugin &Plugin, RT::PiKernel Kernel,
     const std::shared_ptr<device_image_impl> &DeviceImageImpl,

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -601,6 +601,13 @@ private:
   void **MDstPtr = nullptr;
 };
 
+void SetArgBasedOnType(
+    const detail::plugin &Plugin, RT::PiKernel Kernel,
+    const std::shared_ptr<device_image_impl> &DeviceImageImpl,
+    const std::function<void *(Requirement *Req)> &getMemAllocationFunc,
+    const sycl::context &Context, bool IsHost, detail::ArgDesc &Arg,
+    size_t NextTrueIndex);
+
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -212,10 +212,5 @@ bool queue::device_has(aspect Aspect) const {
   // avoid creating sycl object from impl
   return impl->getDeviceImplPtr()->has(Aspect);
 }
-
-template __SYCL_EXPORT bool
-queue::has_property<ext::oneapi::property::queue::lazy_execution>() const;
-template __SYCL_EXPORT ext::oneapi::property::queue::lazy_execution
-queue::get_property<ext::oneapi::property::queue::lazy_execution>() const;
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/test/graph/graph-explicit-dotp-buffer.cpp
+++ b/sycl/test/graph/graph-explicit-dotp-buffer.cpp
@@ -24,9 +24,7 @@ int main() {
   float beta = 2.0f;
   float gamma = 3.0f;
 
-  sycl::property_list properties{sycl::property::queue::in_order{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 

--- a/sycl/test/graph/graph-explicit-dotp-buffer.cpp
+++ b/sycl/test/graph/graph-explicit-dotp-buffer.cpp
@@ -24,9 +24,7 @@ int main() {
   float beta = 2.0f;
   float gamma = 3.0f;
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order{},
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
+  sycl::property_list properties{sycl::property::queue::in_order{}};
 
   sycl::queue q{sycl::gpu_selector_v, properties};
 

--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -64,11 +64,22 @@ int main() {
 
   auto node_c = g.add(
       [&](sycl::handler &h) {
+#ifdef TEST_GRAPH_REDUCTIONS
+        h.parallel_for(sycl::range<1>{n},
+                       sycl::reduction(dotp, 0.0f, std::plus()),
+                       [=](sycl::id<1> it, auto &sum) {
+                         const size_t i = it[0];
+                         sum += x[i] * z[i];
+                       });
+#else
         h.single_task([=]() {
+          // Doing a manual reduction here because reduction objects cause
+          // issues with graphs.
           for (size_t j = 0; j < n; j++) {
             dotp[0] += x[j] * z[j];
           }
         });
+#endif
       },
       {node_a, node_b});
 

--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -24,11 +24,7 @@ int main() {
   float beta = 2.0f;
   float gamma = 3.0f;
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order{},
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 
@@ -68,12 +64,11 @@ int main() {
 
   auto node_c = g.add(
       [&](sycl::handler &h) {
-        h.parallel_for(sycl::range<1>{n},
-                       sycl::reduction(dotp, 0.0f, std::plus()),
-                       [=](sycl::id<1> it, auto &sum) {
-                         const size_t i = it[0];
-                         sum += x[i] * z[i];
-                       });
+        h.single_task([=]() {
+          for (size_t j = 0; j < n; j++) {
+            dotp[0] += x[j] * z[j];
+          }
+        });
       },
       {node_a, node_b});
 

--- a/sycl/test/graph/graph-explicit-empty.cpp
+++ b/sycl/test/graph/graph-explicit-empty.cpp
@@ -5,46 +5,48 @@
 
 int main() {
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order{},
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 
   const size_t n = 10;
-  float *h_arr = sycl::malloc_host<float>(n, q);
   float *arr = sycl::malloc_device<float>(n, q);
-  
+
   auto start = g.add();
 
-  auto init = g.add([&](sycl::handler &h) {
-      h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> idx) {
-        size_t i = idx;
-        arr[i] = 0;
-      });
-  }, {start});
-    
-  auto empty = g.add({init});
+  auto init = g.add(
+      [&](sycl::handler &h) {
+        h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> idx) {
+          size_t i = idx;
+          arr[i] = 0;
+        });
+      },
+      {start});
 
-  g.add([&](sycl::handler &h) {
-    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> idx) {
-      size_t i = idx;
-      arr[i] = 1;
-    });
-  }, {empty});
+  auto empty = g.add({init});
+  auto empty2 = g.add({empty});
+
+  g.add(
+      [&](sycl::handler &h) {
+        h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> idx) {
+          size_t i = idx;
+          arr[i] = 1;
+        });
+      },
+      {empty2});
 
   auto executable_graph = g.finalize(q.get_context());
 
-  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); }).wait();
+  q.submit([&](sycl::handler &h) {
+     h.ext_oneapi_graph(executable_graph);
+   }).wait();
 
-  q.memcpy(&(h_arr[0]), arr, n).wait();
+  std::vector<float> HostData(n);
+  q.memcpy(HostData.data(), arr, n * sizeof(float)).wait();
 
   for (int i = 0; i < n; i++)
-    assert(h_arr[i] == 1.0f);
+    assert(HostData[i] == 1.f);
 
-  sycl::free(h_arr, q);
   sycl::free(arr, q);
 
   return 0;

--- a/sycl/test/graph/graph-explicit-node-ordering.cpp
+++ b/sycl/test/graph/graph-explicit-node-ordering.cpp
@@ -5,9 +5,7 @@
 
 int main() {
 
-  sycl::property_list properties{sycl::property::queue::in_order{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 

--- a/sycl/test/graph/graph-explicit-node-ordering.cpp
+++ b/sycl/test/graph/graph-explicit-node-ordering.cpp
@@ -5,9 +5,7 @@
 
 int main() {
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order{},
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
+  sycl::property_list properties{sycl::property::queue::in_order{}};
 
   sycl::queue q{sycl::gpu_selector_v, properties};
 

--- a/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
+++ b/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
@@ -5,11 +5,7 @@
 
 int main() {
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order{},
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   // Test passing empty property list, which is the default
   sycl::property_list empty_properties;

--- a/sycl/test/graph/graph-explicit-reduction.cpp
+++ b/sycl/test/graph/graph-explicit-reduction.cpp
@@ -4,11 +4,7 @@
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 
 int main() {
-  sycl::property_list properties{
-      sycl::property::queue::in_order{},
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 

--- a/sycl/test/graph/graph-explicit-repeated-exec.cpp
+++ b/sycl/test/graph/graph-explicit-repeated-exec.cpp
@@ -5,9 +5,7 @@
 
 int main() {
 
-  sycl::property_list properties{sycl::property::queue::in_order{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 

--- a/sycl/test/graph/graph-explicit-repeated-exec.cpp
+++ b/sycl/test/graph/graph-explicit-repeated-exec.cpp
@@ -5,9 +5,7 @@
 
 int main() {
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order{},
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
+  sycl::property_list properties{sycl::property::queue::in_order{}};
 
   sycl::queue q{sycl::gpu_selector_v, properties};
 

--- a/sycl/test/graph/graph-explicit-saxpy.cpp
+++ b/sycl/test/graph/graph-explicit-saxpy.cpp
@@ -5,11 +5,7 @@
 
 int main() {
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order{},
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 

--- a/sycl/test/graph/graph-explicit-single-node.cpp
+++ b/sycl/test/graph/graph-explicit-single-node.cpp
@@ -6,11 +6,7 @@
 
 int main() {
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order{},
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 
@@ -23,7 +19,7 @@ int main() {
   g.add([&](sycl::handler &h) {
     h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> idx) {
       size_t i = idx;
-      arr[i] = 1;
+      arr[i] = 3.14f;
     });
   });
 
@@ -42,7 +38,7 @@ int main() {
    }).wait();
 
   for (int i = 0; i < n; i++)
-    assert(arr[i] == 1);
+    assert(arr[i] == 3.14f);
 
   sycl::free(arr, q);
 

--- a/sycl/test/graph/graph-explicit-subgraph.cpp
+++ b/sycl/test/graph/graph-explicit-subgraph.cpp
@@ -27,9 +27,7 @@ int main() {
   float beta = 2.0f;
   float gamma = 3.0f;
 
-  sycl::property_list properties{sycl::property::queue::in_order{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
   sycl::ext::oneapi::experimental::command_graph subGraph;

--- a/sycl/test/graph/graph-record-dotp-buffer.cpp
+++ b/sycl/test/graph/graph-record-dotp-buffer.cpp
@@ -24,11 +24,7 @@ int main() {
   float beta = 2.0f;
   float gamma = 3.0f;
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order(),
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 

--- a/sycl/test/graph/graph-record-dotp.cpp
+++ b/sycl/test/graph/graph-record-dotp.cpp
@@ -24,9 +24,7 @@ int main() {
   float beta = 2.0f;
   float gamma = 3.0f;
 
-  sycl::property_list properties{sycl::property::queue::in_order()};
-
-  sycl::queue q{sycl::gpu_selector_v, properties};
+  sycl::queue q{sycl::gpu_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 

--- a/sycl/test/graph/graph-record-simple.cpp
+++ b/sycl/test/graph/graph-record-simple.cpp
@@ -8,11 +8,7 @@ int main() {
   const size_t n = 10;
   const float expectedValue = 7.f;
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order(),
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue q{sycl::default_selector_v, properties};
+  sycl::queue q{sycl::default_selector_v};
   sycl::queue q2;
 
   sycl::ext::oneapi::experimental::command_graph g;

--- a/sycl/test/graph/graph-record-temp-scope.cpp
+++ b/sycl/test/graph/graph-record-temp-scope.cpp
@@ -20,11 +20,7 @@ void run_some_kernel(sycl::queue q, float *data) {
 
 int main() {
 
-  sycl::property_list properties{
-      sycl::property::queue::in_order(),
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue q{sycl::default_selector_v, properties};
+  sycl::queue q{sycl::default_selector_v};
 
   sycl::ext::oneapi::experimental::command_graph g;
 

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -35,15 +35,6 @@ protected:
   experimental::command_graph<experimental::graph_state::modifiable> Graph;
 };
 
-TEST_F(CommandGraphTest, LazyQueueProperty) {
-  sycl::property_list Props{
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue Queue{Dev, Props};
-  bool hasProp =
-      Queue.has_property<sycl::ext::oneapi::property::queue::lazy_execution>();
-  ASSERT_TRUE(hasProp);
-}
 
 TEST_F(CommandGraphTest, AddNode) {
   using namespace sycl::ext::oneapi;
@@ -98,11 +89,8 @@ TEST_F(CommandGraphTest, MakeEdge) {
 TEST_F(CommandGraphTest, BeginEndRecording) {
   using namespace sycl::ext::oneapi;
 
-  sycl::property_list Props{
-      sycl::ext::oneapi::property::queue::lazy_execution{}};
-
-  sycl::queue Queue{Dev, Props};
-  sycl::queue Queue2{Dev, Props};
+  sycl::queue Queue{Dev};
+  sycl::queue Queue2{Dev};
 
   // Test throwing behaviour
   // Check we can repeatedly begin recording on the same queues


### PR DESCRIPTION
Hook up the `command_graph` runtime to use the new PI entry-points by creating a PI command-buffer
on finalization and enqueueing the command-buffer handler submit on the executable graph. Based on the [[SYCL] Remove CGF reuse in graph nodes #87 ](https://github.com/reble/llvm/pull/87) PR

Removes the need for the lazy queue property.

Note: Subgraphs are currently broken by this change. Making them work with the command buffers is in progress but will be split to a different PR.

Changes:
- Remove lazy queue property
- Use command buffers inside graphs for execution
- Separate executable graph impl from modifiable graph impl
- Implement handler::depends_on for record and replay nodes
- New test for finalizing different graphs from the same modifiable one
- graph-record-dotp test now uses handler::depends_on

Closes #17 