### PR TITLE
[SYCL] Fixes to check-sycl target

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -20,13 +20,14 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 
 class handler;
 class queue;
+class device;
 namespace ext {
 namespace oneapi {
 namespace experimental {
 
 namespace detail {
 struct node_impl;
-struct graph_impl;
+class graph_impl;
 class exec_graph_impl;
 
 } // namespace detail

--- a/sycl/unittests/helpers/PiMockPlugin.hpp
+++ b/sycl/unittests/helpers/PiMockPlugin.hpp
@@ -904,6 +904,45 @@ inline pi_result mock_piextPluginGetOpaqueData(void *opaque_data_param,
   return PI_SUCCESS;
 }
 
+inline pi_result
+mock_piextCommandBufferCreate(pi_context context, pi_device device,
+                              const pi_ext_command_buffer_desc *desc,
+                              pi_ext_command_buffer *ret_command_buffer) {
+
+  return PI_SUCCESS;
+}
+
+inline pi_result
+mock_piextCommandBufferRetain(pi_ext_command_buffer command_buffer) {
+  return PI_SUCCESS;
+}
+
+inline pi_result
+mock_piextCommandBufferRelease(pi_ext_command_buffer command_buffer) {
+  return PI_SUCCESS;
+}
+
+inline pi_result
+mock_piextCommandBufferFinalize(pi_ext_command_buffer command_buffer) {
+  return PI_SUCCESS;
+}
+
+inline pi_result mock_piextCommandBufferNDRangeKernel(
+    pi_ext_command_buffer command_buffer, pi_kernel kernel, pi_uint32 work_dim,
+    const size_t *global_work_offset, const size_t *global_work_size,
+    const size_t *local_work_size, pi_uint32 num_sync_points_in_wait_list,
+    const pi_ext_sync_point *sync_point_wait_list,
+    pi_ext_sync_point *sync_point) {
+  return PI_SUCCESS;
+}
+
+inline pi_result mock_piextEnqueueCommandBuffer(
+    pi_ext_command_buffer command_buffer, pi_queue queue,
+    pi_uint32 num_events_in_wait_list, const pi_event *event_wait_list,
+    pi_event *event) {
+  return PI_SUCCESS;
+}
+
 inline pi_result mock_piTearDown(void *PluginParameter) { return PI_SUCCESS; }
 
 inline pi_result mock_piPluginGetLastError(char **message) {


### PR DESCRIPTION
When running the `ninja check-sycl` target I encountered a few issues which I've fixed here:

* Consistently declare `class graph_impl` due to reported issue
```
In file included from /home/ewan/Development/dpc++/build_release/bin/../include/sycl/queue.hpp:21:
/home/ewan/Development/dpc++/build_release/bin/../include/sycl/handler.hpp:84:1: error: class 'graph_impl' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
class graph_impl;
^
/home/ewan/Development/dpc++/build_release/bin/../include/sycl/ext/oneapi/experimental/graph.hpp:29:8: note: previous use is here
struct graph_impl;
```

* Use updated `command_graph` constructor in Mock testing to pass context & device.
* Declare `mock_*` PI functions which lead to compilation failures when missing
* Forward declare `sycl::device` in graph.hpp header, otherwise there are issues if we include graph.hpp before <sycl/sycl.hpp>