### PR TITLE
Graph Testing: Add missing waits and USM device tests

### DIFF
--- a/sycl/test/graph/graph-explicit-dotp-device-mem.cpp
+++ b/sycl/test/graph/graph-explicit-dotp-device-mem.cpp
@@ -1,0 +1,96 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+const size_t n = 10;
+
+float host_gold_result() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  float sum = 0.0f;
+
+  for (size_t i = 0; i < n; ++i) {
+    sum += (alpha * 1.0f + beta * 2.0f) * (gamma * 3.0f + beta * 2.0f);
+  }
+
+  return sum;
+}
+
+int main() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  sycl::property_list properties{
+      sycl::property::queue::in_order{},
+      sycl::ext::oneapi::property::queue::lazy_execution{}};
+
+  sycl::queue q{sycl::gpu_selector_v, properties};
+
+  sycl::ext::oneapi::experimental::command_graph g;
+
+  float *dotp = sycl::malloc_device<float>(1, q);
+
+  float *x = sycl::malloc_device<float>(n, q);
+  float *y = sycl::malloc_device<float>(n, q);
+  float *z = sycl::malloc_device<float>(n, q);
+
+  /* init data on the device */
+  auto n_i = g.add([&](sycl::handler &h) {
+    h.parallel_for(n, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      x[i] = 1.0f;
+      y[i] = 2.0f;
+      z[i] = 3.0f;
+    });
+  });
+
+  auto node_a = g.add(
+      [&](sycl::handler &h) {
+        h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+          const size_t i = it[0];
+          x[i] = alpha * x[i] + beta * y[i];
+        });
+      },
+      {n_i});
+
+  auto node_b = g.add(
+      [&](sycl::handler &h) {
+        h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+          const size_t i = it[0];
+          z[i] = gamma * z[i] + beta * y[i];
+        });
+      },
+      {n_i});
+
+  auto node_c = g.add(
+      [&](sycl::handler &h) {
+        h.parallel_for(sycl::range<1>{n},
+                       sycl::reduction(dotp, 0.0f, std::plus()),
+                       [=](sycl::id<1> it, auto &sum) {
+                         const size_t i = it[0];
+                         sum += x[i] * z[i];
+                       });
+      },
+      {node_a, node_b});
+
+  auto executable_graph = g.finalize(q.get_context());
+
+  // Using shortcut for executing a graph of commands
+  q.ext_oneapi_graph(executable_graph).wait();
+
+  std::vector<float> dotp_host(1);
+  q.copy(dotp, dotp_host.data(), 1).wait();
+
+  assert(dotp_host[0] == host_gold_result());
+
+  sycl::free(dotp, q);
+  sycl::free(x, q);
+  sycl::free(y, q);
+  sycl::free(z, q);
+
+  return 0;
+}

--- a/sycl/test/graph/graph-explicit-repeated-exec.cpp
+++ b/sycl/test/graph/graph-explicit-repeated-exec.cpp
@@ -36,13 +36,17 @@ int main() {
     assert(arr[i] == 0);
   }
 
-  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });
+  q.submit([&](sycl::handler &h) {
+     h.ext_oneapi_graph(executable_graph);
+   }).wait();
 
   for (int i = 0; i < n; i++) {
     assert(arr[i] == 1);
   }
 
-  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });
+  q.submit([&](sycl::handler &h) {
+     h.ext_oneapi_graph(executable_graph);
+   }).wait();
 
   for (int i = 0; i < n; i++)
     assert(arr[i] == 2);

--- a/sycl/test/graph/graph-explicit-single-node.cpp
+++ b/sycl/test/graph/graph-explicit-single-node.cpp
@@ -37,7 +37,9 @@ int main() {
     assert(arr[i] == 0);
   }
 
-  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(executable_graph); });
+  q.submit([&](sycl::handler &h) {
+     h.ext_oneapi_graph(executable_graph);
+   }).wait();
 
   for (int i = 0; i < n; i++)
     assert(arr[i] == 1);

--- a/sycl/test/graph/graph-record-dotp-buffer.cpp
+++ b/sycl/test/graph/graph-record-dotp-buffer.cpp
@@ -102,7 +102,7 @@ int main() {
 
     auto exec_graph = g.finalize(q.get_context());
 
-    q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
+    q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); }).wait();
   }
 
   assert(dotpData == host_gold_result());

--- a/sycl/test/graph/graph-record-dotp.cpp
+++ b/sycl/test/graph/graph-record-dotp.cpp
@@ -86,7 +86,7 @@ int main() {
 
   auto exec_graph = g.finalize(q.get_context());
 
-  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
+  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); }).wait();
 
   assert(dotp[0] == host_gold_result());
 

--- a/sycl/test/graph/graph-record-simple.cpp
+++ b/sycl/test/graph/graph-record-simple.cpp
@@ -33,7 +33,7 @@ int main() {
 
   auto exec_graph = g.finalize(q.get_context());
 
-  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
+  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); }).wait();
 
   // Verify results
   for (size_t i = 0; i < n; i++) {

--- a/sycl/test/graph/graph-record-temp-scope.cpp
+++ b/sycl/test/graph/graph-record-temp-scope.cpp
@@ -36,7 +36,7 @@ int main() {
 
   auto exec_graph = g.finalize(q.get_context());
 
-  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); });
+  q.submit([&](sycl::handler &h) { h.ext_oneapi_graph(exec_graph); }).wait();
 
   // Verify results
   for (size_t i = 0; i < n; i++) {


### PR DESCRIPTION
This PR addresses two improvements to the SYCL Graph testing:

1. @reble noticed missing wait statements in the existing tests.
2. Add a test to verify correct behavior when using SYCL USM device memory and explicit memory copies.