### PR TITLE
[SYCL] Add support for accessors in graphs

### DIFF
--- a/sycl/include/sycl/detail/cg.hpp
+++ b/sycl/include/sycl/detail/cg.hpp
@@ -75,6 +75,7 @@ public:
     CopyToDeviceGlobal = 19,
     CopyFromDeviceGlobal = 20,
     ReadWriteHostPipe = 21,
+    ExecCommandBuffer = 22,
   };
 
   CG(CGTYPE Type, std::vector<std::vector<char>> ArgsStorage,
@@ -592,6 +593,15 @@ public:
   size_t getNumBytes() { return MNumBytes; }
   size_t getOffset() { return MOffset; }
   detail::OSModuleHandle getOSModuleHandle() { return MOSModuleHandle; }
+};
+class CGExecCommandBuffer : public CG {
+public:
+  pi_ext_command_buffer MCommandBuffer;
+
+  CGExecCommandBuffer(pi_ext_command_buffer CommandBuffer,
+                      std::vector<AccessorImplHost *> Requirements)
+      : CG(CGTYPE::ExecCommandBuffer, {}, {}, {}, Requirements, {}),
+        MCommandBuffer(CommandBuffer) {}
 };
 
 } // namespace detail

--- a/sycl/include/sycl/detail/cg.hpp
+++ b/sycl/include/sycl/detail/cg.hpp
@@ -596,9 +596,9 @@ public:
 };
 class CGExecCommandBuffer : public CG {
 public:
-  pi_ext_command_buffer MCommandBuffer;
+  RT::PiExtCommandBuffer MCommandBuffer;
 
-  CGExecCommandBuffer(pi_ext_command_buffer CommandBuffer,
+  CGExecCommandBuffer(RT::PiExtCommandBuffer CommandBuffer,
                       std::vector<AccessorImplHost *> Requirements)
       : CG(CGTYPE::ExecCommandBuffer, {}, {}, {}, Requirements, {}),
         MCommandBuffer(CommandBuffer) {}

--- a/sycl/include/sycl/detail/pi.hpp
+++ b/sycl/include/sycl/detail/pi.hpp
@@ -143,6 +143,9 @@ using PiMemObjectType = ::pi_mem_type;
 using PiMemImageChannelOrder = ::pi_image_channel_order;
 using PiMemImageChannelType = ::pi_image_channel_type;
 using PiKernelCacheConfig = ::pi_kernel_cache_config;
+using PiExtSyncPoint = ::pi_ext_sync_point;
+using PiExtCommandBuffer = ::pi_ext_command_buffer;
+using PiExtCommandBufferDesc = ::pi_ext_command_buffer_desc;
 
 __SYCL_EXPORT void contextSetExtendedDeleter(const sycl::context &constext,
                                              pi_context_extended_deleter func,

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -313,7 +313,8 @@ std::shared_ptr<event_impl> createCommandAndEnqueue(
     std::vector<detail::AccessorImplHost *> Requirements,
     std::vector<detail::EventImplPtr> Events,
     std::vector<detail::EventImplPtr> EventsWaitWithBarrier,
-    detail::OSModuleHandle OSModHandle, detail::code_location CodeLoc);
+    detail::OSModuleHandle OSModHandle,
+    RT::PiKernelCacheConfig KernelCacheConfig, detail::code_location CodeLoc);
 
 } // namespace detail
 

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -292,6 +292,29 @@ private:
 using std::enable_if_t;
 using sycl::detail::queue_impl;
 
+std::shared_ptr<event_impl> createCommandAndEnqueue(
+    CG::CGTYPE Type, std::shared_ptr<detail::queue_impl> Queue,
+    NDRDescT NDRDesc, std::unique_ptr<detail::HostKernelBase> HostKernel,
+    std::unique_ptr<detail::HostTask> HostTaskPtr,
+    std::unique_ptr<detail::InteropTask> InteropTask,
+    std::shared_ptr<detail::kernel_impl> Kernel, std::string KernelName,
+    KernelBundleImplPtr KernelBundle,
+    std::vector<std::vector<char>> ArgsStorage,
+    std::vector<detail::AccessorImplPtr> AccStorage,
+    std::vector<detail::LocalAccessorImplPtr> LocalAccStorage,
+    std::vector<std::shared_ptr<detail::stream_impl>> StreamStorage,
+    std::vector<std::shared_ptr<const void>> SharedPtrStorage,
+    std::vector<std::shared_ptr<const void>> AuxiliaryResources,
+    std::vector<detail::ArgDesc> Args, void *SrcPtr, void *DstPtr,
+    size_t Length, std::vector<char> Pattern, size_t SrcPitch, size_t DstPitch,
+    size_t Width, size_t Height, size_t Offset, bool IsDeviceImageScoped,
+    const std::string &HostPipeName, void *HostPipePtr, bool HostPipeBlocking,
+    size_t HostPipeTypeSize, bool HostPipeRead, pi_mem_advice Advice,
+    std::vector<detail::AccessorImplHost *> Requirements,
+    std::vector<detail::EventImplPtr> Events,
+    std::vector<detail::EventImplPtr> EventsWaitWithBarrier,
+    detail::OSModuleHandle OSModHandle, detail::code_location CodeLoc);
+
 } // namespace detail
 
 /// Command group handler class.

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -255,6 +255,13 @@ public:
     ensureContextInitialized();
     return MContext;
   }
+  
+  // Sets a sync point which is used when this event represents an enqueue to a
+  // pi_ext_command_buffer.
+  void setSyncPoint(pi_ext_sync_point SyncPoint) { MSyncPoint = SyncPoint; }
+
+  // Get the sync point associated with this event.
+  pi_ext_sync_point getSyncPoint() const { return MSyncPoint; }
 
 protected:
   // When instrumentation is enabled emits trace event for event wait begin and
@@ -301,6 +308,10 @@ protected:
 
   std::mutex MMutex;
   std::condition_variable cv;
+
+  // If this event represents a submission to a pi_ext_command_buffer
+  // the sync point for that submission is stored here.
+  pi_ext_sync_point MSyncPoint;
 
   friend std::vector<RT::PiEvent>
   getOrWaitEvents(std::vector<sycl::event> DepEvents,

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -257,11 +257,11 @@ public:
   }
   
   // Sets a sync point which is used when this event represents an enqueue to a
-  // pi_ext_command_buffer.
-  void setSyncPoint(pi_ext_sync_point SyncPoint) { MSyncPoint = SyncPoint; }
+  // RT::PiExtCommandBuffer.
+  void setSyncPoint(RT::PiExtSyncPoint SyncPoint) { MSyncPoint = SyncPoint; }
 
   // Get the sync point associated with this event.
-  pi_ext_sync_point getSyncPoint() const { return MSyncPoint; }
+  RT::PiExtSyncPoint getSyncPoint() const { return MSyncPoint; }
 
 protected:
   // When instrumentation is enabled emits trace event for event wait begin and
@@ -309,9 +309,9 @@ protected:
   std::mutex MMutex;
   std::condition_variable cv;
 
-  // If this event represents a submission to a pi_ext_command_buffer
+  // If this event represents a submission to a RT::PiExtCommandBuffer
   // the sync point for that submission is stored here.
-  pi_ext_sync_point MSyncPoint;
+  RT::PiExtSyncPoint MSyncPoint;
 
   friend std::vector<RT::PiEvent>
   getOrWaitEvents(std::vector<sycl::event> DepEvents,

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -8,6 +8,8 @@
 
 #include <detail/graph_impl.hpp>
 #include <detail/kernel_arg_mask.hpp>
+#include <detail/handler_impl.hpp> 
+#include <detail/program_manager/program_manager.hpp>
 #include <detail/queue_impl.hpp>
 #include <detail/scheduler/commands.hpp>
 #include <sycl/feature_test.hpp>
@@ -148,8 +150,8 @@ graph_impl::add(const std::shared_ptr<graph_impl> &Impl,
   // TODO: Do we need to pass event dependencies here for the explicit API?
   return this->add(Handler.MKernel, Handler.MNDRDesc, Handler.MOSModuleHandle,
                    Handler.MKernelName, Handler.MAccStorage,
-                   Handler.MLocalAccStorage, Handler.MRequirements,
-                   Handler.MArgs, Dep);
+                   Handler.MLocalAccStorage, Handler.MCGType, Handler.MArgs,
+                   Handler.MImpl->MAuxiliaryResources, Dep);
 }
 
 std::shared_ptr<node_impl> graph_impl::add(
@@ -158,13 +160,14 @@ std::shared_ptr<node_impl> graph_impl::add(
     std::string KernelName,
     const std::vector<sycl::detail::AccessorImplPtr> &AccStorage,
     const std::vector<sycl::detail::LocalAccessorImplPtr> &LocalAccStorage,
-    const std::vector<sycl::detail::AccessorImplHost *> &Requirements,
+    sycl::detail::CG::CGTYPE CGType,
     const std::vector<sycl::detail::ArgDesc> &Args,
+    const std::vector<std::shared_ptr<const void>> &AuxiliaryResources,
     const std::vector<std::shared_ptr<node_impl>> &Dep,
     const std::vector<std::shared_ptr<sycl::detail::event_impl>> &DepEvents) {
   const std::shared_ptr<node_impl> &NodeImpl = std::make_shared<node_impl>(
       Kernel, NDRDesc, OSModuleHandle, KernelName, AccStorage, LocalAccStorage,
-      Requirements, Args);
+      CGType, Args, AuxiliaryResources);
   // Copy deps so we can modify them
   auto Deps = Dep;
   // A unique set of dependencies obtained by checking kernel arguments
@@ -241,6 +244,134 @@ void exec_graph_impl::find_real_deps(std::vector<pi_ext_sync_point> &Deps,
   }
 }
 
