### PR TITLE
Remove wording on adding tasks after defining graph

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -513,8 +513,7 @@ node add(const property_list& propList = {});
 ----
 |This creates an empty node which contains no command. Its intended use is
 to make a connection point inside a graph between groups of nodes, and can
-significantly reduce the number of edges ( O(n) vs. O(n^2) ). Another use-case
-is building the structure of a graph first and adding tasks later.
+significantly reduce the number of edges ( O(n) vs. O(n^2^) ).
 
 Preconditions:
 


### PR DESCRIPTION
Removes wording from `graph.add()` about being able to add tasks after defining the graph structure. Actions feedback https://github.com/intel/llvm/pull/5626#discussion_r1055852971

Also use [asciidoc superscript syntax](https://docs.asciidoctor.org/asciidoc/latest/text/subscript-and-superscript/) for power-of-two. Now renders as 
![image](https://user-images.githubusercontent.com/2334151/228181069-9b5df6b8-61b0-416d-816f-78bbc4e7d969.png)
rather than 
![image](https://user-images.githubusercontent.com/2334151/228181117-7c161a5d-d020-4288-8089-d92469d7acdd.png)
