### PR TITLE
[SYCL][DOC] Add wording about buffer host data copies

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -470,7 +470,7 @@ graph LR
 
 The `no_host_copy` property is defined by this extension and can be passed to
 either the `command_graph` constructor or the `command_graph::begin_recording()`
-member function. This property will disable the host data copy and that may
+member function. This property will disable the host data copy that may
 occur as detailed in the <<storage-lifetimes, storage lifetimes>> section of
 this specification.
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -321,7 +321,7 @@ enum class graph_state {
   executable
 };
 
-namespace property{ 
+namespace property { 
 namespace graph {
 
 class no_host_copy;

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -321,6 +321,14 @@ enum class graph_state {
   executable
 };
 
+namespace property{ 
+namespace graph {
+
+class no_host_copy;
+
+} // namespace graph
+} // namespace property
+
 // New object representing graph
 template<graph_state State = graph_state::modifiable>
 class command_graph {};
@@ -333,8 +341,8 @@ public:
   command_graph<graph_state::executable>
   finalize(const context& syclContext, const property_list& propList = {}) const;
 
-  bool begin_recording(queue& recordingQueue);
-  bool begin_recording(const std::vector<queue>& recordingQueues);
+  bool begin_recording(queue& recordingQueue, const property_list& propList = {});
+  bool begin_recording(const std::vector<queue>& recordingQueues, const property_list& propList = {});
 
   bool end_recording();
   bool end_recording(queue& recordingQueue);
@@ -457,6 +465,19 @@ construction.
 graph LR
     Modifiable -->|Finalize| Executable
 ....
+
+==== No-Host-Copy Property
+
+The `no_host_copy` property is defined by this extension and can be passed to
+either the `command_graph` constructor or the `command_graph::begin_recording()`
+member function. This property will disable the host data copy and that may
+occur as detailed in the <<storage-lifetimes, storage lifetimes>> section of
+this specification.
+
+Passing this property represents a promise from the user that host data
+associated with a buffer that was created using a host data pointer will
+outlive any executable graphs created from a modifiable graph which uses
+that buffer.
 
 ==== Executable Graph Update
 
@@ -1010,7 +1031,7 @@ be immediately stale, any code which relies on queue waits should take care
 to ensure waits are not performed on queues in recording mode. For example, by
 using separate queues for graph recording and normal queue operations.
 
-=== Storage Lifetimes
+=== Storage Lifetimes [[storage-lifetimes]]
 
 The lifetime of any buffer recorded as part of a submission
 to a command graph will be extended in keeping with the common reference
@@ -1019,9 +1040,20 @@ extended either for the lifetime of the graph (including both modifiable graphs
 and the executable graphs created from them) or until the buffer is no longer
 required by the graph (such as after being replaced through executable graph update).
 
-Because of the extension of storage lifetimes, users should avoid the use of the
-buffer copy-back on destruction mechanism. If used in code intended to be
-executed as part of a graph, it may not perform as expected.
+If a buffer created with a host data pointer is recorded as part of a submission to
+a command graph, the lifetime of that host data will also be extended by taking a
+copy of that data inside the buffer. This copy will occur during the call to
+`queue::submit()`. Users can opt-out of this behaviour by passing the property
+`graph::no_host_copy` to `command_graph::begin_recording()` or the constructor
+of the `command_graph` the commands will be recorded to. Passing the property to
+`begin_recording()` will prevent host copies only for commands recorded before
+`end_recording()` is called for a given queue. Passing the property to the
+`command_graph` constructor will prevent host copies for all commands recorded to
+the graph.
+
+The copy will not occur if the buffer is accessed inside the submitted command
+group function with an accessor with `access_mode::write` or the `no_init`
+property.
 
 === Buffer Limitations for Record & Replay API
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -695,8 +695,8 @@ Exceptions:
 |
 [source, c++]
 ----
-bool begin_recording(const std::vector<queue>& recordingQueues, 
-const property_list& propList = {})
+bool begin_recording(const std::vector<queue>& recordingQueues,
+                     const property_list& propList = {})
 ----
 
 |Synchronously changes the state of each queue in `recordingQueues` to the

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -324,7 +324,10 @@ enum class graph_state {
 namespace property { 
 namespace graph {
 
-class no_host_copy;
+class no_host_copy {
+public:
+  no_host_copy() = default;
+};
 
 } // namespace graph
 } // namespace property
@@ -466,7 +469,9 @@ graph LR
     Modifiable -->|Finalize| Executable
 ....
 
-==== No-Host-Copy Property
+==== Graph Properties [[graph-properties]]
+
+===== No-Host-Copy Property
 
 The `no_host_copy` property is defined by this extension and can be passed to
 either the `command_graph` constructor or the `command_graph::begin_recording()`
@@ -515,8 +520,8 @@ Parameters:
 * `syclDevice` - Device that all nodes added to the graph will target,
   an immutable characteristic of the graph.
 
-* `propList` - Optional parameter for passing properties. No `command_graph`
-  constructor properties are defined by this extension.
+* `propList` - Optional parameter for passing properties. Properties for
+  the `command_graph` class are defined in <<graph-properties, Graph Properties>>.
 
 |===
 
@@ -661,7 +666,7 @@ Table {counter: tableNumber}. Member functions of the `command_graph` class for 
 |
 [source, c++]
 ----
-bool begin_recording(queue& recordingQueue)
+bool begin_recording(queue& recordingQueue, const property_list& propList = {})
 ----
 
 |Synchronously changes the state of `recordingQueue` to the
@@ -672,6 +677,9 @@ Parameters:
 * `recordingQueue` - A `sycl::queue` object to change to the
   `queue_state::recording` state and start recording commands to the graph
   instance.
+
+* `propList` - Optional parameter for passing properties. Properties for
+  the `command_graph` class are defined in <<graph-properties, Graph Properties>>.
 
 Returns: `true` if `recordingQueue` has its state changed from
 `queue_state::executing` to `queue_state::recording`, `false` otherwise.
@@ -687,7 +695,8 @@ Exceptions:
 |
 [source, c++]
 ----
-bool begin_recording(const std::vector<queue>& recordingQueues)
+bool begin_recording(const std::vector<queue>& recordingQueues, 
+const property_list& propList = {})
 ----
 
 |Synchronously changes the state of each queue in `recordingQueues` to the
@@ -698,6 +707,9 @@ Parameters:
 * `recordingQueues` - List of `sycl::queue` objects to change to the
   `queue_state::recording` state and start recording commands to the graph
   instance.
+
+* `propList` - Optional parameter for passing properties. Properties for
+  the `command_graph` class are defined in <<graph-properties, Graph Properties>>.
 
 Returns: `true` if any queue in `recordingQueues` has its state changed from
 `queue_state::executing` to `queue_state::recording`, `false` otherwise.


### PR DESCRIPTION
- Adds wording about buffers taking host data copies in some situations
- Introduces a new graph property which disables copy behaviour
- Add property list to begin_recording()