### PR TITLE
[SYCL][Doc] Simplify section on error handling

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -1015,9 +1015,9 @@ preemptively changed the state of the queue.
 === Exception Safety
 
 In addition to the destruction semantics provided by the SYCL
-{crs}[common reference semantics], when a modifiable `command_graph` is
-destroyed recording is ended on any queues that are recording to that
-graph, equivalent to `+this->end_recording()+`.
+{crs}[common reference semantics], when the last copy a modifiable
+`command_graph` is destroyed recording is ended on any queues that are recording
+to that graph, equivalent to `+this->end_recording()+`.
 
 As a result, users don't need to manually wrap queue recording code in a
 `try` / `catch` block to reset the state of recording queues on an exception
@@ -1026,21 +1026,11 @@ modifiable graph will perform this action, useful in RAII pattern usage.
 
 === Error Handling
 
-Errors are reported through exceptions, as usual in the SYCL API. For new APIs,
-submitting a graph for execution can generate unspecified asynchronous errors,
-while `command_graph::finalize()` may throw unspecified synchronous exceptions.
-Synchronous exception errors codes are defined for all of
-`command_graph::add()`, `command_graph::make_edge()`, `command_graph::update()`,
-`command_graph::begin_recording()`, and `command_graph::end_recording()`.
-
-Submitting an executable graph using `handler::ext_oneapi_graph()` to
-a queue with a different SYCL context than that of the executable graph will
-result in a synchronous exception.
-
 When a queue is in recording mode asynchronous exceptions will not be
 generated, as no device execution is occurring. Synchronous errors specified as
 being thrown in the default queue executing state, will still be thrown when a
-queue is in the recording state.
+queue is in the recording state. Queue query methods operate as usual in
+recording mode, as opposed to throwing.
 
 The `command_graph::begin_recording` and `command_graph::end_recording`
 entry-points return a `bool` value informing the user whether a related queue
@@ -1048,15 +1038,6 @@ state change occurred. False is returned rather than throwing an exception when
 no queue state is changed. This design is because the queues are already in
 the state the user desires, so if the function threw an exception in this case,
 the application would likely swallow it and then proceed.
-
-While a queue is in the recording state, methods performed on that queue which
-are not command submissions behave as normal except for waits. Waiting on a
-queue in the recording state is an error and will throw a synchronous
-exception. Other methods are ignored by the graph system as opposed to
-throwing in recording mode. As any query about the state of the queue may
-be immediately stale, any code which relies on queue waits should take care
-to ensure waits are not performed on queues in recording mode. For example, by
-using separate queues for graph recording and normal queue operations.
 
 === Storage Lifetimes [[storage-lifetimes]]
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -1015,7 +1015,7 @@ preemptively changed the state of the queue.
 === Exception Safety
 
 In addition to the destruction semantics provided by the SYCL
-{crs}[common reference semantics], when the last copy a modifiable
+{crs}[common reference semantics], when the last copy of a modifiable
 `command_graph` is destroyed recording is ended on any queues that are recording
 to that graph, equivalent to `+this->end_recording()+`.
 


### PR DESCRIPTION
Address feedback that it's not necessary to duplicate in this section error information already specified https://github.com/intel/llvm/pull/5626#discussion_r1150846349

This includes removing wording about unspecified errors on finalize https://github.com/intel/llvm/pull/5626#discussion_r1150845124

And clarifying that queue queries behave as normal during recording https://github.com/intel/llvm/pull/5626#discussion_r1150851343

Additionally, use suggestion from https://github.com/intel/llvm/pull/5626#discussion_r1150829677 about "last copy" of modifiable graph.

There is also the feedback that we could better group queue recording error behaviour into its own section, but I've left that larger change out the scope of the PR.