### PR TITLE
[SYCL] Fix subgraphs, move sync points to exec graph

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2541,6 +2541,7 @@ private:
   std::shared_ptr<detail::handler_impl> MImpl;
   std::shared_ptr<detail::queue_impl> MQueue;
   std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> MGraph;
+  std::shared_ptr<ext::oneapi::experimental::detail::node_impl> MSubgraphNode;
 
   /// The storage for the arguments passed.
   /// We need to store a copy of values that are passed explicitly through

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -371,19 +371,9 @@ sycl::event exec_graph_impl::enqueue(
     const std::shared_ptr<sycl::detail::queue_impl> &Queue) {
   std::vector<pi_event> RawEvents;
   auto CreateNewEvent([&]() {
-    pi_event *OutEvent = nullptr;
     auto NewEvent = std::make_shared<sycl::detail::event_impl>(Queue);
     NewEvent->setContextImpl(Queue->getContextImplPtr());
     NewEvent->setStateIncomplete();
-    OutEvent = &NewEvent->getHandleRef();
-    pi_result Res =
-        Queue->getPlugin().call_nocheck<sycl::detail::PiApiKind::piEventCreate>(
-            sycl::detail::getSyclObjImpl(Queue->get_context())->getHandleRef(),
-            OutEvent);
-    if (Res != pi_result::PI_SUCCESS) {
-      throw sycl::exception(errc::event,
-                            "Failed to create event for node submission");
-    }
     return NewEvent;
   });
 #if SYCL_EXT_ONEAPI_GRAPH

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -236,8 +236,7 @@ void exec_graph_impl::find_real_deps(std::vector<pi_ext_sync_point> &Deps,
         Deps.push_back(SyncPoint->second);
       }
     } else {
-      // If no sync point was found something has gone wrong.
-      assert(false);
+      assert(false && "No sync point has been set for node dependency.");
     }
   }
 }

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1977,7 +1977,7 @@ static void adjustNDRangePerKernel(NDRDescT &NDR, RT::PiKernel Kernel,
 // Initially we keep the order of NDRDescT as it provided by the user, this
 // simplifies overall handling and do the reverse only when
 // the kernel is enqueued.
-static void ReverseRangeDimensionsForKernel(NDRDescT &NDR) {
+void ReverseRangeDimensionsForKernel(NDRDescT &NDR) {
   if (NDR.Dims > 1) {
     std::swap(NDR.GlobalSize[0], NDR.GlobalSize[NDR.Dims - 1]);
     std::swap(NDR.LocalSize[0], NDR.LocalSize[NDR.Dims - 1]);

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -616,6 +616,8 @@ void applyFuncOnFilteredArgs(
     std::vector<ArgDesc> &Args,
     std::function<void(detail::ArgDesc &Arg, int NextTrueIndex)> Func);
 
+void ReverseRangeDimensionsForKernel(NDRDescT &NDR);
+
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -97,15 +97,25 @@ event handler::finalize() {
   if (MIsFinalized)
     return MLastEvent;
   MIsFinalized = true;
-  if (auto GraphImpl = MQueue->getCommandGraph(); GraphImpl != nullptr) {
+  // If the queue has a graph impl we are in recording mode
+  if (auto GraphImpl = MQueue->getCommandGraph(); GraphImpl) {
+    auto EventImpl = std::make_shared<detail::event_impl>();
+
+    // If we have a subgraph node that means that a subgraph was recorded as
+    // part of this queue submission, so we skip adding a new node here since
+    // they have already been added, and return the event associated with the
+    // subgraph node.
+    if (MSubgraphNode) {
+      return detail::createSyclObjFromImpl<event>(
+          GraphImpl->get_event_for_node(MSubgraphNode));
+    }
     // Extract relevant data from the handler and pass to graph to create a new
     // node representing this command group.
-    auto NodeImpl = GraphImpl->add(
-        GraphImpl, MKernel, MNDRDesc, MOSModuleHandle, MKernelName, MAccStorage,
-        MLocalAccStorage, MRequirements, MArgs, {}, MEvents);
+    auto NodeImpl = GraphImpl->add(MKernel, MNDRDesc, MOSModuleHandle,
+                                   MKernelName, MAccStorage, MLocalAccStorage,
+                                   MRequirements, MArgs, {}, MEvents);
 
     // Create and associated an event with this new node
-    auto EventImpl = std::make_shared<detail::event_impl>();
     GraphImpl->add_event_for_node(EventImpl, NodeImpl);
 
     return detail::createSyclObjFromImpl<event>(EventImpl);
@@ -721,9 +731,26 @@ void handler::ext_oneapi_graph(
         ext::oneapi::experimental::graph_state::executable>
         Graph) {
   auto GraphImpl = detail::getSyclObjImpl(Graph);
-  auto GraphCompletionEvent = GraphImpl->exec(MQueue);
-  auto EventImpl = detail::getSyclObjImpl(GraphCompletionEvent);
-  MEvents.push_back(EventImpl);
+  std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> ParentGraph;
+  if (MQueue) {
+    ParentGraph = MQueue->getCommandGraph();
+  } else {
+    ParentGraph = MGraph;
+  }
+
+  // If a parent graph is set that means we are adding or recording a subgraph
+  if (ParentGraph) {
+    // Store the node representing the subgraph in the handler so that we can
+    // return it to the user later.
+    MSubgraphNode = ParentGraph->add_subgraph_nodes(GraphImpl->get_schedule());
+    // Associate an event with the subgraph node.
+    auto SubgraphEvent = std::make_shared<event_impl>();
+    ParentGraph->add_event_for_node(SubgraphEvent, MSubgraphNode);
+  } else {
+    auto GraphCompletionEvent = GraphImpl->exec(MQueue);
+    auto EventImpl = detail::getSyclObjImpl(GraphCompletionEvent);
+    MEvents.push_back(EventImpl);
+  }
 }
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/test/graph/graph-record-subgraph.cpp
+++ b/sycl/test/graph/graph-record-subgraph.cpp
@@ -1,0 +1,109 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+
+// Modified version of the dotp example which records part of the graph as a
+// sub-graph
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+const size_t n = 10;
+
+float host_gold_result() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  float sum = 0.0f;
+
+  for (size_t i = 0; i < n; ++i) {
+    sum += (alpha * 1.0f + beta * 2.0f) * (gamma * 3.0f + beta * 2.0f);
+  }
+
+  return sum;
+}
+
+int main() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  sycl::queue q{sycl::gpu_selector_v};
+
+  sycl::ext::oneapi::experimental::command_graph g;
+  sycl::ext::oneapi::experimental::command_graph subGraph;
+
+  float *dotp = sycl::malloc_shared<float>(1, q);
+
+  float *x = sycl::malloc_shared<float>(n, q);
+  float *y = sycl::malloc_shared<float>(n, q);
+  float *z = sycl::malloc_shared<float>(n, q);
+
+  subGraph.begin_recording(q);
+  q.submit([&](sycl::handler &h) {
+    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      x[i] = alpha * x[i] + beta * y[i];
+    });
+  });
+
+  q.submit([&](sycl::handler &h) {
+    h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      z[i] = gamma * z[i] + beta * y[i];
+    });
+  });
+
+  subGraph.end_recording();
+  auto subGraphExec = subGraph.finalize(q.get_context());
+
+  g.begin_recording(q);
+  /* init data on the device */
+  auto init = q.submit([&](sycl::handler &h) {
+    h.parallel_for(n, [=](sycl::id<1> it) {
+      const size_t i = it[0];
+      x[i] = 1.0f;
+      y[i] = 2.0f;
+      z[i] = 3.0f;
+    });
+  });
+
+  auto sub = q.submit([&](sycl::handler &h) {
+    h.depends_on(init);
+    h.ext_oneapi_graph(subGraphExec);
+  });
+
+  q.submit([&](sycl::handler &h) {
+    h.depends_on(sub);
+#ifdef TEST_GRAPH_REDUCTIONS
+    h.parallel_for(sycl::range<1>{n}, sycl::reduction(dotp, 0.0f, std::plus()),
+                   [=](sycl::id<1> it, auto &sum) {
+                     const size_t i = it[0];
+                     sum += x[i] * z[i];
+                   });
+#else
+    h.single_task([=]() {
+      // Doing a manual reduction here because reduction objects cause
+      // issues with graphs.
+      for (size_t j = 0; j < n; j++) {
+        dotp[0] += x[j] * z[j];
+      }
+    });
+#endif
+  });
+
+  g.end_recording();
+
+  auto executable_graph = g.finalize(q.get_context());
+
+  // Using shortcut for executing a graph of commands
+  q.ext_oneapi_graph(executable_graph).wait();
+
+  assert(*dotp == host_gold_result());
+
+  sycl::free(dotp, q);
+  sycl::free(x, q);
+  sycl::free(y, q);
+  sycl::free(z, q);
+
+  return 0;
+}


### PR DESCRIPTION
- Fixes subgraph support for command buffer graphs
- Move sync points to executable graph instead of node
- Removed unused graph impl from nodes
- Add new test for recording a subgraph
- Also reverses kernel dims (when the number of dims > 1) before execution which fixes an issue with oneDNN support

Depends on #100 