### PR TITLE
[SYCL][DOC] Error on simultaneous graph submission

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -931,9 +931,9 @@ Table {counter: tableNumber}. Additional member functions of the `sycl::handler`
 void handler::ext_oneapi_graph(command_graph<graph_state::executable>& graph)
 ----
 
-|Invokes the execution of a graph. Support for invoking an executable graph,
-before a previous execution of the same graph has been completed is backend
-specific. The runtime may throw an error.
+|Invokes the execution of a graph. Only one instance of `graph` may be executing,
+or pending execution, at any time. Concurrent graph execution can be achieved by
+finalizing a modifiable graph into multiple executable graphs.
 
 Parameters:
 
@@ -944,6 +944,9 @@ Exceptions:
 * Throws synchronously with error code `invalid` if the handler is submitted
   to a queue which doesn't have a SYCL context which matches the context of
   the executable graph.
+
+* Throws synchronously with error code `invalid` if a previous submission of
+  `graph` has yet to complete execution.
 |===
 
 === Thread Safety
@@ -1313,6 +1316,14 @@ submitted in its entirety for execution via
 ----
 
 == Issues
+
+=== Simultaneous Graph Submission
+
+Enable an instance of an executable graph to be submitted for execution
+when a previous submission of the same graph has yet to complete execution.
+
+**Outcome:** Backend support for this is inconsistent, but the runtime could
+schedule the submissions sequentially for backends which don't support it.
 
 === Multi Device Graph
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -933,7 +933,7 @@ void handler::ext_oneapi_graph(command_graph<graph_state::executable>& graph)
 
 |Invokes the execution of a graph. Only one instance of `graph` may be executing,
 or pending execution, at any time. Concurrent graph execution can be achieved by
-finalizing a modifiable graph into multiple executable graphs.
+finalizing a graph in modifiable state into multiple graphs in executable state.
 
 Parameters:
 
@@ -1319,7 +1319,7 @@ submitted in its entirety for execution via
 
 === Simultaneous Graph Submission
 
-Enable an instance of an executable graph to be submitted for execution
+Enable an instance of a graph in executable state to be submitted for execution
 when a previous submission of the same graph has yet to complete execution.
 
 **Outcome:** Backend support for this is inconsistent, but the runtime could


### PR DESCRIPTION
Actions [feedback](https://github.com/intel/llvm/pull/5626#discussion_r1150765202) that we should error when a graph is submitted before a previous execution of the same graph has completed, rather than make it conditional on the backend when we have no query.

Added an issue to the bottom of the spec, since I think for revision 2 we could possibly do better and serialize the graph executions in the runtime.

Closes https://github.com/reble/llvm/issues/122