+// Enqueue a node directly to the command buffer without going through the
+// scheduler.
+pi_ext_sync_point exec_graph_impl::enqueue_node_direct(
+    sycl::context Ctx, sycl::detail::DeviceImplPtr DeviceImpl,
+    pi_ext_command_buffer CommandBuffer, std::shared_ptr<node_impl> Node) {
+  auto ContextImpl = sycl::detail::getSyclObjImpl(Ctx);
+  const sycl::detail::plugin &Plugin = ContextImpl->getPlugin();
+  pi_kernel PiKernel = nullptr;
+  std::mutex *KernelMutex = nullptr;
+  pi_program PiProgram = nullptr;
+
+  auto Kernel = Node->MKernel;
+  if (Kernel != nullptr) {
+    PiKernel = Kernel->getHandleRef();
+  } else {
+    std::tie(PiKernel, KernelMutex, PiProgram) =
+        sycl::detail::ProgramManager::getInstance().getOrCreateKernel(
+            Node->MOSModuleHandle, ContextImpl, DeviceImpl, Node->MKernelName,
+            nullptr);
+  }
+
+  sycl::detail::ProgramManager::KernelArgMask EliminatedArgMask;
+  if (nullptr == Node->MKernel || !Node->MKernel->isCreatedFromSource()) {
+    EliminatedArgMask =
+        sycl::detail::ProgramManager::getInstance().getEliminatedKernelArgMask(
+            Node->MOSModuleHandle, PiProgram, Node->MKernelName);
+  }
+
+  auto SetFunc = [&Plugin, &PiKernel, &Ctx](sycl::detail::ArgDesc &Arg,
+                                            size_t NextTrueIndex) {
+    sycl::detail::SetArgBasedOnType(
+        Plugin, PiKernel,
+        nullptr /* TODO: Handle spec constants and pass device image here */
+        ,
+        nullptr, Ctx, false, Arg, NextTrueIndex);
+  };
+  std::vector<sycl::detail::ArgDesc> Args;
+  sycl::detail::applyFuncOnFilteredArgs(EliminatedArgMask, Node->MArgs,
+                                        SetFunc);
+
+  std::vector<pi_ext_sync_point> Deps;
+  for (auto &N : Node->MPredecessors) {
+    find_real_deps(Deps, N.lock());
+  }
+
+  // add commands
+  // Remember this information before the range dimensions are reversed
+  const bool HasLocalSize = (Node->MNDRDesc.LocalSize[0] != 0);
+
+  // Reverse kernel dims
+  auto NDRDesc = Node->MNDRDesc;
+  sycl::detail::ReverseRangeDimensionsForKernel(NDRDesc);
+
+  size_t RequiredWGSize[3] = {0, 0, 0};
+  size_t *LocalSize = nullptr;
+
+  if (HasLocalSize)
+    LocalSize = &NDRDesc.LocalSize[0];
+  else {
+    Plugin.call<sycl::detail::PiApiKind::piKernelGetGroupInfo>(
+        PiKernel, DeviceImpl->getHandleRef(),
+        PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE, sizeof(RequiredWGSize),
+        RequiredWGSize,
+        /* param_value_size_ret = */ nullptr);
+
+    const bool EnforcedLocalSize =
+        (RequiredWGSize[0] != 0 || RequiredWGSize[1] != 0 ||
+         RequiredWGSize[2] != 0);
+    if (EnforcedLocalSize)
+      LocalSize = RequiredWGSize;
+  }
+
+  pi_ext_sync_point NewSyncPoint;
+  pi_result Res = Plugin.call_nocheck<
+      sycl::detail::PiApiKind::piextCommandBufferNDRangeKernel>(
+      CommandBuffer, PiKernel, NDRDesc.Dims, &NDRDesc.GlobalOffset[0],
+      &NDRDesc.GlobalSize[0], LocalSize, Deps.size(),
+      Deps.size() ? Deps.data() : nullptr, &NewSyncPoint);
+
+  if (Res != pi_result::PI_SUCCESS) {
+    throw sycl::exception(errc::invalid,
+                          "Failed to add kernel to PI command-buffer");
+  }
+
+  return NewSyncPoint;
+}
+
+pi_ext_sync_point exec_graph_impl::enqueue_node(
+    sycl::context Ctx, std::shared_ptr<sycl::detail::device_impl> DeviceImpl,
+    pi_ext_command_buffer CommandBuffer, std::shared_ptr<node_impl> Node) {
+  std::unique_ptr<sycl::detail::CG> CommandGroup;
+  switch (Node->MCGType) {
+  case sycl::detail::CG::Kernel:
+    CommandGroup.reset(new sycl::detail::CGExecKernel(
+        Node->MNDRDesc, nullptr /* Host Kernel */, Node->MKernel,
+        nullptr /* Kernel Bundle */, Node->MArgStorage, Node->MAccStorage,
+        {} /* Shared pointer storage for copies */, Node->MRequirements,
+        {} /* Events */, Node->MArgs, Node->MKernelName, Node->MOSModuleHandle,
+        Node->MStreamStorage, Node->MAuxiliaryResources, Node->MCGType,
+        {} /* Code Location */));
+    break;
+
+  default:
+    assert(false && "Node types other than kernels are not supported!");
+    break;
+  }
+
+  if (!CommandGroup)
+    throw sycl::runtime_error(
+        "Internal Error. Command group cannot be constructed.",
+        PI_ERROR_INVALID_OPERATION);
+
+  // Queue which will be used for allocation operations for accessors.
+  auto AllocaQueue = std::make_shared<sycl::detail::queue_impl>(
+      DeviceImpl, sycl::detail::getSyclObjImpl(Ctx), sycl::async_handler{},
+      sycl::property_list{});
+
+  std::vector<pi_ext_sync_point> Deps;
+  for (auto &N : Node->MPredecessors) {
+    find_real_deps(Deps, N.lock());
+  }
+
+  sycl::detail::EventImplPtr Event =
+      sycl::detail::Scheduler::getInstance().addCGToCommandBuffer(
+          std::move(CommandGroup), CommandBuffer, Deps, AllocaQueue);
+
+  return Event->getSyncPoint();
+}
 void exec_graph_impl::create_pi_command_buffers(sycl::device D) {
   // TODO we only have a single command-buffer per graph here, but
   // this will need to be multiple command-buffers for non-trivial graphs
@@ -261,78 +392,21 @@ void exec_graph_impl::create_pi_command_buffers(sycl::device D) {
 
   // TODO extract kernel bundle logic from enqueueImpKernel
   for (auto Node : MSchedule) {
-    pi_kernel PiKernel = nullptr;
-    std::mutex *KernelMutex = nullptr;
-    pi_program PiProgram = nullptr;
-
-    auto Kernel = Node->MKernel;
-    const sycl::detail::KernelArgMask *EliminatedArgMask;
-    if (Kernel != nullptr) {
-      PiKernel = Kernel->getHandleRef();
+    sycl::detail::CG::CGTYPE type = Node->MCGType;
+    // If the node is a kernel with no special requirements we can enqueue it
+    // directly.
+    if (type == sycl::detail::CG::Kernel &&
+        Node->MRequirements.size() + Node->MStreamStorage.size() == 0) {
+      MPiSyncPoints[Node] =
+          enqueue_node_direct(MContext, DeviceImpl, OutCommandBuffer, Node);
     } else {
-      std::tie(PiKernel, KernelMutex, EliminatedArgMask, PiProgram) =
-          sycl::detail::ProgramManager::getInstance().getOrCreateKernel(
-              Node->MOSModuleHandle, ContextImpl, DeviceImpl, Node->MKernelName,
-              nullptr);
+      MPiSyncPoints[Node] =
+          enqueue_node(MContext, DeviceImpl, OutCommandBuffer, Node);
     }
 
-    auto SetFunc = [&Plugin, &PiKernel, this](sycl::detail::ArgDesc &Arg,
-                                              size_t NextTrueIndex) {
-      sycl::detail::SetArgBasedOnType(
-          Plugin, PiKernel,
-          nullptr /* TODO: Handle spec constants and pass device image here */,
-          nullptr /* TODO: Pass getMemAllocation function for buffers */,
-          this->MContext, false, Arg, NextTrueIndex);
-    };
-    std::vector<sycl::detail::ArgDesc> Args;
-    sycl::detail::applyFuncOnFilteredArgs(EliminatedArgMask, Node->MArgs,
-                                          SetFunc);
-
-    std::vector<pi_ext_sync_point> Deps;
-    for (auto &N : Node->MPredecessors) {
-      find_real_deps(Deps, N.lock());
-    }
-
-    // add commands
-    // Remember this information before the range dimensions are reversed
-    const bool HasLocalSize = (Node->MNDRDesc.LocalSize[0] != 0);
-
-    // Reverse kernel dims
-    auto NDRDesc = Node->MNDRDesc;
-    sycl::detail::ReverseRangeDimensionsForKernel(NDRDesc);
-
-    size_t RequiredWGSize[3] = {0, 0, 0};
-    size_t *LocalSize = nullptr;
-
-    if (HasLocalSize)
-      LocalSize = &NDRDesc.LocalSize[0];
-    else {
-      Plugin.call<sycl::detail::PiApiKind::piKernelGetGroupInfo>(
-          PiKernel, DeviceImpl->getHandleRef(),
-          PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE, sizeof(RequiredWGSize),
-          RequiredWGSize, /* param_value_size_ret = */ nullptr);
-
-      const bool EnforcedLocalSize =
-          (RequiredWGSize[0] != 0 || RequiredWGSize[1] != 0 ||
-           RequiredWGSize[2] != 0);
-      if (EnforcedLocalSize)
-        LocalSize = RequiredWGSize;
-    }
-
-    pi_ext_sync_point NewSyncPoint;
-    Res = Plugin.call_nocheck<
-        sycl::detail::PiApiKind::piextCommandBufferNDRangeKernel>(
-        OutCommandBuffer, PiKernel, NDRDesc.Dims, &NDRDesc.GlobalOffset[0],
-        &NDRDesc.GlobalSize[0], LocalSize, Deps.size(),
-        Deps.size() ? Deps.data() : nullptr, &NewSyncPoint);
-
-    if (Res != pi_result::PI_SUCCESS) {
-      throw sycl::exception(errc::invalid,
-                            "Failed to add kernel to PI command-buffer");
-    }
-
-    // Associate the new syncpoint with the current node
-    MPiSyncPoints[Node] = NewSyncPoint;
+    // Append Node requirements to overall graph requirements
+    MRequirements.insert(MRequirements.end(), Node->MRequirements.begin(),
+                         Node->MRequirements.end());
   }
 
   Res =
@@ -371,14 +445,26 @@ sycl::event exec_graph_impl::enqueue(
   auto NewEvent = CreateNewEvent();
   pi_event *OutEvent = &NewEvent->getHandleRef();
   auto CommandBuffer = MPiCommandBuffers[Queue->get_device()];
-  pi_result Res =
-      Queue->getPlugin()
-          .call_nocheck<sycl::detail::PiApiKind::piextEnqueueCommandBuffer>(
-              CommandBuffer, Queue->getHandleRef(), RawEvents.size(),
-              RawEvents.empty() ? nullptr : &RawEvents[0], OutEvent);
-  if (Res != pi_result::PI_SUCCESS) {
-    throw sycl::exception(errc::event,
-                          "Failed to enqueue event for node submission");
+
+  // If we have no requirements for accessors for the command buffer, enqueue it
+  // directly
+  if (MRequirements.empty()) {
+    pi_result Res =
+        Queue->getPlugin()
+            .call_nocheck<sycl::detail::PiApiKind::piextEnqueueCommandBuffer>(
+                CommandBuffer, Queue->getHandleRef(), RawEvents.size(),
+                RawEvents.empty() ? nullptr : &RawEvents[0], OutEvent);
+    if (Res != pi_result::PI_SUCCESS) {
+      throw sycl::exception(
+          errc::event, "Failed to enqueue event for command buffer submission");
+    }
+  } else {
+    std::unique_ptr<sycl::detail::CG> CommandGroup =
+        std::make_unique<sycl::detail::CGExecCommandBuffer>(CommandBuffer,
+                                                            MRequirements);
+
+    NewEvent = sycl::detail::Scheduler::getInstance().addCG(
+        std::move(CommandGroup), Queue);
   }
 
 #else

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -435,8 +435,15 @@ sycl::event exec_graph_impl::enqueue(
           NodeImpl->MStreamStorage, {} /* shared_ptr storage */,
           NodeImpl->MAuxiliaryResources, NodeImpl->MArgs, nullptr /* SrcPtr */,
           nullptr /* DstPtr */, 0 /* Length */, {} /* Pattern */,
-          {} /* Advice */, NodeImpl->MRequirements, {} /* Events */,
-          {} /* Events w/ Barrier */, NodeImpl->MOSModuleHandle,
+          0 /* SrcPitch */, 0 /* DstPitch */, 0 /* Width */, 0 /* Height */,
+          0 /* Offset */, false /* IsDeviceImageScoped */,
+          {} /* HostPipeName */, nullptr /* HostPipePtr */,
+          false /* HostPipeBlocking */, 0 /* HostPipeTypeSize */,
+          false /* HostPipeRead */, {} /* Advice */, NodeImpl->MRequirements,
+          {} /* Events */, {} /* Events w/ Barrier */,
+          NodeImpl->MOSModuleHandle,
+          PI_EXT_KERNEL_EXEC_INFO_CACHE_DEFAULT
+          /* KernelCacheConfig */,
           {} /* CodeLoc */);
 
       ScheduledEvents.push_back(EventImpl);

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -303,8 +303,8 @@ RT::PiExtSyncPoint exec_graph_impl::enqueue_node(
   }
 
   sycl::detail::EventImplPtr Event =
-      sycl::detail::Scheduler::getInstance().addCGToCommandBuffer(
-          std::move(CommandGroup), CommandBuffer, Deps, AllocaQueue);
+      sycl::detail::Scheduler::getInstance().addCG(
+          std::move(CommandGroup), AllocaQueue, CommandBuffer, Deps);
 
   return Event->getSyncPoint();
 }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -279,8 +279,6 @@ private:
   // List of requirements for enqueueing this command graph, accumulated from
   // all nodes enqueued to the graph.
   std::vector<sycl::detail::AccessorImplHost *> MRequirements;
-  // Queue used for alloc operations
-  std::shared_ptr<sycl::detail::queue_impl> MAllocQueue;
 };
 
 } // namespace detail

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -254,25 +254,25 @@ public:
   }
 
 private:
-  pi_ext_sync_point enqueue_node(sycl::context Ctx,
-                                 sycl::detail::DeviceImplPtr DeviceImpl,
-                                 pi_ext_command_buffer CommandBuffer,
-                                 std::shared_ptr<node_impl> Node);
-  pi_ext_sync_point enqueue_node_direct(sycl::context Ctx,
-                                        sycl::detail::DeviceImplPtr DeviceImpl,
-                                        pi_ext_command_buffer CommandBuffer,
-                                        std::shared_ptr<node_impl> Node);
+  RT::PiExtSyncPoint enqueue_node(sycl::context Ctx,
+                                  sycl::detail::DeviceImplPtr DeviceImpl,
+                                  RT::PiExtCommandBuffer CommandBuffer,
+                                  std::shared_ptr<node_impl> Node);
+  RT::PiExtSyncPoint enqueue_node_direct(sycl::context Ctx,
+                                         sycl::detail::DeviceImplPtr DeviceImpl,
+                                         RT::PiExtCommandBuffer CommandBuffer,
+                                         std::shared_ptr<node_impl> Node);
 
-  void find_real_deps(std::vector<pi_ext_sync_point> &Deps,
+  void find_real_deps(std::vector<RT::PiExtSyncPoint> &Deps,
                       std::shared_ptr<node_impl> CurrentNode);
   std::list<std::shared_ptr<node_impl>> MSchedule;
   // Pointer to the modifiable graph impl associated with this executable graph
   std::shared_ptr<graph_impl> MGraphImpl;
   // Map of devices to command buffers
-  std::unordered_map<sycl::device, pi_ext_command_buffer> MPiCommandBuffers;
+  std::unordered_map<sycl::device, RT::PiExtCommandBuffer> MPiCommandBuffers;
   /// Map of nodes in the exec graph to the sync point representing their
   /// execution in the command graph.
-  std::unordered_map<std::shared_ptr<node_impl>, pi_ext_sync_point>
+  std::unordered_map<std::shared_ptr<node_impl>, RT::PiExtSyncPoint>
       MPiSyncPoints;
   // Context associated with this executable graph
   sycl::context MContext;

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2237,8 +2237,6 @@ pi_int32 enqueueImpCommandBufferKernel(
     const std::string &KernelName, const detail::OSModuleHandle &OSModuleHandle,
     std::vector<pi_ext_sync_point> &SyncPoints, pi_ext_sync_point *OutSyncPoint,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc) {
-
-  // TODO Tidy this up if it survives till the end of the task.
   auto ContextImpl = sycl::detail::getSyclObjImpl(Ctx);
   const sycl::detail::plugin &Plugin = ContextImpl->getPlugin();
   pi_kernel PiKernel = nullptr;

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2229,6 +2229,88 @@ void DispatchNativeKernel(void *Blob) {
   delete NDRDesc;
 }
 
+pi_int32 enqueueImpCommandBufferKernel(
+    context Ctx, DeviceImplPtr DeviceImpl, pi_ext_command_buffer CommandBuffer,
+    NDRDescT NDRDesc, std::vector<ArgDesc> Args,
+    const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
+    const std::shared_ptr<detail::kernel_impl> &SyclKernel,
+    const std::string &KernelName, const detail::OSModuleHandle &OSModuleHandle,
+    std::vector<pi_ext_sync_point> &SyncPoints, pi_ext_sync_point *OutSyncPoint,
+    const std::function<void *(Requirement *Req)> &getMemAllocationFunc) {
+
+  // TODO Tidy this up if it survives till the end of the task.
+  auto ContextImpl = sycl::detail::getSyclObjImpl(Ctx);
+  const sycl::detail::plugin &Plugin = ContextImpl->getPlugin();
+  pi_kernel PiKernel = nullptr;
+  std::mutex *KernelMutex = nullptr;
+  pi_program PiProgram = nullptr;
+
+  auto Kernel = SyclKernel;
+  if (Kernel != nullptr) {
+    PiKernel = Kernel->getHandleRef();
+  } else {
+    std::tie(PiKernel, KernelMutex, PiProgram) =
+        sycl::detail::ProgramManager::getInstance().getOrCreateKernel(
+            OSModuleHandle, ContextImpl, DeviceImpl, KernelName, nullptr);
+  }
+
+  sycl::detail::ProgramManager::KernelArgMask EliminatedArgMask;
+  if (nullptr == Kernel || !Kernel->isCreatedFromSource()) {
+    EliminatedArgMask =
+        sycl::detail::ProgramManager::getInstance().getEliminatedKernelArgMask(
+            OSModuleHandle, PiProgram, KernelName);
+  }
+
+  auto SetFunc = [&Plugin, &PiKernel, &Ctx, &getMemAllocationFunc](
+                     sycl::detail::ArgDesc &Arg, size_t NextTrueIndex) {
+    sycl::detail::SetArgBasedOnType(
+        Plugin, PiKernel,
+        nullptr /* TODO: Handle spec constants and pass device image here */
+        ,
+        getMemAllocationFunc, Ctx, false, Arg, NextTrueIndex);
+  };
+
+  sycl::detail::applyFuncOnFilteredArgs(EliminatedArgMask, Args, SetFunc);
+
+  // Remember this information before the range dimensions are reversed
+  const bool HasLocalSize = (NDRDesc.LocalSize[0] != 0);
+
+  // Reverse kernel dims
+  sycl::detail::ReverseRangeDimensionsForKernel(NDRDesc);
+
+  size_t RequiredWGSize[3] = {0, 0, 0};
+  size_t *LocalSize = nullptr;
+
+  if (HasLocalSize)
+    LocalSize = &NDRDesc.LocalSize[0];
+  else {
+    Plugin.call<sycl::detail::PiApiKind::piKernelGetGroupInfo>(
+        PiKernel, DeviceImpl->getHandleRef(),
+        PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE, sizeof(RequiredWGSize),
+        RequiredWGSize,
+        /* param_value_size_ret = */ nullptr);
+
+    const bool EnforcedLocalSize =
+        (RequiredWGSize[0] != 0 || RequiredWGSize[1] != 0 ||
+         RequiredWGSize[2] != 0);
+    if (EnforcedLocalSize)
+      LocalSize = RequiredWGSize;
+  }
+
+  pi_result Res = Plugin.call_nocheck<
+      sycl::detail::PiApiKind::piextCommandBufferNDRangeKernel>(
+      CommandBuffer, PiKernel, NDRDesc.Dims, &NDRDesc.GlobalOffset[0],
+      &NDRDesc.GlobalSize[0], LocalSize, SyncPoints.size(),
+      SyncPoints.size() ? SyncPoints.data() : nullptr, OutSyncPoint);
+
+  if (Res != pi_result::PI_SUCCESS) {
+    throw sycl::exception(errc::invalid,
+                          "Failed to add kernel to PI command-buffer");
+  }
+
+  return Res;
+}
+
 pi_int32 enqueueImpKernel(
     const QueueImplPtr &Queue, NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
@@ -2820,6 +2902,15 @@ pi_int32 ExecCGCommand::enqueueImp() {
     return enqueueReadWriteHostPipe(MQueue, pipeName, blocking, hostPtr,
                                     typeSize, RawEvents, Event, read);
   }
+  case CG::CGTYPE::ExecCommandBuffer: {
+    CGExecCommandBuffer *CmdBufferCG =
+        static_cast<CGExecCommandBuffer *>(MCommandGroup.get());
+    return MQueue->getPlugin()
+        .call_nocheck<sycl::detail::PiApiKind::piextEnqueueCommandBuffer>(
+            CmdBufferCG->MCommandBuffer, MQueue->getHandleRef(),
+            RawEvents.size(), RawEvents.empty() ? nullptr : &RawEvents[0],
+            Event);
+  }
   case CG::CGTYPE::None:
     throw runtime_error("CG type not implemented.", PI_ERROR_INVALID_OPERATION);
   }
@@ -2959,6 +3050,91 @@ void KernelFusionCommand::printDot(std::ostream &Stream) const {
            << std::endl;
   }
 }
+
+CommandBufferEnqueueCGCommand::CommandBufferEnqueueCGCommand(
+    std::unique_ptr<detail::CG> CommandGroup,
+    pi_ext_command_buffer CommandBuffer,
+    const std::vector<pi_ext_sync_point> &Dependencies, QueueImplPtr Queue)
+    : Command(CommandType::ENQUEUE_TO_CMD_BUFFER, Queue),
+      MCommandGroup(std::move(CommandGroup)), MCommandBuffer(CommandBuffer),
+      MSyncPoint(), MDependencies(Dependencies) {}
+
+std::vector<StreamImplPtr> CommandBufferEnqueueCGCommand::getStreams() const {
+  // Not implemented
+  return {};
+}
+std::vector<std::shared_ptr<const void>>
+CommandBufferEnqueueCGCommand::getAuxiliaryResources() const {
+  // Not implemented
+  return {};
+}
+void CommandBufferEnqueueCGCommand::printDot(std::ostream &Stream) const {
+  // Not implemented
+  (void)Stream;
+}
+void CommandBufferEnqueueCGCommand::emitInstrumentationData() {
+  // Not implemented
+}
+pi_int32 CommandBufferEnqueueCGCommand::enqueueImp() {
+  std::vector<EventImplPtr> EventImpls = MPreparedDepsEvents;
+  auto RawEvents = getPiEvents(EventImpls);
+  flushCrossQueueDeps(EventImpls, getWorkerQueue());
+
+  RT::PiEvent *Event = (MQueue->has_discard_events_support() &&
+                        MCommandGroup->MRequirements.size() == 0)
+                           ? nullptr
+                           : &MEvent->getHandleRef();
+  switch (MCommandGroup->getType()) {
+  case CG::CGTYPE::Kernel: {
+    CGExecKernel *ExecKernel = (CGExecKernel *)MCommandGroup.get();
+
+    NDRDescT &NDRDesc = ExecKernel->MNDRDesc;
+    std::vector<ArgDesc> &Args = ExecKernel->MArgs;
+
+    auto getMemAllocationFunc = [this](Requirement *Req) {
+      AllocaCommandBase *AllocaCmd = getAllocaForReq(Req);
+      return AllocaCmd->getMemAllocation();
+    };
+
+    const std::shared_ptr<detail::kernel_impl> &SyclKernel =
+        ExecKernel->MSyclKernel;
+    const std::string &KernelName = ExecKernel->MKernelName;
+    const detail::OSModuleHandle &OSModuleHandle = ExecKernel->MOSModuleHandle;
+
+    if (!Event) {
+      // Kernel only uses assert if it's non interop one
+      bool KernelUsesAssert = !(SyclKernel && SyclKernel->isInterop()) &&
+                              ProgramManager::getInstance().kernelUsesAssert(
+                                  OSModuleHandle, KernelName);
+      if (KernelUsesAssert) {
+        Event = &MEvent->getHandleRef();
+      }
+    }
+    pi_ext_sync_point OutSyncPoint;
+    auto result = enqueueImpCommandBufferKernel(
+        MQueue->get_context(), MQueue->getDeviceImplPtr(), MCommandBuffer,
+        NDRDesc, Args, ExecKernel->getKernelBundle(), SyclKernel, KernelName,
+        OSModuleHandle, MDependencies, &OutSyncPoint, getMemAllocationFunc);
+    MEvent->setSyncPoint(OutSyncPoint);
+    return result;
+  }
+  default:
+    throw runtime_error("CG type not implemented for command buffers.",
+                        PI_ERROR_INVALID_OPERATION);
+  }
+}
+
+AllocaCommandBase *
+CommandBufferEnqueueCGCommand::getAllocaForReq(Requirement *Req) {
+  for (const DepDesc &Dep : MDeps) {
+    if (Dep.MDepRequirement == Req)
+      return Dep.MAllocaCmd;
+  }
+  throw runtime_error("Alloca for command not found",
+                      PI_ERROR_INVALID_OPERATION);
+}
+
+bool CommandBufferEnqueueCGCommand::producesPiEvent() const { return false; }
 
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2230,12 +2230,13 @@ void DispatchNativeKernel(void *Blob) {
 }
 
 pi_int32 enqueueImpCommandBufferKernel(
-    context Ctx, DeviceImplPtr DeviceImpl, pi_ext_command_buffer CommandBuffer,
+    context Ctx, DeviceImplPtr DeviceImpl, RT::PiExtCommandBuffer CommandBuffer,
     NDRDescT NDRDesc, std::vector<ArgDesc> Args,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
     const std::shared_ptr<detail::kernel_impl> &SyclKernel,
     const std::string &KernelName, const detail::OSModuleHandle &OSModuleHandle,
-    std::vector<pi_ext_sync_point> &SyncPoints, pi_ext_sync_point *OutSyncPoint,
+    std::vector<RT::PiExtSyncPoint> &SyncPoints,
+    RT::PiExtSyncPoint *OutSyncPoint,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc) {
   auto ContextImpl = sycl::detail::getSyclObjImpl(Ctx);
   const sycl::detail::plugin &Plugin = ContextImpl->getPlugin();
@@ -3051,8 +3052,8 @@ void KernelFusionCommand::printDot(std::ostream &Stream) const {
 
 CommandBufferEnqueueCGCommand::CommandBufferEnqueueCGCommand(
     std::unique_ptr<detail::CG> CommandGroup,
-    pi_ext_command_buffer CommandBuffer,
-    const std::vector<pi_ext_sync_point> &Dependencies, QueueImplPtr Queue)
+    RT::PiExtCommandBuffer CommandBuffer,
+    const std::vector<RT::PiExtSyncPoint> &Dependencies, QueueImplPtr Queue)
     : Command(CommandType::ENQUEUE_TO_CMD_BUFFER, Queue),
       MCommandGroup(std::move(CommandGroup)), MCommandBuffer(CommandBuffer),
       MSyncPoint(), MDependencies(Dependencies) {}
@@ -3108,7 +3109,7 @@ pi_int32 CommandBufferEnqueueCGCommand::enqueueImp() {
         Event = &MEvent->getHandleRef();
       }
     }
-    pi_ext_sync_point OutSyncPoint;
+    RT::PiExtSyncPoint OutSyncPoint;
     auto result = enqueueImpCommandBufferKernel(
         MQueue->get_context(), MQueue->getDeviceImplPtr(), MCommandBuffer,
         NDRDesc, Args, ExecKernel->getKernelBundle(), SyclKernel, KernelName,

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -732,6 +732,15 @@ private:
   friend class Command;
 };
 
+pi_int32 enqueueImpCommandBufferKernel(
+    context Ctx, DeviceImplPtr DeviceImpl, pi_ext_command_buffer CommandBuffer,
+    NDRDescT NDRDesc, std::vector<ArgDesc> Args,
+    const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
+    const std::shared_ptr<detail::kernel_impl> &SyclKernel,
+    const std::string &KernelName, const detail::OSModuleHandle &OSModuleHandle,
+    std::vector<pi_ext_sync_point> &SyncPoints, pi_ext_sync_point *OutSyncPoint,
+    const std::function<void *(Requirement *Req)> &getMemAllocationFunc);
+
 // Sets arguments for a given kernel and device based on the argument type.
 // Refactored from SetKernelParamsAndLaunch to allow it to be used in the graphs
 // extension.

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -732,6 +732,7 @@ private:
   friend class Command;
 };
 
+// Enqueues a given kernel to a pi_ext_command_buffer
 pi_int32 enqueueImpCommandBufferKernel(
     context Ctx, DeviceImplPtr DeviceImpl, pi_ext_command_buffer CommandBuffer,
     NDRDescT NDRDesc, std::vector<ArgDesc> Args,

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -704,8 +704,8 @@ class CommandBufferEnqueueCGCommand : public Command {
 public:
   CommandBufferEnqueueCGCommand(
       std::unique_ptr<detail::CG> CommandGroup,
-      pi_ext_command_buffer CommandBuffer,
-      const std::vector<pi_ext_sync_point> &Dependencies, QueueImplPtr Queue);
+      RT::PiExtCommandBuffer CommandBuffer,
+      const std::vector<RT::PiExtSyncPoint> &Dependencies, QueueImplPtr Queue);
 
   detail::CG &getCG() const { return *MCommandGroup; }
 
@@ -726,20 +726,21 @@ private:
   pi_int32 enqueueImp() final;
   AllocaCommandBase *getAllocaForReq(Requirement *Req);
   std::unique_ptr<detail::CG> MCommandGroup;
-  pi_ext_command_buffer MCommandBuffer;
-  pi_ext_sync_point MSyncPoint;
-  std::vector<pi_ext_sync_point> MDependencies;
+  RT::PiExtCommandBuffer MCommandBuffer;
+  RT::PiExtSyncPoint MSyncPoint;
+  std::vector<RT::PiExtSyncPoint> MDependencies;
   friend class Command;
 };
 
-// Enqueues a given kernel to a pi_ext_command_buffer
+// Enqueues a given kernel to a RT::PiExtCommandBuffer
 pi_int32 enqueueImpCommandBufferKernel(
-    context Ctx, DeviceImplPtr DeviceImpl, pi_ext_command_buffer CommandBuffer,
+    context Ctx, DeviceImplPtr DeviceImpl, RT::PiExtCommandBuffer CommandBuffer,
     NDRDescT NDRDesc, std::vector<ArgDesc> Args,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
     const std::shared_ptr<detail::kernel_impl> &SyclKernel,
     const std::string &KernelName, const detail::OSModuleHandle &OSModuleHandle,
-    std::vector<pi_ext_sync_point> &SyncPoints, pi_ext_sync_point *OutSyncPoint,
+    std::vector<RT::PiExtSyncPoint> &SyncPoints,
+    RT::PiExtSyncPoint *OutSyncPoint,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc);
 
 // Sets arguments for a given kernel and device based on the argument type.

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1116,8 +1116,8 @@ void Scheduler::GraphBuilder::createGraphForCommand(
 
 Command *Scheduler::GraphBuilder::addCGToCommandBuffer(
     std::unique_ptr<detail::CG> CommandGroup,
-    pi_ext_command_buffer CommandBuffer,
-    const std::vector<pi_ext_sync_point> &Dependencies,
+    RT::PiExtCommandBuffer CommandBuffer,
+    const std::vector<RT::PiExtSyncPoint> &Dependencies,
     QueueImplPtr AllocaQueue, std::vector<Command *> &ToEnqueue) {
   std::vector<Requirement *> &Reqs = CommandGroup->MRequirements;
   const std::vector<detail::EventImplPtr> &Events = CommandGroup->MEvents;

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -898,7 +898,8 @@ EmptyCommand *Scheduler::GraphBuilder::addEmptyCmd(
   return EmptyCmd;
 }
 
-static bool isInteropHostTask(ExecCGCommand *Cmd) {
+template <typename T>
+static bool isInteropHostTask(T *Cmd) {
   if (Cmd->getCG().getType() != CG::CGTYPE::CodeplayHostTask)
     return false;
 
@@ -1111,6 +1112,123 @@ void Scheduler::GraphBuilder::createGraphForCommand(
   for (Command *Cmd : ToCleanUp) {
     cleanupCommand(Cmd);
   }
+}
+
+Command *Scheduler::GraphBuilder::addCGToCommandBuffer(
+    std::unique_ptr<detail::CG> CommandGroup,
+    pi_ext_command_buffer CommandBuffer,
+    const std::vector<pi_ext_sync_point> &Dependencies,
+    QueueImplPtr AllocaQueue, std::vector<Command *> &ToEnqueue) {
+  std::vector<Requirement *> &Reqs = CommandGroup->MRequirements;
+  const std::vector<detail::EventImplPtr> &Events = CommandGroup->MEvents;
+  const CG::CGTYPE CGType = CommandGroup->getType();
+
+  auto NewCmd = std::make_unique<CommandBufferEnqueueCGCommand>(
+      std::move(CommandGroup), CommandBuffer, Dependencies, AllocaQueue);
+  if (!NewCmd)
+    throw runtime_error("Out of host memory", PI_ERROR_OUT_OF_HOST_MEMORY);
+
+  if (MPrintOptionsArray[BeforeAddCG])
+    printGraphAsDot("before_addCG");
+
+  // If there are multiple requirements for the same memory object, its
+  // AllocaCommand creation will be dependent on the access mode of the first
+  // requirement. Combine these access modes to take all of them into account.
+  combineAccessModesOfReqs(Reqs);
+  std::vector<Command *> ToCleanUp;
+  for (Requirement *Req : Reqs) {
+    MemObjRecord *Record = nullptr;
+    AllocaCommandBase *AllocaCmd = nullptr;
+
+    bool isSameCtx = false;
+
+    {
+      const QueueImplPtr &QueueForAlloca =
+          isInteropHostTask(NewCmd)
+              ? static_cast<detail::CGHostTask &>(NewCmd->getCG()).MQueue
+              : AllocaQueue;
+
+      Record = getOrInsertMemObjRecord(QueueForAlloca, Req, ToEnqueue);
+      markModifiedIfWrite(Record, Req);
+
+      AllocaCmd =
+          getOrCreateAllocaForReq(Record, Req, QueueForAlloca, ToEnqueue);
+
+      isSameCtx =
+          sameCtx(QueueForAlloca->getContextImplPtr(), Record->MCurContext);
+    }
+
+    // If there is alloca command we need to check if the latest memory is in
+    // required context.
+    if (isSameCtx) {
+      // If the memory is already in the required host context, check if the
+      // required access mode is valid, remap if not.
+      if (Record->MCurContext->is_host() &&
+          !isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess))
+        remapMemoryObject(Record, Req, AllocaCmd, ToEnqueue);
+    } else {
+      // Cannot directly copy memory from OpenCL device to OpenCL device -
+      // create two copies: device->host and host->device.
+      bool NeedMemMoveToHost = false;
+      std::shared_ptr<queue_impl> MemMoveTargetQueue = nullptr;
+
+      if (isInteropHostTask(NewCmd)) {
+        const detail::CGHostTask &HT =
+            static_cast<detail::CGHostTask &>(NewCmd->getCG());
+
+        if (HT.MQueue->getContextImplPtr() != Record->MCurContext) {
+          NeedMemMoveToHost = true;
+          MemMoveTargetQueue = HT.MQueue;
+        }
+      } else if (!false && !Record->MCurContext->is_host())
+        NeedMemMoveToHost = true;
+
+      if (NeedMemMoveToHost)
+        insertMemoryMove(Record, Req,
+                         Scheduler::getInstance().getDefaultHostQueue(),
+                         ToEnqueue);
+      insertMemoryMove(Record, Req, MemMoveTargetQueue, ToEnqueue);
+    }
+    std::set<Command *> Deps =
+        findDepsForReq(Record, Req, AllocaQueue->getContextImplPtr());
+
+    for (Command *Dep : Deps) {
+      Command *ConnCmd =
+          NewCmd->addDep(DepDesc{Dep, Req, AllocaCmd}, ToCleanUp);
+      if (ConnCmd)
+        ToEnqueue.push_back(ConnCmd);
+    }
+  }
+
+  // Set new command as user for dependencies and update leaves.
+  // Node dependencies can be modified further when adding the node to leaves,
+  // iterate over their copy.
+  // FIXME employ a reference here to eliminate copying of a vector
+  std::vector<DepDesc> Deps = NewCmd->MDeps;
+  for (DepDesc &Dep : Deps) {
+    const Requirement *Req = Dep.MDepRequirement;
+    MemObjRecord *Record = getMemObjRecord(Req->MSYCLMemObj);
+    updateLeaves({Dep.MDepCommand}, Record, Req->MAccessMode, ToCleanUp);
+    addNodeToLeaves(Record, NewCmd.get(), Req->MAccessMode, ToEnqueue);
+  }
+
+  // Register all the events as dependencies
+  for (detail::EventImplPtr e : Events) {
+    if (Command *ConnCmd = NewCmd->addDep(e, ToCleanUp))
+      ToEnqueue.push_back(ConnCmd);
+  }
+
+  if (CGType == CG::CGTYPE::CodeplayHostTask)
+    NewCmd->MEmptyCmd =
+        addEmptyCmd(NewCmd.get(), NewCmd->getCG().MRequirements, AllocaQueue,
+                    Command::BlockReason::HostTask, ToEnqueue);
+
+  if (MPrintOptionsArray[AfterAddCG])
+    printGraphAsDot("after_addCG");
+
+  for (Command *Cmd : ToCleanUp)
+    cleanupCommand(Cmd);
+  return NewCmd.release();
 }
 
 void Scheduler::GraphBuilder::decrementLeafCountersForRecord(

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -89,8 +89,8 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
 
 EventImplPtr Scheduler::addCGToCommandBuffer(
     std::unique_ptr<detail::CG> CommandGroup,
-    pi_ext_command_buffer CommandBuffer,
-    const std::vector<pi_ext_sync_point> &Dependencies,
+    RT::PiExtCommandBuffer CommandBuffer,
+    const std::vector<RT::PiExtSyncPoint> &Dependencies,
     QueueImplPtr AllocaQueue) {
   EventImplPtr NewEvent = nullptr;
   const CG::CGTYPE Type = CommandGroup->getType();

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -124,10 +124,9 @@ Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup, const QueueImplPtr &Q
                                              DefaultHostQueue, AuxiliaryCmds);
       NewEvent = NewCmd->getEvent();
       break;
-    case CG::CodeplayHostTask:
-      auto Result = MGraphBuilder.addCG<ExecCGCommand>(
-          std::move(CommandGroup), DefaultHostQueue, AuxiliaryCmds);
-          
+    case CG::CodeplayHostTask: {
+      auto Result = MGraphBuilder.addCG(std::move(CommandGroup),
+                                        DefaultHostQueue, AuxiliaryCmds);
       NewCmd = Result.NewCmd;
       NewEvent = Result.NewEvent;
       ShouldEnqueue = Result.ShouldEnqueue;
@@ -135,16 +134,9 @@ Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup, const QueueImplPtr &Q
     }
     default:
       auto Result = MGraphBuilder.addCG(std::move(CommandGroup),
-                                        std::move(Queue), AuxiliaryCmds);
-      GraphBuilderResult Result;
-      if (CommandBuffer) {
-        Result = MGraphBuilder.addCG<CommandBufferEnqueueCGCommand>(
-            std::move(CommandGroup), std::move(Queue), AuxiliaryCmds,
-            CommandBuffer, std::move(Dependencies));
-      } else {
-        Result = MGraphBuilder.addCG<ExecCGCommand>(
-            std::move(CommandGroup), std::move(Queue), AuxiliaryCmds);
-      }
+                                        std::move(Queue), AuxiliaryCmds,
+                                        CommandBuffer, std::move(Dependencies));
+
       NewCmd = Result.NewCmd;
       NewEvent = Result.NewEvent;
       ShouldEnqueue = Result.ShouldEnqueue;

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -87,6 +87,105 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
   }
 }
 
+EventImplPtr Scheduler::addCGToCommandBuffer(
+    std::unique_ptr<detail::CG> CommandGroup,
+    pi_ext_command_buffer CommandBuffer,
+    const std::vector<pi_ext_sync_point> &Dependencies,
+    QueueImplPtr AllocaQueue) {
+  EventImplPtr NewEvent = nullptr;
+  const CG::CGTYPE Type = CommandGroup->getType();
+  std::vector<Command *> AuxiliaryCmds;
+  std::vector<StreamImplPtr> Streams;
+
+  if (Type == CG::Kernel) {
+    Streams = ((CGExecKernel *)CommandGroup.get())->getStreams();
+    // Stream's flush buffer memory is mainly initialized in stream's __init
+    // method. However, this method is not available on host device.
+    // Initializing stream's flush buffer on the host side in a separate task.
+    if (AllocaQueue->is_host()) {
+      for (const StreamImplPtr &Stream : Streams) {
+        initStream(Stream, AllocaQueue);
+      }
+    }
+  }
+
+  {
+    WriteLockT Lock(MGraphLock, std::defer_lock);
+    acquireWriteLock(Lock);
+
+    Command *NewCmd = nullptr;
+    switch (Type) {
+    case CG::UpdateHost:
+      NewCmd = MGraphBuilder.addCGUpdateHost(std::move(CommandGroup),
+                                             DefaultHostQueue, AuxiliaryCmds);
+      break;
+    case CG::CodeplayHostTask:
+      NewCmd = MGraphBuilder.addCG(std::move(CommandGroup), DefaultHostQueue,
+                                   AuxiliaryCmds);
+      break;
+    default:
+      NewCmd = MGraphBuilder.addCGToCommandBuffer(std::move(CommandGroup),
+                                                  CommandBuffer, Dependencies,
+                                                  AllocaQueue, AuxiliaryCmds);
+    }
+    NewEvent = NewCmd->getEvent();
+  }
+
+  std::vector<Command *> ToCleanUp;
+  {
+    ReadLockT Lock(MGraphLock);
+
+    Command *NewCmd = static_cast<Command *>(NewEvent->getCommand());
+
+    EnqueueResultT Res;
+    bool Enqueued;
+
+    auto CleanUp = [&]() {
+      if (NewCmd && (NewCmd->MDeps.size() == 0 && NewCmd->MUsers.size() == 0)) {
+        NewEvent->setCommand(nullptr);
+        delete NewCmd;
+      }
+    };
+
+    for (Command *Cmd : AuxiliaryCmds) {
+      Enqueued = GraphProcessor::enqueueCommand(Cmd, Res, ToCleanUp);
+      try {
+        if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
+          throw runtime_error("Auxiliary enqueue process failed.",
+                              PI_ERROR_INVALID_OPERATION);
+      } catch (...) {
+        // enqueueCommand() func and if statement above may throw an exception,
+        // so destroy required resources to avoid memory leak
+        CleanUp();
+        std::rethrow_exception(std::current_exception());
+      }
+    }
+
+    if (NewCmd) {
+      // TODO: Check if lazy mode.
+      EnqueueResultT Res;
+      try {
+        bool Enqueued = GraphProcessor::enqueueCommand(NewCmd, Res, ToCleanUp);
+        if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
+          throw runtime_error("Enqueue process failed.",
+                              PI_ERROR_INVALID_OPERATION);
+      } catch (...) {
+        // enqueueCommand() func and if statement above may throw an exception,
+        // so destroy required resources to avoid memory leak
+        CleanUp();
+        std::rethrow_exception(std::current_exception());
+      }
+    }
+  }
+  cleanupCommands(ToCleanUp);
+
+  for (auto StreamImplPtr : Streams) {
+    StreamImplPtr->flush();
+  }
+
+  return NewEvent;
+}
+
 EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
                               const QueueImplPtr &Queue) {
   EventImplPtr NewEvent = nullptr;

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -373,7 +373,7 @@ public:
   /// sync points when enqueuing to a command buffer.
   /// \return an event object to wait on for command group completion.
   EventImplPtr addCG(std::unique_ptr<detail::CG> CommandGroup,
-                     QueueImplPtr Queue,
+                     const QueueImplPtr &Queue,
                      RT::PiExtCommandBuffer CommandBuffer = nullptr,
                      const std::vector<RT::PiExtSyncPoint> &Dependencies = {});
 
@@ -532,8 +532,6 @@ protected:
     /// Registers \ref CG "command group" and adds it to the dependency graph.
     ///
     /// \sa queue::submit, Scheduler::addCG
-    /// \tparam CommandType Type of command to use, since command buffers
-    /// require a different command to be used.
     /// \param CommandBuffer Optional command buffer to enqueue to instead of
     /// directly to the queue.
     /// \param Dependencies Optional list of dependency
@@ -542,7 +540,6 @@ protected:
     /// \return a command that represents command group execution and a bool
     /// indicating whether this command should be enqueued to the graph
     /// processor right away or not.
-    template <typename CommandType>
     GraphBuildResult addCG(std::unique_ptr<detail::CG> CommandGroup, const QueueImplPtr &Queue,
                    std::vector<Command *> &ToEnqueue,
                    RT::PiExtCommandBuffer CommandBuffer = nullptr,

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -367,22 +367,15 @@ public:
   /// It's called by SYCL's queue.submit.
   ///
   /// \param CommandGroup is a unique_ptr to a command group to be added.
+  /// \param CommandBuffer Optional command buffer to enqueue to instead of
+  /// directly to the queue.
+  /// \param Dependencies Optional list of dependency
+  /// sync points when enqueuing to a command buffer.
   /// \return an event object to wait on for command group completion.
   EventImplPtr addCG(std::unique_ptr<detail::CG> CommandGroup,
-                     const QueueImplPtr &Queue);
-
-  /// Registers a command group, and adds it to the dependency graph
-  /// for enqueue to a command buffer.
-  ///
-  /// \sa ext::oneapi::experimental::command_graph::finalize,
-  /// Scheduler::addCGToCommandBuffer
-  ///
-  /// \return an event object representing the command group enqueue.
-  EventImplPtr
-  addCGToCommandBuffer(std::unique_ptr<detail::CG> CommandGroup,
-                       RT::PiExtCommandBuffer CommandBuffer,
-                       const std::vector<RT::PiExtSyncPoint> &Dependencies,
-                       QueueImplPtr Queue);
+                     QueueImplPtr Queue,
+                     RT::PiExtCommandBuffer CommandBuffer = nullptr,
+                     const std::vector<RT::PiExtSyncPoint> &Dependencies = {});
 
   /// Registers a command group, that copies most recent memory to the memory
   /// pointed by the requirement.
@@ -539,27 +532,21 @@ protected:
     /// Registers \ref CG "command group" and adds it to the dependency graph.
     ///
     /// \sa queue::submit, Scheduler::addCG
+    /// \tparam CommandType Type of command to use, since command buffers
+    /// require a different command to be used.
+    /// \param CommandBuffer Optional command buffer to enqueue to instead of
+    /// directly to the queue.
+    /// \param Dependencies Optional list of dependency
+    /// sync points when enqueuing to a command buffer.
     ///
     /// \return a command that represents command group execution and a bool
     /// indicating whether this command should be enqueued to the graph
     /// processor right away or not.
-    GraphBuildResult addCG(std::unique_ptr<detail::CG> CommandGroup,
-                           const QueueImplPtr &Queue,
-                           std::vector<Command *> &ToEnqueue);
-
-    /// Registers \ref CG "command group" and adds it to the dependency graph
-    /// for enqueue to a command buffer.
-    ///
-    /// \sa ext::oneapi::experimental::command_graph::finalize,
-    /// Scheduler::addCGToCommandBuffer
-    ///
-    /// \return a command that represents command group enqueue.
-    Command *
-    addCGToCommandBuffer(std::unique_ptr<detail::CG> CommandGroup,
-                         RT::PiExtCommandBuffer CommandBuffer,
-                         const std::vector<RT::PiExtSyncPoint> &Dependencies,
-                         QueueImplPtr AllocaQueue,
-                         std::vector<Command *> &ToEnqueue);
+    template <typename CommandType>
+    GraphBuildResult addCG(std::unique_ptr<detail::CG> CommandGroup, const QueueImplPtr &Queue,
+                   std::vector<Command *> &ToEnqueue,
+                   RT::PiExtCommandBuffer CommandBuffer = nullptr,
+                   const std::vector<RT::PiExtSyncPoint> &Dependencies = {});
 
     /// Registers a \ref CG "command group" that updates host memory to the
     /// latest state.

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -373,8 +373,8 @@ public:
 
   EventImplPtr
   addCGToCommandBuffer(std::unique_ptr<detail::CG> CommandGroup,
-                       pi_ext_command_buffer CommandBuffer,
-                       const std::vector<pi_ext_sync_point> &Dependencies,
+                       RT::PiExtCommandBuffer CommandBuffer,
+                       const std::vector<RT::PiExtSyncPoint> &Dependencies,
                        QueueImplPtr Queue);
 
   /// Registers a command group, that copies most recent memory to the memory
@@ -542,8 +542,8 @@ protected:
 
     Command *
     addCGToCommandBuffer(std::unique_ptr<detail::CG> CommandGroup,
-                         pi_ext_command_buffer CommandBuffer,
-                         const std::vector<pi_ext_sync_point> &Dependencies,
+                         RT::PiExtCommandBuffer CommandBuffer,
+                         const std::vector<RT::PiExtSyncPoint> &Dependencies,
                          QueueImplPtr AllocaQueue,
                          std::vector<Command *> &ToEnqueue);
 

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -371,6 +371,13 @@ public:
   EventImplPtr addCG(std::unique_ptr<detail::CG> CommandGroup,
                      const QueueImplPtr &Queue);
 
+  /// Registers a command group, and adds it to the dependency graph
+  /// for enqueue to a command buffer.
+  ///
+  /// \sa ext::oneapi::experimental::command_graph::finalize,
+  /// Scheduler::addCGToCommandBuffer
+  ///
+  /// \return an event object representing the command group enqueue.
   EventImplPtr
   addCGToCommandBuffer(std::unique_ptr<detail::CG> CommandGroup,
                        RT::PiExtCommandBuffer CommandBuffer,
@@ -540,6 +547,13 @@ protected:
                            const QueueImplPtr &Queue,
                            std::vector<Command *> &ToEnqueue);
 
+    /// Registers \ref CG "command group" and adds it to the dependency graph
+    /// for enqueue to a command buffer.
+    ///
+    /// \sa ext::oneapi::experimental::command_graph::finalize,
+    /// Scheduler::addCGToCommandBuffer
+    ///
+    /// \return a command that represents command group enqueue.
     Command *
     addCGToCommandBuffer(std::unique_ptr<detail::CG> CommandGroup,
                          RT::PiExtCommandBuffer CommandBuffer,

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -371,6 +371,12 @@ public:
   EventImplPtr addCG(std::unique_ptr<detail::CG> CommandGroup,
                      const QueueImplPtr &Queue);
 
+  EventImplPtr
+  addCGToCommandBuffer(std::unique_ptr<detail::CG> CommandGroup,
+                       pi_ext_command_buffer CommandBuffer,
+                       const std::vector<pi_ext_sync_point> &Dependencies,
+                       QueueImplPtr Queue);
+
   /// Registers a command group, that copies most recent memory to the memory
   /// pointed by the requirement.
   ///
@@ -533,6 +539,13 @@ protected:
     GraphBuildResult addCG(std::unique_ptr<detail::CG> CommandGroup,
                            const QueueImplPtr &Queue,
                            std::vector<Command *> &ToEnqueue);
+
+    Command *
+    addCGToCommandBuffer(std::unique_ptr<detail::CG> CommandGroup,
+                         pi_ext_command_buffer CommandBuffer,
+                         const std::vector<pi_ext_sync_point> &Dependencies,
+                         QueueImplPtr AllocaQueue,
+                         std::vector<Command *> &ToEnqueue);
 
     /// Registers a \ref CG "command group" that updates host memory to the
     /// latest state.

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -40,6 +40,172 @@ bool isDeviceGlobalUsedInKernel(const void *DeviceGlobalPtr) {
   return DGEntry && !DGEntry->MImageIdentifiers.empty();
 }
 
+std::shared_ptr<event_impl> createCommandAndEnqueue(
+    CG::CGTYPE Type, std::shared_ptr<detail::queue_impl> Queue, 
+    NDRDescT NDRDesc, std::unique_ptr<detail::HostKernelBase> HostKernel,
+    std::unique_ptr<detail::HostTask> HostTaskPtr,
+    std::unique_ptr<detail::InteropTask> InteropTask,
+    std::shared_ptr<detail::kernel_impl> Kernel, std::string KernelName,
+    KernelBundleImplPtr KernelBundle,
+    std::vector<std::vector<char>> ArgsStorage,
+    std::vector<detail::AccessorImplPtr> AccStorage,
+    std::vector<detail::LocalAccessorImplPtr> LocalAccStorage,
+    std::vector<std::shared_ptr<detail::stream_impl>> StreamStorage,
+    std::vector<std::shared_ptr<const void>> SharedPtrStorage,
+    std::vector<std::shared_ptr<const void>> AuxiliaryResources,
+    std::vector<detail::ArgDesc> Args, void *SrcPtr, void *DstPtr,
+    size_t Length, std::vector<char> Pattern,size_t SrcPitch, size_t DstPitch,
+    size_t Width, size_t Height, size_t Offset, bool IsDeviceImageScoped,
+    const std::string &HostPipeName, void *HostPipePtr, bool HostPipeBlocking,
+    size_t HostPipeTypeSize, bool HostPipeRead, pi_mem_advice Advice,
+    std::vector<detail::AccessorImplHost *> Requirements,
+    std::vector<detail::EventImplPtr> Events,
+    std::vector<detail::EventImplPtr> EventsWaitWithBarrier,
+    detail::OSModuleHandle OSModHandle, detail::code_location CodeLoc) {
+  std::unique_ptr<detail::CG> CommandGroup;
+  switch (Type) {
+  case detail::CG::Kernel:
+  case detail::CG::RunOnHostIntel: {
+    // Copy kernel name here instead of move so that it's available after
+    // running of this method by reductions implementation. This allows for
+    // assert feature to check if kernel uses assertions
+    CommandGroup.reset(new detail::CGExecKernel(
+        std::move(NDRDesc), std::move(HostKernel), std::move(Kernel),
+        std::move(KernelBundle), std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements), std::move(Events),
+        std::move(Args), KernelName, OSModHandle, std::move(StreamStorage),
+        std::move(AuxiliaryResources), Type, CodeLoc));
+    break;
+  }
+  case detail::CG::CodeplayInteropTask:
+    CommandGroup.reset(new detail::CGInteropTask(
+        std::move(InteropTask), std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements), std::move(Events),
+        Type, CodeLoc));
+    break;
+  case detail::CG::CopyAccToPtr:
+  case detail::CG::CopyPtrToAcc:
+  case detail::CG::CopyAccToAcc:
+    CommandGroup.reset(new detail::CGCopy(
+        Type, SrcPtr, DstPtr, std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements), std::move(Events),
+        CodeLoc));
+    break;
+  case detail::CG::Fill:
+    CommandGroup.reset(new detail::CGFill(
+        std::move(Pattern), DstPtr, std::move(ArgsStorage),
+        std::move(AccStorage), std::move(SharedPtrStorage),
+        std::move(Requirements), std::move(Events), CodeLoc));
+    break;
+  case detail::CG::UpdateHost:
+    CommandGroup.reset(new detail::CGUpdateHost(
+        DstPtr, std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements), std::move(Events),
+        CodeLoc));
+    break;
+  case detail::CG::CopyUSM:
+    CommandGroup.reset(new detail::CGCopyUSM(
+        SrcPtr, DstPtr, Length, std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements), std::move(Events),
+        CodeLoc));
+    break;
+  case detail::CG::FillUSM:
+    CommandGroup.reset(new detail::CGFillUSM(
+        std::move(Pattern), DstPtr, Length, std::move(ArgsStorage),
+        std::move(AccStorage), std::move(SharedPtrStorage),
+        std::move(Requirements), std::move(Events), CodeLoc));
+    break;
+  case detail::CG::PrefetchUSM:
+    CommandGroup.reset(new detail::CGPrefetchUSM(
+        DstPtr, Length, std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements), std::move(Events),
+        CodeLoc));
+    break;
+  case detail::CG::AdviseUSM:
+    CommandGroup.reset(new detail::CGAdviseUSM(
+        DstPtr, Length, Advice, std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements), std::move(Events),
+        Type, CodeLoc));
+    break;
+  case detail::CG::Copy2DUSM:
+    CommandGroup.reset(new detail::CGCopy2DUSM(
+        SrcPtr, DstPtr, SrcPitch, DstPitch, Width,
+        Height, std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements),
+        std::move(Events), CodeLoc));
+    break;
+  case detail::CG::Fill2DUSM:
+    CommandGroup.reset(new detail::CGFill2DUSM(
+        std::move(Pattern), DstPtr, DstPitch, Width,
+        Height, std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements),
+        std::move(Events), CodeLoc));
+    break;
+  case detail::CG::Memset2DUSM:
+    CommandGroup.reset(new detail::CGMemset2DUSM(
+        Pattern[0], DstPtr, DstPitch, Width, Height,
+        std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements),
+        std::move(Events), CodeLoc));
+    break;
+  case detail::CG::CodeplayHostTask:
+    CommandGroup.reset(new detail::CGHostTask(
+        std::move(HostTaskPtr), Queue, Queue->getContextImplPtr(),
+        std::move(Args), std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements), std::move(Events),
+        Type, CodeLoc));
+    break;
+  case detail::CG::Barrier:
+  case detail::CG::BarrierWaitlist:
+    CommandGroup.reset(new detail::CGBarrier(
+        std::move(EventsWaitWithBarrier), std::move(ArgsStorage),
+        std::move(AccStorage), std::move(SharedPtrStorage),
+        std::move(Requirements), std::move(Events), Type, CodeLoc));
+    break;
+  case detail::CG::CopyToDeviceGlobal: {
+    CommandGroup.reset(new detail::CGCopyToDeviceGlobal(
+        SrcPtr, DstPtr, IsDeviceImageScoped, Length, Offset,
+        std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements),
+        std::move(Events), OSModHandle, CodeLoc));
+    break;
+  }
+  case detail::CG::CopyFromDeviceGlobal: {
+    CommandGroup.reset(new detail::CGCopyFromDeviceGlobal(
+        SrcPtr, DstPtr, IsDeviceImageScoped, Length, Offset,
+        std::move(ArgsStorage), std::move(AccStorage),
+        std::move(SharedPtrStorage), std::move(Requirements),
+        std::move(Events), OSModHandle, CodeLoc));
+    break;
+  }
+  case detail::CG::ReadWriteHostPipe: {
+    CommandGroup.reset(new detail::CGReadWriteHostPipe(
+        HostPipeName, HostPipeBlocking, HostPipePtr,
+        HostPipeTypeSize, HostPipeRead, std::move(ArgsStorage),
+        std::move(AccStorage), std::move(SharedPtrStorage),
+        std::move(Requirements), std::move(Events), CodeLoc));
+    break;
+  }
+  case detail::CG::ExecCommandBuffer:
+    assert(false && "Error: Command graph submission should not be finalized");
+    break;
+  case detail::CG::None:
+    if (detail::pi::trace(detail::pi::TraceLevel::PI_TRACE_ALL)) {
+      std::cout << "WARNING: An empty command group is submitted." << std::endl;
+    }
+    return std::make_shared<sycl::detail::event_impl>();
+  }
+
+  if (!CommandGroup)
+    throw sycl::runtime_error(
+        "Internal Error. Command group cannot be constructed.",
+        PI_ERROR_INVALID_OPERATION);
+
+  detail::EventImplPtr Event = detail::Scheduler::getInstance().addCG(
+      std::move(CommandGroup), std::move(Queue));
+
+  return Event;
+}
 } // namespace detail
 
 handler::handler(std::shared_ptr<detail::queue_impl> Queue, bool IsHost)
