### PR TITLE
[SYCL][Doc]Error on recorded event query.

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -875,18 +875,17 @@ Table {counter: tableNumber}. Queue info query
 Events returned from queue submissions when a queue is in the recording state
 may only be used as parameters to `handler::depends_on()` or as dependent
 events for queue shortcuts like `queue::parallel_for()` for submissions which
-are being recorded to the same modifiable `command_graph`. These events have
-status `info::event_command_status::complete`. The event status of an event
-returned from an executable graph submission will have
-`info::event_command_status::running` once any command group node starts
-executing on a device, and status `info::event_command_status::complete`
-once all the nodes have finished execution.
+are being recorded to the same modifiable `command_graph`.
+
+Calling `event::get_info<info::event::command_execution_status>()` or
+`event::get_profiling_info()` on an event returned from a queue submission
+recorded to a graph will throw synchronously with error code `invalid`.
 
 Waiting on an event returned from a queue submission recorded to a graph
 will throw synchronously with error code `invalid`.
 
-Calling `queue::wait()` on a queue in the recording state is an error and
-will throw synchronously with error code `invalid`.
+Waiting on a queue in the recording state is an error and will throw
+synchronously with error code `invalid`.
 
 ==== Queue Properties
 
@@ -940,6 +939,10 @@ event queue::ext_oneapi_graph(command_graph<graph_state::executable>& graph)
 |Queue shortcut function that is equivalent to submitting a command-group
 containing `handler::ext_oneapi_graph(graph)`.
 
+The command status of the event returned will be
+`info::event_command_status::running` once any command group node starts
+executing on a device, and status `info::event_command_status::complete` once
+all the nodes have finished execution.
 |
 [source,c++]
 ----
@@ -951,6 +954,10 @@ event queue::ext_oneapi_graph(command_graph<graph_state::executable>& graph,
 containing `handler::depends_on(depEvent)` and
 `handler::ext_oneapi_graph(graph)`.
 
+The command status of the event returned will be
+`info::event_command_status::running` once any command group node starts
+executing on a device, and status `info::event_command_status::complete` once
+all the nodes have finished execution.
 |
 [source,c++]
 ----
@@ -961,6 +968,11 @@ event queue::ext_oneapi_graph(command_graph<graph_state::executable>& graph,
 |Queue shortcut function that is equivalent to submitting a command-group
 containing `handler::depends_on(depEvents)` and
 `handler::ext_oneapi_graph(graph)`.
+
+The command status of the event returned will be
+`info::event_command_status::running` once any command group node starts
+executing on a device, and status `info::event_command_status::complete` once
+all the nodes have finished execution.
 |===
 
 ==== New Handler Member Functions


### PR DESCRIPTION
Specify that it is an error to query an event returned by a queue recording for either its command status or profiling info. Addresses feedback https://github.com/intel/llvm/pull/5626#discussion_r1150688098

Additionally:

* The description on the meaning of event command status for a graph submission is moved next to the description of graph submission shortcuts. Where there is a returned event that this behaviour applies to.
* Rephrased error wording around `queue::wait()` as "waiting on a queue" to cover `queue::wait_and_throw()` as well.