### PR TITLE
Update record & replay tests

### DIFF
--- a/sycl/test/graph/graph-explicit-dotp.cpp
+++ b/sycl/test/graph/graph-explicit-dotp.cpp
@@ -1,5 +1,4 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <iostream>
 #include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-explicit-node-ordering.cpp
+++ b/sycl/test/graph/graph-explicit-node-ordering.cpp
@@ -1,5 +1,4 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <iostream>
 #include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
+++ b/sycl/test/graph/graph-explicit-queue-shortcuts.cpp
@@ -1,5 +1,4 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <iostream>
 #include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-explicit-reduction.cpp
+++ b/sycl/test/graph/graph-explicit-reduction.cpp
@@ -1,5 +1,4 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <iostream>
 #include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-explicit-repeated-exec.cpp
+++ b/sycl/test/graph/graph-explicit-repeated-exec.cpp
@@ -1,5 +1,4 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <iostream>
 #include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
@@ -27,24 +26,20 @@ int main() {
     });
   });
 
-  bool check = true;
   for (int i = 0; i < n; i++) {
-    if (arr[i] != 0)
-      check = false;
+    assert(arr[i] == 0);
   }
 
   auto executable_graph = g.finalize(q.get_context());
 
   for (int i = 0; i < n; i++) {
-    if (arr[i] != 0)
-      check = false;
+    assert(arr[i] == 0);
   }
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });
 
   for (int i = 0; i < n; i++) {
-    if (arr[i] != 1)
-      check = false;
+    assert(arr[i] == 1);
   }
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });

--- a/sycl/test/graph/graph-explicit-saxpy.cpp
+++ b/sycl/test/graph/graph-explicit-saxpy.cpp
@@ -1,5 +1,4 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-#include <iostream>
 #include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-explicit-single-node.cpp
+++ b/sycl/test/graph/graph-explicit-single-node.cpp
@@ -27,17 +27,14 @@ int main() {
     });
   });
 
-  bool check = true;
   for (int i = 0; i < n; i++) {
-    if (arr[i] != 0)
-      check = false;
+    assert(arr[i] == 0);
   }
 
   auto executable_graph = g.finalize(q.get_context());
 
   for (int i = 0; i < n; i++) {
-    if (arr[i] != 0)
-      check = false;
+    assert(arr[i] == 0);
   }
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });

--- a/sycl/test/graph/graph-explicit-subgraph.cpp
+++ b/sycl/test/graph/graph-explicit-subgraph.cpp
@@ -2,7 +2,6 @@
 
 // Modified version of the dotp example which submits part of the graph as a
 // sub-graph
-#include <iostream>
 #include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test/graph/graph-record-dotp-buffer.cpp
+++ b/sycl/test/graph/graph-record-dotp-buffer.cpp
@@ -1,7 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 #include <CL/sycl.hpp>
-#include <iostream>
-#include <thread>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 
@@ -102,11 +100,7 @@ int main() {
     q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
   }
 
-  if (dotpData != host_gold_result()) {
-    std::cout << "Test failed: Error unexpected result!\n";
-  } else {
-    std::cout << "Test passed successfuly.";
-  }
+  assert(dotpData == host_gold_result());
 
   return 0;
 }

--- a/sycl/test/graph/graph-record-dotp.cpp
+++ b/sycl/test/graph/graph-record-dotp.cpp
@@ -1,7 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 #include <CL/sycl.hpp>
-#include <iostream>
-#include <thread>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
 
@@ -85,18 +83,12 @@ int main() {
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
 
-  if (dotp[0] != host_gold_result()) {
-    std::cout << "Test failed: Error unexpected result!\n";
-  } else {
-    std::cout << "Test passed successfuly.";
-  }
+  assert(dotp[0] == host_gold_result());
 
   sycl::free(dotp, q);
   sycl::free(x, q);
   sycl::free(y, q);
   sycl::free(z, q);
-
-  std::cout << "done.\n";
 
   return 0;
 }

--- a/sycl/test/graph/graph-record-simple.cpp
+++ b/sycl/test/graph/graph-record-simple.cpp
@@ -1,6 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 
-#include <iostream>
 #include <sycl/sycl.hpp>
 
 #include <sycl/ext/oneapi/experimental/graph.hpp>
@@ -36,24 +35,12 @@ int main() {
 
   q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
 
-  int errors = 0;
   // Verify results
   for (size_t i = 0; i < n; i++) {
-    if (arr[i] != expectedValue) {
-      std::cout << "Test failed: Unexpected result at index: " << i
-                << ", expected: " << expectedValue << " actual: " << arr[i]
-                << "\n";
-      errors++;
-    }
+    assert(arr[i] == expectedValue);
   }
-
-  if (errors == 0) {
-    std::cout << "Test passed successfuly.";
-  }
-
-  std::cout << "done.\n";
 
   sycl::free(arr, q.get_context());
 
-  return errors;
+  return 0;
 }


### PR DESCRIPTION
Update the record & replay tests to match changes from https://github.com/reble/llvm/pull/72 which were missed after merging the record and replay branch:

* Remove unused headers
* Uses asserts instead of printing to std out