### PR TITLE
[SYCL] Stop USM arguments creating edges in the explicit API

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -118,9 +118,10 @@ std::shared_ptr<node_impl> graph_impl::add(
   // Copy deps so we can modify them
   auto Deps = Dep;
   // A unique set of dependencies obtained by checking kernel arguments
+  // for accessors
   std::set<std::shared_ptr<node_impl>> UniqueDeps;
   for (auto &Arg : Args) {
-    if (Arg.MType != sycl::detail::kernel_param_kind_t::kind_pointer) {
+    if (Arg.MType != sycl::detail::kernel_param_kind_t::kind_accessor) {
       continue;
     }
     // Look through the graph for nodes which share this argument
@@ -129,7 +130,7 @@ std::shared_ptr<node_impl> graph_impl::add(
     }
   }
 
-  // Add any deps determined from arguments into the dependency list
+  // Add any deps determined from accessor arguments into the dependency list
   Deps.insert(Deps.end(), UniqueDeps.begin(), UniqueDeps.end());
   if (!Deps.empty()) {
     for (auto N : Deps) {

--- a/sycl/test/graph/graph-explicit-dotp-buffer.cpp
+++ b/sycl/test/graph/graph-explicit-dotp-buffer.cpp
@@ -1,0 +1,103 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+const size_t n = 10;
+
+float host_gold_result() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  float sum = 0.0f;
+
+  for (size_t i = 0; i < n; ++i) {
+    sum += (alpha * 1.0f + beta * 2.0f) * (gamma * 3.0f + beta * 2.0f);
+  }
+
+  return sum;
+}
+
+int main() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  sycl::property_list properties{
+      sycl::property::queue::in_order{},
+      sycl::ext::oneapi::property::queue::lazy_execution{}};
+
+  sycl::queue q{sycl::gpu_selector_v, properties};
+
+  sycl::ext::oneapi::experimental::command_graph g;
+
+  float dotpData = 0.f;
+  std::vector<float> xData(n);
+  std::vector<float> yData(n);
+  std::vector<float> zData(n);
+
+  {
+    sycl::buffer dotpBuf(&dotpData, sycl::range<1>(1));
+
+    sycl::buffer xBuf(xData);
+    sycl::buffer yBuf(yData);
+    sycl::buffer zBuf(zData);
+
+    /* init data on the device */
+    auto n_i = g.add([&](sycl::handler &h) {
+      auto x = xBuf.get_access(h);
+      auto y = yBuf.get_access(h);
+      auto z = zBuf.get_access(h);
+      h.parallel_for(n, [=](sycl::id<1> it) {
+        const size_t i = it[0];
+        x[i] = 1.0f;
+        y[i] = 2.0f;
+        z[i] = 3.0f;
+      });
+    });
+
+    auto node_a = g.add([&](sycl::handler &h) {
+      auto x = xBuf.get_access(h);
+      auto y = yBuf.get_access(h);
+      h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+        const size_t i = it[0];
+        x[i] = alpha * x[i] + beta * y[i];
+      });
+    });
+
+    auto node_b = g.add([&](sycl::handler &h) {
+      auto y = yBuf.get_access(h);
+      auto z = zBuf.get_access(h);
+      h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+        const size_t i = it[0];
+        z[i] = gamma * z[i] + beta * y[i];
+      });
+    });
+
+    auto node_c = g.add([&](sycl::handler &h) {
+      auto dotp = dotpBuf.get_access(h);
+      auto x = xBuf.get_access(h);
+      auto z = zBuf.get_access(h);
+      h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+        const size_t i = it[0];
+        // Doing a manual reduction here because reduction objects cause issues
+        // with graphs.
+        if (i == 0) {
+          for (size_t j = 0; j < n; j++) {
+            dotp[0] += x[j] * z[j];
+          }
+        }
+      });
+    });
+
+    auto executable_graph = g.finalize(q.get_context());
+
+    // Using shortcut for executing a graph of commands
+    q.ext_oneapi_graph(executable_graph).wait();
+  }
+
+  assert(dotpData == host_gold_result());
+  return 0;
+}

--- a/sycl/test/graph/graph-explicit-subgraph.cpp
+++ b/sycl/test/graph/graph-explicit-subgraph.cpp
@@ -74,12 +74,22 @@ int main() {
 
   auto node_c = g.add(
       [&](sycl::handler &h) {
+#ifdef TEST_GRAPH_REDUCTIONS
         h.parallel_for(sycl::range<1>{n},
                        sycl::reduction(dotp, 0.0f, std::plus()),
                        [=](sycl::id<1> it, auto &sum) {
                          const size_t i = it[0];
                          sum += x[i] * z[i];
                        });
+#else
+        h.single_task([=]() {
+          // Doing a manual reduction here because reduction objects cause
+          // issues with graphs.
+          for (size_t j = 0; j < n; j++) {
+            dotp[0] += x[j] * z[j];
+          }
+        });
+#endif
       },
       {node_sub});
 

--- a/sycl/test/graph/graph-record-dotp-buffer.cpp
+++ b/sycl/test/graph/graph-record-dotp-buffer.cpp
@@ -83,18 +83,23 @@ int main() {
       auto dotp = dotpBuf.get_access(h);
       auto x = xBuf.get_access(h);
       auto z = zBuf.get_access(h);
-      h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
-        const size_t i = it[0];
+#ifdef TEST_GRAPH_REDUCTIONS
+      h.parallel_for(sycl::range<1>{n},
+                     sycl::reduction(dotpBuf, h, 0.0f, std::plus()),
+                     [=](sycl::id<1> it, auto &sum) {
+                       const size_t i = it[0];
+                       sum += x[i] * z[i];
+                     });
+#else
+      h.single_task([=]() {
         // Doing a manual reduction here because reduction objects cause issues
         // with graphs.
-        if (i == 0) {
-          for (size_t j = 0; j < n; j++) {
-            dotp[0] += x[j] * z[j];
-          }
+        for (size_t j = 0; j < n; j++) {
+          dotp[0] += x[j] * z[j];
         }
       });
+#endif
     });
-
     g.end_recording();
 
     auto exec_graph = g.finalize(q.get_context());

--- a/sycl/test/graph/graph-record-dotp.cpp
+++ b/sycl/test/graph/graph-record-dotp.cpp
@@ -67,16 +67,21 @@ int main() {
   });
 
   q.submit([&](sycl::handler &h) {
-    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
-      const size_t i = it[0];
+#ifdef TEST_GRAPH_REDUCTIONS
+    h.parallel_for(sycl::range<1>{n}, sycl::reduction(dotp, 0.0f, std::plus()),
+                   [=](sycl::id<1> it, auto &sum) {
+                     const size_t i = it[0];
+                     sum += x[i] * z[i];
+                   });
+#else
+    h.single_task([=]() {
       // Doing a manual reduction here because reduction objects cause issues
       // with graphs.
-      if (i == 0) {
-        for (size_t j = 0; j < n; j++) {
-          dotp[0] += x[j] * z[j];
-        }
+      for (size_t j = 0; j < n; j++) {
+        dotp[0] += x[j] * z[j];
       }
     });
+#endif
   });
 
   g.end_recording();


### PR DESCRIPTION
Instead it is buffer accessors that should be used for edge detection

Fixes graph-explicit-node-ordering which is currently creating incorrect extra edges