### PR TITLE
[SYCL] New sycl::handler constructor for a graph

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -376,6 +376,14 @@ private:
           std::shared_ptr<detail::queue_impl> PrimaryQueue,
           std::shared_ptr<detail::queue_impl> SecondaryQueue, bool IsHost);
 
+  /// Constructs SYCL handler from Graph.
+  ///
+  /// The hander will add the command-group as a node to the graph rather than
+  /// processing it straight away.
+  ///
+  /// \param Graph is a SYCL command_graph
+  handler(std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> Graph);
+
   /// Stores copy of Arg passed to the MArgsStorage.
   template <typename T, typename F = typename detail::remove_const_t<
                             typename detail::remove_reference_t<T>>>
@@ -2532,6 +2540,8 @@ public:
 private:
   std::shared_ptr<detail::handler_impl> MImpl;
   std::shared_ptr<detail::queue_impl> MQueue;
+  std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> MGraph;
+
   /// The storage for the arguments passed.
   /// We need to store a copy of values that are passed explicitly through
   /// set_arg, require and so on, because we need them to be alive after

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -379,7 +379,7 @@ private:
   /// Constructs SYCL handler from Graph.
   ///
   /// The hander will add the command-group as a node to the graph rather than
-  /// processing it straight away.
+  /// enqueueing it straight away.
   ///
   /// \param Graph is a SYCL command_graph
   handler(std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> Graph);

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -90,10 +90,7 @@ graph_impl::add(const std::shared_ptr<graph_impl> &Impl,
                 std::function<void(handler &)> CGF,
                 const std::vector<sycl::detail::ArgDesc> &Args,
                 const std::vector<std::shared_ptr<node_impl>> &Dep) {
-  sycl::queue TempQueue{};
-  auto QueueImpl = sycl::detail::getSyclObjImpl(TempQueue);
-  QueueImpl->setCommandGraph(Impl);
-  sycl::handler Handler{QueueImpl, false};
+  sycl::handler Handler{Impl};
   CGF(Handler);
 
   return this->add(Impl, Handler.MKernel, Handler.MNDRDesc,

--- a/sycl/source/detail/handler_impl.hpp
+++ b/sycl/source/detail/handler_impl.hpp
@@ -29,6 +29,8 @@ public:
       : MSubmissionPrimaryQueue(std::move(SubmissionPrimaryQueue)),
         MSubmissionSecondaryQueue(std::move(SubmissionSecondaryQueue)){};
 
+  handler_impl() = default;
+
   void setStateExplicitKernelBundle() {
     if (MSubmissionState == HandlerSubmissionState::SPEC_CONST_SET_STATE)
       throw sycl::exception(

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -40,6 +40,10 @@ handler::handler(std::shared_ptr<detail::queue_impl> Queue,
                                                    std::move(SecondaryQueue))),
       MQueue(std::move(Queue)), MIsHost(IsHost) {}
 
+handler::handler(
+    std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> Graph)
+    : MImpl(std::make_shared<detail::handler_impl>()), MGraph(Graph) {}
+
 // Sets the submission state to indicate that an explicit kernel bundle has been
 // set. Throws a sycl::exception with errc::invalid if the current state
 // indicates that a specialization constant has been set.


### PR DESCRIPTION
This change adds a new handler constructor which takes a graph, rather than creating a default temporary queue object to pass to the existing constructor.

Not sure if this change to the public API of a user exposed class is considered an ABI break.