### PR TITLE
[SYCL][DOC] Introduce property to switch off error on cycle

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -789,6 +789,18 @@ Exceptions:
   the same order.
 |===
 
+==== Graph Properties
+
+There are the following properties defined that can be passed to a `command_graph`
+on construction via the property list parameter.
+
+1. `property::graph::no_cycle_error_check` - This property disables any checks if
+   a newly added dependency will lead to a cycle in a specific `command_graph`.
+   As a result, no errors are reported when a function tries to create a cyclic
+   dependency. Thus, it's the user's responsibility to create an acyclic graph 
+   for execution when this property is set. Executing any graph with cyclic
+   dependencies is undefined behavior.
+
 === Queue Class Modifications
 
 :queue-class: https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:interface.queue.class

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -302,6 +302,16 @@ enum class queue_state {
 };
 
 namespace property {
+
+namespace graph {
+
+class no_cycle_error_check {
+  public:
+    no_cycle_error_check() = default; 
+};
+
+} // namespace graph
+
 namespace node {
 
 class depends_on {

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -604,7 +604,7 @@ Exceptions:
   are the same node.
   
 * Throws synchronously with error code `invalid` if the resulting dependency would
-  lead to a cycle.
+  lead to a cycle. This error is omitted when `property::graph::no_cycle_check` is set.
 
 |
 [source,c++]

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -800,7 +800,7 @@ on construction via the property list parameter.
    dependency. Thus, it's the user's responsibility to create an acyclic graph 
    for execution when this property is set. Creating a `command_graph` in
    executable state through `finalize` from a graph with cyclic dependencies
-   is undefined behavior.
+   is not allowed and results in undefined behavior.
 
 === Queue Class Modifications
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -305,9 +305,9 @@ namespace property {
 
 namespace graph {
 
-class no_cycle_error_check {
+class no_cycle_check {
   public:
-    no_cycle_error_check() = default; 
+    no_cycle_check() = default; 
 };
 
 } // namespace graph
@@ -791,15 +791,16 @@ Exceptions:
 
 ==== Graph Properties
 
-There are the following properties defined that can be passed to a `command_graph`
+There is the one following property defined that can be passed to a `command_graph`
 on construction via the property list parameter.
 
-1. `property::graph::no_cycle_error_check` - This property disables any checks if
+1. `property::graph::no_cycle_check` - This property disables any checks if
    a newly added dependency will lead to a cycle in a specific `command_graph`.
    As a result, no errors are reported when a function tries to create a cyclic
    dependency. Thus, it's the user's responsibility to create an acyclic graph 
-   for execution when this property is set. Executing any graph with cyclic
-   dependencies is undefined behavior.
+   for execution when this property is set. Creating a `command_graph` in
+   executable state through `finalize` from a graph with cyclic dependencies
+   is undefined behavior.
 
 === Queue Class Modifications
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -504,8 +504,8 @@ Parameters:
 * `syclDevice` - Device that all nodes added to the graph will target,
   an immutable characteristic of the graph.
 
-* `propList` - Optional parameter for passing properties. No `command_graph`
-  constructor properties are defined by this extension.
+* `propList` - Optional parameter for passing properties. Valid `command_graph`
+  constructor properties are listed in Section <<graph-properties, Graph Properties>>.
 
 |===
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -602,6 +602,9 @@ Exceptions:
 
 * Throws synchronously with error code `invalid` if `src` and `dest`
   are the same node.
+  
+* Throws synchronously with error code `invalid` if the resulting dependency would
+  lead to a cycle.
 
 |
 [source,c++]
@@ -633,10 +636,6 @@ Parameters:
 Returns: A new executable graph object which can be submitted to a queue.
 
 Exceptions:
-
-* Throws synchronously with error code `invalid` if the graph contains a cycle.
-  A cycle may be introduced to the graph via a call to `make_edge()` that
-  creates a forward dependency.
 
 * Throws synchronously with error code `invalid` if the graph contains a
   node which targets a device not present in `syclContext`.


### PR DESCRIPTION
This patch adds the option to switch off cycle detection in the DAG by a property. By default an error would be thrown when a `make_edge` call would result in a cyclic graph.