### PR TITLE
[SYCL] Remove cycle error from finalize

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -674,10 +674,6 @@ Exceptions:
 * Throws synchronously with error code `invalid` if the graph contains a
   node which targets a device not present in `syclContext`.
 
-* Throws synchronously with error code `invalid` if the graph contains a cycle.
-  A cycle may be introduced to the graph via a call to `make_edge()` that
-  creates a forward dependency.
-
 |===
 
 Table {counter: tableNumber}. Member functions of the `command_graph` class for queue recording.


### PR DESCRIPTION
Removes the error on detection of a cycle from `finalize()` as we are already detecting this in `make_edge()` and it is not possible for a cycle to be introduced to the DAG any other way.

Change was originally implemented in #128 but was reverted by commit d6e09f6d899437efc4348e31c1cb9b3ce6beaf41.