@@ -280,154 +446,18 @@ event handler::finalize() {
       return MLastEvent;
     }
   }
+  detail::EventImplPtr EventImpl = createCommandAndEnqueue(
+      type, MQueue, MNDRDesc, std::move(MHostKernel), std::move(MHostTask),
+      std::move(MInteropTask), std::move(MKernel), MKernelName,
+      std::move(MImpl->MKernelBundle), std::move(MArgsStorage),
+      std::move(MAccStorage), std::move(MLocalAccStorage),
+      std::move(MStreamStorage), std::move(MSharedPtrStorage),
+      std::move(MImpl->MAuxiliaryResources), std::move(MArgs), MSrcPtr, MDstPtr,
+      MLength, std::move(MPattern), MImpl->MAdvice, std::move(MRequirements),
+      std::move(MEvents), std::move(MEventsWaitWithBarrier), MOSModuleHandle,
+      MCodeLoc);
 
-  std::unique_ptr<detail::CG> CommandGroup;
-  switch (type) {
-  case detail::CG::Kernel:
-  case detail::CG::RunOnHostIntel: {
-    // Copy kernel name here instead of move so that it's available after
-    // running of this method by reductions implementation. This allows for
-    // assert feature to check if kernel uses assertions
-    CommandGroup.reset(new detail::CGExecKernel(
-        std::move(MNDRDesc), std::move(MHostKernel), std::move(MKernel),
-        std::move(MImpl->MKernelBundle), std::move(MArgsStorage),
-        std::move(MAccStorage), std::move(MSharedPtrStorage),
-        std::move(MRequirements), std::move(MEvents), std::move(MArgs),
-        MKernelName, MOSModuleHandle, std::move(MStreamStorage),
-        std::move(MImpl->MAuxiliaryResources), MCGType,
-        MImpl->MKernelCacheConfig, MCodeLoc));
-    break;
-  }
-  case detail::CG::CodeplayInteropTask:
-    CommandGroup.reset(new detail::CGInteropTask(
-        std::move(MInteropTask), std::move(MArgsStorage),
-        std::move(MAccStorage), std::move(MSharedPtrStorage),
-        std::move(MRequirements), std::move(MEvents), MCGType, MCodeLoc));
-    break;
-  case detail::CG::CopyAccToPtr:
-  case detail::CG::CopyPtrToAcc:
-  case detail::CG::CopyAccToAcc:
-    CommandGroup.reset(new detail::CGCopy(
-        MCGType, MSrcPtr, MDstPtr, std::move(MArgsStorage),
-        std::move(MAccStorage), std::move(MSharedPtrStorage),
-        std::move(MRequirements), std::move(MEvents), MCodeLoc));
-    break;
-  case detail::CG::Fill:
-    CommandGroup.reset(new detail::CGFill(
-        std::move(MPattern), MDstPtr, std::move(MArgsStorage),
-        std::move(MAccStorage), std::move(MSharedPtrStorage),
-        std::move(MRequirements), std::move(MEvents), MCodeLoc));
-    break;
-  case detail::CG::UpdateHost:
-    CommandGroup.reset(new detail::CGUpdateHost(
-        MDstPtr, std::move(MArgsStorage), std::move(MAccStorage),
-        std::move(MSharedPtrStorage), std::move(MRequirements),
-        std::move(MEvents), MCodeLoc));
-    break;
-  case detail::CG::CopyUSM:
-    CommandGroup.reset(new detail::CGCopyUSM(
-        MSrcPtr, MDstPtr, MLength, std::move(MArgsStorage),
-        std::move(MAccStorage), std::move(MSharedPtrStorage),
-        std::move(MRequirements), std::move(MEvents), MCodeLoc));
-    break;
-  case detail::CG::FillUSM:
-    CommandGroup.reset(new detail::CGFillUSM(
-        std::move(MPattern), MDstPtr, MLength, std::move(MArgsStorage),
-        std::move(MAccStorage), std::move(MSharedPtrStorage),
-        std::move(MRequirements), std::move(MEvents), MCodeLoc));
-    break;
-  case detail::CG::PrefetchUSM:
-    CommandGroup.reset(new detail::CGPrefetchUSM(
-        MDstPtr, MLength, std::move(MArgsStorage), std::move(MAccStorage),
-        std::move(MSharedPtrStorage), std::move(MRequirements),
-        std::move(MEvents), MCodeLoc));
-    break;
-  case detail::CG::AdviseUSM:
-    CommandGroup.reset(new detail::CGAdviseUSM(
-        MDstPtr, MLength, MImpl->MAdvice, std::move(MArgsStorage),
-        std::move(MAccStorage), std::move(MSharedPtrStorage),
-        std::move(MRequirements), std::move(MEvents), MCGType, MCodeLoc));
-    break;
-  case detail::CG::Copy2DUSM:
-    CommandGroup.reset(new detail::CGCopy2DUSM(
-        MSrcPtr, MDstPtr, MImpl->MSrcPitch, MImpl->MDstPitch, MImpl->MWidth,
-        MImpl->MHeight, std::move(MArgsStorage), std::move(MAccStorage),
-        std::move(MSharedPtrStorage), std::move(MRequirements),
-        std::move(MEvents), MCodeLoc));
-    break;
-  case detail::CG::Fill2DUSM:
-    CommandGroup.reset(new detail::CGFill2DUSM(
-        std::move(MPattern), MDstPtr, MImpl->MDstPitch, MImpl->MWidth,
-        MImpl->MHeight, std::move(MArgsStorage), std::move(MAccStorage),
-        std::move(MSharedPtrStorage), std::move(MRequirements),
-        std::move(MEvents), MCodeLoc));
-    break;
-  case detail::CG::Memset2DUSM:
-    CommandGroup.reset(new detail::CGMemset2DUSM(
-        MPattern[0], MDstPtr, MImpl->MDstPitch, MImpl->MWidth, MImpl->MHeight,
-        std::move(MArgsStorage), std::move(MAccStorage),
-        std::move(MSharedPtrStorage), std::move(MRequirements),
-        std::move(MEvents), MCodeLoc));
-    break;
-  case detail::CG::CodeplayHostTask:
-    CommandGroup.reset(new detail::CGHostTask(
-        std::move(MHostTask), MQueue, MQueue->getContextImplPtr(),
-        std::move(MArgs), std::move(MArgsStorage), std::move(MAccStorage),
-        std::move(MSharedPtrStorage), std::move(MRequirements),
-        std::move(MEvents), MCGType, MCodeLoc));
-    break;
-  case detail::CG::Barrier:
-  case detail::CG::BarrierWaitlist:
-    CommandGroup.reset(new detail::CGBarrier(
-        std::move(MEventsWaitWithBarrier), std::move(MArgsStorage),
-        std::move(MAccStorage), std::move(MSharedPtrStorage),
-        std::move(MRequirements), std::move(MEvents), MCGType, MCodeLoc));
-    break;
-  case detail::CG::CopyToDeviceGlobal: {
-    CommandGroup.reset(new detail::CGCopyToDeviceGlobal(
-        MSrcPtr, MDstPtr, MImpl->MIsDeviceImageScoped, MLength, MImpl->MOffset,
-        std::move(MArgsStorage), std::move(MAccStorage),
-        std::move(MSharedPtrStorage), std::move(MRequirements),
-        std::move(MEvents), MOSModuleHandle, MCodeLoc));
-    break;
-  }
-  case detail::CG::CopyFromDeviceGlobal: {
-    CommandGroup.reset(new detail::CGCopyFromDeviceGlobal(
-        MSrcPtr, MDstPtr, MImpl->MIsDeviceImageScoped, MLength, MImpl->MOffset,
-        std::move(MArgsStorage), std::move(MAccStorage),
-        std::move(MSharedPtrStorage), std::move(MRequirements),
-        std::move(MEvents), MOSModuleHandle, MCodeLoc));
-    break;
-  }
-  case detail::CG::ReadWriteHostPipe: {
-    CommandGroup.reset(new detail::CGReadWriteHostPipe(
-        MImpl->HostPipeName, MImpl->HostPipeBlocking, MImpl->HostPipePtr,
-        MImpl->HostPipeTypeSize, MImpl->HostPipeRead, std::move(MArgsStorage),
-        std::move(MAccStorage), std::move(MSharedPtrStorage),
-        std::move(MRequirements), std::move(MEvents), MCodeLoc));
-    break;
-  }
-  case detail::CG::ExecCommandBuffer:
-    assert(false && "Error: Command graph submission should not be finalized");
-    break;
-  case detail::CG::None:
-    if (detail::pi::trace(detail::pi::TraceLevel::PI_TRACE_ALL)) {
-      std::cout << "WARNING: An empty command group is submitted." << std::endl;
-    }
-    detail::EventImplPtr Event = std::make_shared<sycl::detail::event_impl>();
-    MLastEvent = detail::createSyclObjFromImpl<event>(Event);
-    return MLastEvent;
-  }
-
-  if (!CommandGroup)
-    throw sycl::runtime_error(
-        "Internal Error. Command group cannot be constructed.",
-        PI_ERROR_INVALID_OPERATION);
-
-  detail::EventImplPtr Event = detail::Scheduler::getInstance().addCG(
-      std::move(CommandGroup), std::move(MQueue));
-
-  MLastEvent = detail::createSyclObjFromImpl<event>(Event);
+  MLastEvent = detail::createSyclObjFromImpl<event>(EventImpl);
   return MLastEvent;
 }
 

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -124,9 +124,10 @@ event handler::finalize() {
     }
     // Extract relevant data from the handler and pass to graph to create a new
     // node representing this command group.
-    auto NodeImpl = GraphImpl->add(MKernel, MNDRDesc, MOSModuleHandle,
-                                   MKernelName, MAccStorage, MLocalAccStorage,
-                                   MRequirements, MArgs, {}, MEvents);
+    auto NodeImpl =
+        GraphImpl->add(MKernel, MNDRDesc, MOSModuleHandle, MKernelName,
+                       MAccStorage, MLocalAccStorage, MCGType, MArgs,
+                       MImpl->MAuxiliaryResources, {}, MEvents);
 
     // Create and associated an event with this new node
     GraphImpl->add_event_for_node(EventImpl, NodeImpl);
@@ -406,6 +407,9 @@ event handler::finalize() {
         std::move(MRequirements), std::move(MEvents), MCodeLoc));
     break;
   }
+  case detail::CG::ExecCommandBuffer:
+    assert(false && "Error: Command graph submission should not be finalized");
+    break;
   case detail::CG::None:
     if (detail::pi::trace(detail::pi::TraceLevel::PI_TRACE_ALL)) {
       std::cout << "WARNING: An empty command group is submitted." << std::endl;

--- a/sycl/test/graph/graph-explicit-dotp-mixed.cpp
+++ b/sycl/test/graph/graph-explicit-dotp-mixed.cpp
@@ -1,0 +1,107 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+const size_t n = 10;
+
+float host_gold_result() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  float sum = 0.0f;
+
+  for (size_t i = 0; i < n; ++i) {
+    sum += (alpha * 1.0f + beta * 2.0f) * (gamma * 3.0f + beta * 2.0f);
+  }
+
+  return sum;
+}
+
+int main() {
+  float alpha = 1.0f;
+  float beta = 2.0f;
+  float gamma = 3.0f;
+
+  sycl::queue q{sycl::gpu_selector_v};
+
+  sycl::ext::oneapi::experimental::command_graph g{q.get_context(),
+                                                   q.get_device()};
+
+  float dotpData = 0.f;
+  std::vector<float> xData(n);
+
+  {
+    sycl::buffer dotpBuf(&dotpData, sycl::range<1>(1));
+
+    sycl::buffer xBuf(xData);
+    float *y = sycl::malloc_shared<float>(n, q);
+    float *z = sycl::malloc_shared<float>(n, q);
+
+    /* init data on the device */
+    auto n_i = g.add([&](sycl::handler &h) {
+      auto x = xBuf.get_access(h);
+      h.parallel_for(n, [=](sycl::id<1> it) {
+        const size_t i = it[0];
+        x[i] = 1.0f;
+        y[i] = 2.0f;
+        z[i] = 3.0f;
+      });
+    });
+
+    // Edge to n_i from buffer accessor
+    auto node_a = g.add([&](sycl::handler &h) {
+      auto x = xBuf.get_access(h);
+      h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+        const size_t i = it[0];
+        x[i] = alpha * x[i] + beta * y[i];
+      });
+    });
+
+    // Edge to n_i explicitly added
+    auto node_b = g.add(
+        [&](sycl::handler &h) {
+          h.parallel_for(sycl::range<1>{n}, [=](sycl::id<1> it) {
+            const size_t i = it[0];
+            z[i] = gamma * z[i] + beta * y[i];
+          });
+        },
+        {n_i});
+
+    // Edge node_a from buffer accessor, and edge to node_b explicitly added
+    auto node_c = g.add(
+        [&](sycl::handler &h) {
+          auto dotp = dotpBuf.get_access(h);
+          auto x = xBuf.get_access(h);
+#ifdef TEST_GRAPH_REDUCTIONS
+          h.parallel_for(sycl::range<1>{n},
+                         sycl::reduction(dotpBuf, h, 0.0f, std::plus()),
+                         [=](sycl::id<1> it, auto &sum) {
+                           const size_t i = it[0];
+                           sum += x[i] * z[i];
+                         });
+#else
+          h.single_task([=]() {
+            // Doing a manual reduction here because reduction objects cause
+            // issues with graphs.
+            for (size_t j = 0; j < n; j++) {
+              dotp[0] += x[j] * z[j];
+            }
+          });
+#endif
+        },
+        {node_b});
+
+    auto executable_graph = g.finalize();
+
+    // Using shortcut for executing a graph of commands
+    q.ext_oneapi_graph(executable_graph).wait();
+
+    sycl::free(y, q);
+    sycl::free(z, q);
+  }
+
+  assert(dotpData == host_gold_result());
+  return 0;
+}


### PR DESCRIPTION
- Enqueue to command buffer through scheduler when required
- New command type enqueueing cmd buffer
- Modifications to execCGCommand and Command class to be cmd buffer aware
- Sync point stored in event impl
- Removed capturing requirements from handler
- Various minor refactors