### PR TITLE
[SYCL][Graph]Use doxygen style comments in graphs header files

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -32,18 +32,20 @@ class exec_graph_impl;
 
 } // namespace detail
 
+/// State to template the command_graph class on
 enum class graph_state {
-  modifiable,
-  executable,
+  modifiable, ///< In modifiable state, commands can be added to graph
+  executable, ///< In executable state, the graph is ready to execute
 };
 
-// Forward declaration
 class node;
 
 namespace property {
 namespace graph {
 
-// TODO: Cycle check not yet implemented.
+/// Property passed to command_graph constructor to disable checking for cycles
+///
+/// \todo Cycle check not yet implemented.
 class no_cycle_check : public ::sycl::detail::DataLessProperty<
                            ::sycl::detail::GraphNoCycleCheck> {
 public:
@@ -54,10 +56,13 @@ public:
 
 namespace node {
 
+/// Property used to define dependent nodes when creating a new node with
+/// command_graph::add()
 class depends_on : public ::sycl::detail::PropertyWithData<
                        ::sycl::detail::GraphNodeDependencies> {
 public:
   template <typename... NodeTN> depends_on(NodeTN... nodes) : MDeps{nodes...} {}
+
   const std::vector<::sycl::ext::oneapi::experimental::node> &
   get_dependencies() const {
     return MDeps;
@@ -70,6 +75,7 @@ private:
 } // namespace node
 } // namespace property
 
+/// Class representing a node in the graph, returned by command_graph::add()
 class __SYCL_EXPORT node {
 private:
   node(const std::shared_ptr<detail::node_impl> &Impl) : impl(Impl) {}
@@ -84,13 +90,20 @@ private:
   std::shared_ptr<detail::graph_impl> MGraph;
 };
 
+/// Class representing a graph in the modifiable state
 template <graph_state State = graph_state::modifiable>
 class __SYCL_EXPORT command_graph {
 public:
-  command_graph(const context &syclContext, const device &syclDevice,
-                const property_list &propList = {});
+  /// Constructor
+  /// @param SyclContext context to use for graph
+  /// @param SyclDevice device all nodes will be associated with
+  /// @param PropList optional list of properties to pass
+  command_graph(const context &SyclContext, const device &SyclDevice,
+                const property_list &PropList = {});
 
-  // Adding empty node with [0..n] predecessors:
+  /// Add an empty node to the graph
+  /// @param PropList property list used to pass [0..n] predecessor nodes
+  /// @return constructed empty node which has been added to the graph
   node add(const property_list &PropList = {}) {
     if (PropList.has_property<property::node::depends_on>()) {
       auto Deps = PropList.get_property<property::node::depends_on>();
@@ -99,7 +112,10 @@ public:
     return add_impl({});
   }
 
-  // Adding device node:
+  /// Add a command-group node to the graph
+  /// @param CGF command group function to create node with
+  /// @param PropList property list used to pass [0..n] predecessor nodes
+  /// @return constructed node which has been added to the graph
   template <typename T> node add(T CGF, const property_list &PropList = {}) {
     if (PropList.has_property<property::node::depends_on>()) {
       auto Deps = PropList.get_property<property::node::depends_on>();
@@ -108,27 +124,32 @@ public:
     return add_impl(CGF, {});
   }
 
-  // Adding dependency between two nodes.
-  void make_edge(node sender, node receiver);
+  /// Add a dependency between two nodes.
+  /// @param Src Node which will be a dependency of dest
+  /// @param Dest Node which will be dependent on src
+  void make_edge(node &Src, node &Dest);
 
+  /// Finalize modifiable graph into an executable graph
+  /// @param PropList property list used to pass properties for finalization
+  /// @return Executable graph object
   command_graph<graph_state::executable>
-  finalize(const property_list &propList = {}) const;
+  finalize(const property_list &PropList = {}) const;
 
   /// Change the state of a queue to be recording and associate this graph with
   /// it.
-  /// @param recordingQueue The queue to change state on and associate this
+  /// @param RecordingQueue The queue to change state on and associate this
   /// graph with.
   /// @return True if the queue had its state changed from executing to
   /// recording.
-  bool begin_recording(queue recordingQueue);
+  bool begin_recording(queue &RecordingQueue);
 
   /// Change the state of multiple queues to be recording and associate this
   /// graph with each of them.
-  /// @param recordingQueues The queues to change state on and associate this
+  /// @param RecordingQueues The queues to change state on and associate this
   /// graph with.
   /// @return True if any queue had its state changed from executing to
   /// recording.
-  bool begin_recording(const std::vector<queue> &recordingQueues);
+  bool begin_recording(const std::vector<queue> &RecordingQueues);
 
   /// Set all queues currently recording to this graph to the executing state.
   /// @return True if any queue had its state changed from recording to
@@ -136,26 +157,34 @@ public:
   bool end_recording();
 
   /// Set a queues currently recording to this graph to the executing state.
-  /// @param recordingQueue The queue to change state on.
+  /// @param RecordingQueue The queue to change state on.
   /// @return True if the queue had its state changed from recording to
   /// executing.
-  bool end_recording(queue recordingQueue);
+  bool end_recording(queue &RecordingQueue);
 
   /// Set multiple queues currently recording to this graph to the executing
   /// state.
-  /// @param recordingQueue The queues to change state on.
+  /// @param RecordingQueue The queues to change state on.
   /// @return True if any queue had its state changed from recording to
   /// executing.
-  bool end_recording(const std::vector<queue> &recordingQueues);
+  bool end_recording(const std::vector<queue> &RecordingQueues);
 
 private:
+  /// Constructor used internally by the runtime
+  /// @param Impl Detail implementation class to construct object with
   command_graph(const std::shared_ptr<detail::graph_impl> &Impl) : impl(Impl) {}
 
-  // Template-less implementation of add()
-  node add_impl(std::function<void(handler &)> cgf,
-                const std::vector<node> &dep);
+  /// Template-less implementation of add() for CGF nodes
+  /// @param CGF command-group function to add
+  /// @param Dep list of predecessor nodes
+  /// @return Node added to the graph
+  node add_impl(std::function<void(handler &)> CGF,
+                const std::vector<node> &Dep);
 
-  node add_impl(const std::vector<node> &dep);
+  /// Template-less implementation of add() for empty nodes
+  /// @param Dep list of predecessor nodes
+  /// @return Node added to the graph
+  node add_impl(const std::vector<node> &Dep);
 
   template <class Obj>
   friend decltype(Obj::impl)
@@ -168,17 +197,25 @@ private:
 
 template <> class __SYCL_EXPORT command_graph<graph_state::executable> {
 public:
+  /// An executable command-graph is not user constructable
   command_graph() = delete;
 
+  /// Constructor used by internal runtime
+  /// @param Graph Detail implementation class to construct with
+  /// @param Ctx Context to use for graph
   command_graph(const std::shared_ptr<detail::graph_impl> &Graph,
                 const sycl::context &Ctx);
+
+  /// Update the inputs & output of the graph
+  /// @param Graph Graph to use the inputs and outputs of
+  void update(const command_graph<graph_state::modifiable> &Graph);
 
 private:
   template <class Obj>
   friend decltype(Obj::impl)
   sycl::detail::getSyclObjImpl(const Obj &SyclObject);
 
-  // Creates a backend representation of the graph in impl
+  /// Creates a backend representation of the graph in impl
   void finalize_impl();
 
   int MTag;

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -103,7 +103,7 @@ public:
 
   /// Add an empty node to the graph
   /// @param PropList property list used to pass [0..n] predecessor nodes
-  /// @return constructed empty node which has been added to the graph
+  /// @return Constructed empty node which has been added to the graph
   node add(const property_list &PropList = {}) {
     if (PropList.has_property<property::node::depends_on>()) {
       auto Deps = PropList.get_property<property::node::depends_on>();
@@ -115,7 +115,7 @@ public:
   /// Add a command-group node to the graph
   /// @param CGF command group function to create node with
   /// @param PropList property list used to pass [0..n] predecessor nodes
-  /// @return constructed node which has been added to the graph
+  /// @return Constructed node which has been added to the graph
   template <typename T> node add(T CGF, const property_list &PropList = {}) {
     if (PropList.has_property<property::node::depends_on>()) {
       auto Deps = PropList.get_property<property::node::depends_on>();

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -38,6 +38,7 @@ enum class graph_state {
   executable, ///< In executable state, the graph is ready to execute.
 };
 
+// Forward declaration
 class node;
 
 namespace property {
@@ -125,8 +126,8 @@ public:
   }
 
   /// Add a dependency between two nodes.
-  /// @param Src Node which will be a dependency of \p dest.
-  /// @param Dest Node which will be dependent on \p src.
+  /// @param Src Node which will be a dependency of \p Dest.
+  /// @param Dest Node which will be dependent on \p Src.
   void make_edge(node &Src, node &Dest);
 
   /// Finalize modifiable graph into an executable graph.

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -32,10 +32,10 @@ class exec_graph_impl;
 
 } // namespace detail
 
-/// State to template the command_graph class on
+/// State to template the command_graph class on.
 enum class graph_state {
-  modifiable, ///< In modifiable state, commands can be added to graph
-  executable, ///< In executable state, the graph is ready to execute
+  modifiable, ///< In modifiable state, commands can be added to graph.
+  executable, ///< In executable state, the graph is ready to execute.
 };
 
 class node;
@@ -43,7 +43,7 @@ class node;
 namespace property {
 namespace graph {
 
-/// Property passed to command_graph constructor to disable checking for cycles
+/// Property passed to command_graph constructor to disable checking for cycles.
 ///
 /// \todo Cycle check not yet implemented.
 class no_cycle_check : public ::sycl::detail::DataLessProperty<
@@ -57,7 +57,7 @@ public:
 namespace node {
 
 /// Property used to define dependent nodes when creating a new node with
-/// command_graph::add()
+/// command_graph::add().
 class depends_on : public ::sycl::detail::PropertyWithData<
                        ::sycl::detail::GraphNodeDependencies> {
 public:
@@ -75,7 +75,7 @@ private:
 } // namespace node
 } // namespace property
 
-/// Class representing a node in the graph, returned by command_graph::add()
+/// Class representing a node in the graph, returned by command_graph::add().
 class __SYCL_EXPORT node {
 private:
   node(const std::shared_ptr<detail::node_impl> &Impl) : impl(Impl) {}
@@ -90,20 +90,20 @@ private:
   std::shared_ptr<detail::graph_impl> MGraph;
 };
 
-/// Class representing a graph in the modifiable state
+/// Class representing a graph in the modifiable state.
 template <graph_state State = graph_state::modifiable>
 class __SYCL_EXPORT command_graph {
 public:
-  /// Constructor
-  /// @param SyclContext context to use for graph
-  /// @param SyclDevice device all nodes will be associated with
-  /// @param PropList optional list of properties to pass
+  /// Constructor.
+  /// @param SyclContext Context to use for graph.
+  /// @param SyclDevice Device all nodes will be associated with.
+  /// @param PropList Optional list of properties to pass.
   command_graph(const context &SyclContext, const device &SyclDevice,
                 const property_list &PropList = {});
 
-  /// Add an empty node to the graph
-  /// @param PropList property list used to pass [0..n] predecessor nodes
-  /// @return Constructed empty node which has been added to the graph
+  /// Add an empty node to the graph.
+  /// @param PropList Property list used to pass [0..n] predecessor nodes.
+  /// @return Constructed empty node which has been added to the graph.
   node add(const property_list &PropList = {}) {
     if (PropList.has_property<property::node::depends_on>()) {
       auto Deps = PropList.get_property<property::node::depends_on>();
@@ -112,10 +112,10 @@ public:
     return add_impl({});
   }
 
-  /// Add a command-group node to the graph
-  /// @param CGF command group function to create node with
-  /// @param PropList property list used to pass [0..n] predecessor nodes
-  /// @return Constructed node which has been added to the graph
+  /// Add a command-group node to the graph.
+  /// @param CGF Command-group function to create node with.
+  /// @param PropList Property list used to pass [0..n] predecessor nodes.
+  /// @return Constructed node which has been added to the graph.
   template <typename T> node add(T CGF, const property_list &PropList = {}) {
     if (PropList.has_property<property::node::depends_on>()) {
       auto Deps = PropList.get_property<property::node::depends_on>();
@@ -125,13 +125,13 @@ public:
   }
 
   /// Add a dependency between two nodes.
-  /// @param Src Node which will be a dependency of dest
-  /// @param Dest Node which will be dependent on src
+  /// @param Src Node which will be a dependency of \p dest.
+  /// @param Dest Node which will be dependent on \p src.
   void make_edge(node &Src, node &Dest);
 
-  /// Finalize modifiable graph into an executable graph
-  /// @param PropList property list used to pass properties for finalization
-  /// @return Executable graph object
+  /// Finalize modifiable graph into an executable graph.
+  /// @param PropList Property list used to pass properties for finalization.
+  /// @return Executable graph object.
   command_graph<graph_state::executable>
   finalize(const property_list &PropList = {}) const;
 
@@ -164,26 +164,26 @@ public:
 
   /// Set multiple queues currently recording to this graph to the executing
   /// state.
-  /// @param RecordingQueue The queues to change state on.
+  /// @param RecordingQueues The queues to change state on.
   /// @return True if any queue had its state changed from recording to
   /// executing.
   bool end_recording(const std::vector<queue> &RecordingQueues);
 
 private:
-  /// Constructor used internally by the runtime
-  /// @param Impl Detail implementation class to construct object with
+  /// Constructor used internally by the runtime.
+  /// @param Impl Detail implementation class to construct object with.
   command_graph(const std::shared_ptr<detail::graph_impl> &Impl) : impl(Impl) {}
 
-  /// Template-less implementation of add() for CGF nodes
-  /// @param CGF command-group function to add
-  /// @param Dep list of predecessor nodes
-  /// @return Node added to the graph
+  /// Template-less implementation of add() for CGF nodes.
+  /// @param CGF Command-group function to add.
+  /// @param Dep List of predecessor nodes.
+  /// @return Node added to the graph.
   node add_impl(std::function<void(handler &)> CGF,
                 const std::vector<node> &Dep);
 
-  /// Template-less implementation of add() for empty nodes
-  /// @param Dep list of predecessor nodes
-  /// @return Node added to the graph
+  /// Template-less implementation of add() for empty nodes.
+  /// @param Dep List of predecessor nodes.
+  /// @return Node added to the graph.
   node add_impl(const std::vector<node> &Dep);
 
   template <class Obj>
@@ -197,17 +197,17 @@ private:
 
 template <> class __SYCL_EXPORT command_graph<graph_state::executable> {
 public:
-  /// An executable command-graph is not user constructable
+  /// An executable command-graph is not user constructable.
   command_graph() = delete;
 
-  /// Constructor used by internal runtime
-  /// @param Graph Detail implementation class to construct with
-  /// @param Ctx Context to use for graph
+  /// Constructor used by internal runtime.
+  /// @param Graph Detail implementation class to construct with.
+  /// @param Ctx Context to use for graph.
   command_graph(const std::shared_ptr<detail::graph_impl> &Graph,
                 const sycl::context &Ctx);
 
-  /// Update the inputs & output of the graph
-  /// @param Graph Graph to use the inputs and outputs of
+  /// Update the inputs & output of the graph.
+  /// @param Graph Graph to use the inputs and outputs of.
   void update(const command_graph<graph_state::modifiable> &Graph);
 
 private:
@@ -215,7 +215,7 @@ private:
   friend decltype(Obj::impl)
   sycl::detail::getSyclObjImpl(const Obj &SyclObject);
 
-  /// Creates a backend representation of the graph in impl
+  /// Creates a backend representation of the graph in \p impl member variable.
   void finalize_impl();
 
   int MTag;

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -46,13 +46,11 @@ void connect_to_exit_nodes(
 
 /// Recursive check if a graph node or its successors contains a given kernel
 /// argument.
-///
 /// @param[in] Arg The kernel argument to check for.
 /// @param[in] CurrentNode The current graph node being checked.
 /// @param[in,out] Deps The unique list of dependencies which have been
 /// identified for this arg.
-///
-/// @return True if a dependency was added in this node of any of its
+/// @return True if a dependency was added in this node or any of its
 /// successors.
 bool check_for_arg(const sycl::detail::ArgDesc &Arg,
                    const std::shared_ptr<node_impl> &CurrentNode,
@@ -249,8 +247,6 @@ void exec_graph_impl::find_real_deps(std::vector<RT::PiExtSyncPoint> &Deps,
   }
 }
 
-// Enqueue a node directly to the command buffer without going through the
-// scheduler.
 RT::PiExtSyncPoint exec_graph_impl::enqueue_node_direct(
     sycl::context Ctx, sycl::detail::DeviceImplPtr DeviceImpl,
     RT::PiExtCommandBuffer CommandBuffer, std::shared_ptr<node_impl> Node) {

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -25,10 +25,10 @@ namespace detail {
 
 namespace {
 
-/// Recursively check if a given node is an exit node and add the new nodes as
+/// Recursively check if a given node is an exit node, and add the new nodes as
 /// successors if so.
-/// @param[in] CurrentNode Node to check as exit node
-/// @param[in] NewInputs Noes to add as sucessors
+/// @param[in] CurrentNode Node to check as exit node.
+/// @param[in] NewInputs Noes to add as successors.
 void connect_to_exit_nodes(
     std::shared_ptr<node_impl> CurrentNode,
     const std::vector<std::shared_ptr<node_impl>> &NewInputs) {
@@ -52,7 +52,7 @@ void connect_to_exit_nodes(
 /// @param[in,out] Deps The unique list of dependencies which have been
 /// identified for this arg.
 ///
-/// @returns True if a dependency was added in this node of any of its
+/// @return True if a dependency was added in this node of any of its
 /// successors.
 bool check_for_arg(const sycl::detail::ArgDesc &Arg,
                    const std::shared_ptr<node_impl> &CurrentNode,

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -23,16 +23,12 @@ namespace oneapi {
 namespace experimental {
 namespace detail {
 
-void exec_graph_impl::schedule() {
-  if (MSchedule.empty()) {
-    for (auto Node : MGraphImpl->MRoots) {
-      Node->topology_sort(Node, MSchedule);
-    }
-  }
-}
+namespace {
 
-// Recursively check if a given node is an exit node and add the new nodes as
-// successors if so.
+/// Recursively check if a given node is an exit node and add the new nodes as
+/// successors if so.
+/// @param[in] CurrentNode Node to check as exit node
+/// @param[in] NewInputs Noes to add as sucessors
 void connect_to_exit_nodes(
     std::shared_ptr<node_impl> CurrentNode,
     const std::vector<std::shared_ptr<node_impl>> &NewInputs) {
@@ -44,6 +40,41 @@ void connect_to_exit_nodes(
   } else {
     for (auto Input : NewInputs) {
       CurrentNode->register_successor(Input, CurrentNode);
+    }
+  }
+}
+
+/// Recursive check if a graph node or its successors contains a given kernel
+/// argument.
+///
+/// @param[in] Arg The kernel argument to check for.
+/// @param[in] CurrentNode The current graph node being checked.
+/// @param[in,out] Deps The unique list of dependencies which have been
+/// identified for this arg.
+///
+/// @returns True if a dependency was added in this node of any of its
+/// successors.
+bool check_for_arg(const sycl::detail::ArgDesc &Arg,
+                   const std::shared_ptr<node_impl> &CurrentNode,
+                   std::set<std::shared_ptr<node_impl>> &Deps) {
+  bool SuccessorAddedDep = false;
+  for (auto &Successor : CurrentNode->MSuccessors) {
+    SuccessorAddedDep |= check_for_arg(Arg, Successor, Deps);
+  }
+
+  if (Deps.find(CurrentNode) == Deps.end() && CurrentNode->has_arg(Arg) &&
+      !SuccessorAddedDep) {
+    Deps.insert(CurrentNode);
+    return true;
+  }
+  return SuccessorAddedDep;
+}
+} // anonymous namespace
+
+void exec_graph_impl::schedule() {
+  if (MSchedule.empty()) {
+    for (auto Node : MGraphImpl->MRoots) {
+      Node->topology_sort(Node, MSchedule);
     }
   }
 }
@@ -87,32 +118,6 @@ void graph_impl::add_root(const std::shared_ptr<node_impl> &Root) {
 
 void graph_impl::remove_root(const std::shared_ptr<node_impl> &Root) {
   MRoots.erase(Root);
-}
-
-// Recursive check if a graph node or its successors contains a given kernel
-// argument.
-//
-// @param[in] Arg The kernel argument to check for.
-// @param[in] CurrentNode The current graph node being checked.
-// @param[in,out] Deps The unique list of dependencies which have been
-// identified for this arg.
-//
-// @returns True if a dependency was added in this node of any of its
-// successors.
-bool check_for_arg(const sycl::detail::ArgDesc &Arg,
-                   const std::shared_ptr<node_impl> &CurrentNode,
-                   std::set<std::shared_ptr<node_impl>> &Deps) {
-  bool SuccessorAddedDep = false;
-  for (auto &Successor : CurrentNode->MSuccessors) {
-    SuccessorAddedDep |= check_for_arg(Arg, Successor, Deps);
-  }
-
-  if (Deps.find(CurrentNode) == Deps.end() && CurrentNode->has_arg(Arg) &&
-      !SuccessorAddedDep) {
-    Deps.insert(CurrentNode);
-    return true;
-  }
-  return SuccessorAddedDep;
 }
 
 std::shared_ptr<node_impl>
@@ -463,9 +468,9 @@ sycl::event exec_graph_impl::enqueue(
 
 template <>
 command_graph<graph_state::modifiable>::command_graph(
-    const sycl::context &syclContext, const sycl::device &syclDevice,
+    const sycl::context &SyclContext, const sycl::device &SyclDevice,
     const sycl::property_list &)
-    : impl(std::make_shared<detail::graph_impl>(syclContext, syclDevice)) {}
+    : impl(std::make_shared<detail::graph_impl>(SyclContext, SyclDevice)) {}
 
 template <>
 node command_graph<graph_state::modifiable>::add_impl(
@@ -493,12 +498,11 @@ node command_graph<graph_state::modifiable>::add_impl(
 }
 
 template <>
-void command_graph<graph_state::modifiable>::make_edge(node Sender,
-                                                       node Receiver) {
+void command_graph<graph_state::modifiable>::make_edge(node &Src, node &Dest) {
   std::shared_ptr<detail::node_impl> SenderImpl =
-      sycl::detail::getSyclObjImpl(Sender);
+      sycl::detail::getSyclObjImpl(Src);
   std::shared_ptr<detail::node_impl> ReceiverImpl =
-      sycl::detail::getSyclObjImpl(Receiver);
+      sycl::detail::getSyclObjImpl(Dest);
 
   SenderImpl->register_successor(ReceiverImpl,
                                  SenderImpl); // register successor
@@ -515,7 +519,7 @@ command_graph<graph_state::modifiable>::finalize(
 
 template <>
 bool command_graph<graph_state::modifiable>::begin_recording(
-    queue RecordingQueue) {
+    queue &RecordingQueue) {
   auto QueueImpl = sycl::detail::getSyclObjImpl(RecordingQueue);
   if (QueueImpl->getCommandGraph() == nullptr) {
     QueueImpl->setCommandGraph(impl);
@@ -535,7 +539,7 @@ template <>
 bool command_graph<graph_state::modifiable>::begin_recording(
     const std::vector<queue> &RecordingQueues) {
   bool QueueStateChanged = false;
-  for (auto &Queue : RecordingQueues) {
+  for (queue Queue : RecordingQueues) {
     QueueStateChanged |= this->begin_recording(Queue);
   }
   return QueueStateChanged;
@@ -547,7 +551,7 @@ template <> bool command_graph<graph_state::modifiable>::end_recording() {
 
 template <>
 bool command_graph<graph_state::modifiable>::end_recording(
-    queue RecordingQueue) {
+    queue &RecordingQueue) {
   auto QueueImpl = sycl::detail::getSyclObjImpl(RecordingQueue);
   if (QueueImpl->getCommandGraph() == impl) {
     QueueImpl->setCommandGraph(nullptr);
@@ -567,7 +571,7 @@ template <>
 bool command_graph<graph_state::modifiable>::end_recording(
     const std::vector<queue> &RecordingQueues) {
   bool QueueStateChanged = false;
-  for (auto &Queue : RecordingQueues) {
+  for (queue Queue : RecordingQueues) {
     QueueStateChanged |= this->end_recording(Queue);
   }
   return QueueStateChanged;
@@ -588,6 +592,13 @@ void command_graph<graph_state::executable>::finalize_impl() {
     impl->create_pi_command_buffers(device);
   }
 #endif
+}
+
+void command_graph<graph_state::executable>::update(
+    const command_graph<graph_state::modifiable> &Graph) {
+  (void)Graph;
+  throw sycl::exception(make_error_code(errc::invalid),
+                        "Method not yet implemented");
 }
 
 } // namespace experimental

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -28,13 +28,14 @@ namespace oneapi {
 namespace experimental {
 namespace detail {
 
+/// Implementation of node class from SYCL_EXT_ONEAPI_GRAPH
 struct node_impl {
-  // List of successors to this node.
+  /// List of successors to this node.
   std::vector<std::shared_ptr<node_impl>> MSuccessors;
-  // List of predecessors to this node. Using weak_ptr here to prevent circular
-  // references between nodes.
+  /// List of predecessors to this node
+  ///
+  /// Using weak_ptr here to prevent circular references between nodes.
   std::vector<std::weak_ptr<node_impl>> MPredecessors;
-
   /// Kernel to be executed by this node
   std::shared_ptr<sycl::detail::kernel_impl> MKernel;
   /// Description of the kernel global and local sizes as well as offset
@@ -44,35 +45,57 @@ struct node_impl {
       sycl::detail::OSUtil::ExeModuleHandle;
   /// Kernel name inside the module
   std::string MKernelName;
+
+  /// Accessor storage for node arguments
   std::vector<sycl::detail::AccessorImplPtr> MAccStorage;
+  /// Local accessor storage for node arguments
   std::vector<sycl::detail::LocalAccessorImplPtr> MLocalAccStorage;
   std::vector<std::shared_ptr<sycl::detail::stream_impl>> MStreamStorage;
+
+  /// The list of requirements to the node for the scheduling.
   std::vector<sycl::detail::AccessorImplHost *> MRequirements;
   sycl::detail::CG::CGTYPE MCGType = sycl::detail::CG::None;
 
   /// Store arg descriptors for the kernel arguments
   std::vector<sycl::detail::ArgDesc> MArgs;
-  // We need to store local copies of the values pointed to by MArgs since they
-  // may go out of scope before execution.
+  /// We need to store local copies of the values pointed to by MArgs since they
+  /// may go out of scope before execution.
   std::vector<std::vector<char>> MArgStorage;
 
-  // Stores auxiliary resources used by internal operations.
+  /// Stores auxiliary resources used by internal operations.
   std::vector<std::shared_ptr<const void>> MAuxiliaryResources;
 
+  /// True if an empty node, false otherwise
   bool MIsEmpty = false;
 
+  /// Add successor to the node
+  /// @param Node node to add as a sucessor
+  /// @param Prev Predecessor to node being added as successor.
+  /// Should be a shared_ptr to `this`.
   void register_successor(const std::shared_ptr<node_impl> &Node,
                           const std::shared_ptr<node_impl> &Prev) {
     MSuccessors.push_back(Node);
     Node->register_predecessor(Prev);
   }
 
+  /// Add predecessor to the node
+  /// @param Node node to add as a predecessor
   void register_predecessor(const std::shared_ptr<node_impl> &Node) {
     MPredecessors.push_back(Node);
   }
 
+  /// Construct an empty node
   node_impl() : MIsEmpty(true) {}
 
+  /// Construct a node representing a command-group
+  /// @param Kernel Kernel to run when node executes
+  /// @param NDRDesc NDRange Decription for kernel
+  /// @param OSModuleHandle Module handle for the kernel to be executed.
+  /// @param KernelName Name of kernel
+  /// @param AccStorage Accessor storage for node arguments
+  /// @param LocalAccStorage Local accessor storage for node arguments
+  /// @param Requirements Scheduling requirements
+  /// @param Args Kernel arguments
   node_impl(
       std::shared_ptr<sycl::detail::kernel_impl> Kernel,
       sycl::detail::NDRDescT NDRDesc,
@@ -105,7 +128,9 @@ struct node_impl {
     }
   }
 
-  // Recursively adding nodes to execution stack:
+  /// Recursively add nodes to execution stack
+  /// @param NodeImpl Node to schedule
+  /// @param Schedule Execution ordering to add node to
   void topology_sort(std::shared_ptr<node_impl> NodeImpl,
                      std::list<std::shared_ptr<node_impl>> &Schedule) {
     for (auto Next : MSuccessors) {
@@ -119,6 +144,9 @@ struct node_impl {
       Schedule.push_front(NodeImpl);
   }
 
+  /// Checks if this node has an argument
+  /// @param Arg Argument to lookup
+  /// @return True if argument is used in node, false otherwise
   bool has_arg(const sycl::detail::ArgDesc &Arg) {
     for (auto &NodeArg : MArgs) {
       if (Arg.MType == NodeArg.MType && Arg.MSize == NodeArg.MSize) {
@@ -134,18 +162,41 @@ struct node_impl {
     return false;
   }
 
+  /// Query if this is an empty node
+  /// @return True if this is an empty node, false otherwise
   bool is_empty() const { return MIsEmpty; }
 };
 
+/// Class resenting implementation details of command_graph<modifiable>
 struct graph_impl {
 
-  graph_impl(const sycl::context &syclContext, const sycl::device &syclDevice)
-      : MContext(syclContext), MDevice(syclDevice), MRecordingQueues(),
+  /// Constructor
+  /// @param SyclContext context to use for graph
+  /// @param SyclDevice device to create nodes with
+  graph_impl(const sycl::context &SyclContext, const sycl::device &SyclDevice)
+      : MContext(SyclContext), MDevice(SyclDevice), MRecordingQueues(),
         MEventsMap() {}
 
-  void add_root(const std::shared_ptr<node_impl> &);
-  void remove_root(const std::shared_ptr<node_impl> &);
+  /// Insert node into list of root nodes
+  /// @param Root Node to add to list of root nodes
+  void add_root(const std::shared_ptr<node_impl> &Root);
 
+  /// Remove node from list of root nodes
+  /// @param Root Node to remove from list of root nodes
+  void remove_root(const std::shared_ptr<node_impl> &Root);
+
+  /// Create a kernel node in the graph
+  /// @param Kernel kernel to run when node executes
+  /// @param NDRDesc NDRange Decription for kernel
+  /// @param OSModuleHandle Module handle for the kernel to be executed.
+  /// @param KernelName Name of kernel
+  /// @param AccStorage Accessor storage for node arguments
+  /// @param LocalAccStorage Local accessor storage for node arguments
+  /// @param Requirements Scheduling requirements
+  /// @param Args Node arguments
+  /// @param Dep Dependencies of the created node
+  /// @param DepEvents Dependent events of the created node
+  /// @return Created node in the graph
   std::shared_ptr<node_impl>
   add(std::shared_ptr<sycl::detail::kernel_impl> Kernel,
       sycl::detail::NDRDescT NDRDesc,
@@ -159,17 +210,27 @@ struct graph_impl {
       const std::vector<std::shared_ptr<sycl::detail::event_impl>> &DepEvents =
           {});
 
+  /// Create a CGF node in the graph
+  /// @param Impl Graph implementation pointer to create a handler with
+  /// @param CGF Command Group Function to create node with
+  /// @param Args Node arguments
+  /// @param Dep Dependencies of the created node
+  /// @return Created node in the graph
   std::shared_ptr<node_impl>
   add(const std::shared_ptr<graph_impl> &Impl,
       std::function<void(handler &)> CGF,
       const std::vector<sycl::detail::ArgDesc> &Args,
       const std::vector<std::shared_ptr<node_impl>> &Dep = {});
 
+  /// Create an empty node in the graph
+  /// @param Dep List of predecessor node
+  /// @return Created node in the graph
   std::shared_ptr<node_impl>
   add(const std::vector<std::shared_ptr<node_impl>> &Dep = {});
 
   /// Add a queue to the set of queues which are currently recording to this
   /// graph.
+  /// @param RecordingQueue Queue to add to set
   void
   add_queue(const std::shared_ptr<sycl::detail::queue_impl> &RecordingQueue) {
     MRecordingQueues.insert(RecordingQueue);
@@ -177,21 +238,29 @@ struct graph_impl {
 
   /// Remove a queue from the set of queues which are currently recording to
   /// this graph.
+  /// @param RecordingQueue Queue to remove from set
   void remove_queue(
       const std::shared_ptr<sycl::detail::queue_impl> &RecordingQueue) {
     MRecordingQueues.erase(RecordingQueue);
   }
 
   /// Remove all queues which are recording to this graph, also sets all queues
-  /// cleared back to the executing state. \return True if any queues were
-  /// removed.
+  /// cleared back to the executing state.
+  ///
+  /// @return True if any queues were removed.
   bool clear_queues();
 
+  /// Associate a sycl event with a node in the graph
+  /// @param EventImpl event to associate with a node in map
+  /// @param NodeImpl node to associate with event in map
   void add_event_for_node(std::shared_ptr<sycl::detail::event_impl> EventImpl,
                           std::shared_ptr<node_impl> NodeImpl) {
     MEventsMap[EventImpl] = NodeImpl;
   }
 
+  /// Find the sycl event associated with a node
+  /// @param NodeImpl Node to find event for
+  /// @return event associated with node
   std::shared_ptr<sycl::detail::event_impl>
   get_event_for_node(std::shared_ptr<node_impl> NodeImpl) const {
     if (auto EventImpl = std::find_if(
@@ -206,49 +275,71 @@ struct graph_impl {
         "No event has been recorded for the specified graph node");
   }
 
-  /// Adds subgraph nodes from an executable graph to this graph, returns
-  /// an empty node is used to schedule dependencies on this sub graph.
+  /// Adds subgraph nodes from an executable graph to this graph
+  /// @return An empty node is used to schedule dependencies on this sub graph.
   std::shared_ptr<node_impl>
   add_subgraph_nodes(const std::list<std::shared_ptr<node_impl>> &NodeList);
+
+  /// Query for the context tied to this graph
+  /// @return context associated with graph
   sycl::context get_context() const { return MContext; }
 
+  /// List of root nodes
   std::set<std::shared_ptr<node_impl>> MRoots;
-  std::shared_ptr<graph_impl> MParent;
 
 private:
-  // Context associated with this graph.
+  /// Context associated with this graph.
   sycl::context MContext;
-  // Device associated with this graph. All graph nodes will execute on this
-  // device.
+  /// Device associated with this graph. All graph nodes will execute on this
+  /// device.
   sycl::device MDevice;
-  // Unique set of queues which are currently recording to this graph.
+  /// Unique set of queues which are currently recording to this graph.
   std::set<std::shared_ptr<sycl::detail::queue_impl>> MRecordingQueues;
-  // Map of events to their associated recorded nodes.
+  /// Map of events to their associated recorded nodes.
   std::unordered_map<std::shared_ptr<sycl::detail::event_impl>,
                      std::shared_ptr<node_impl>>
       MEventsMap;
 };
 
+/// Class representing the implementation of command_graph<executable>
 class exec_graph_impl {
 public:
+  /// Constructor
+  /// @param Context context to create graph with
+  /// @param GraphImp Modifiable graph implementation to create with
   exec_graph_impl(sycl::context Context,
                   const std::shared_ptr<graph_impl> &GraphImpl)
       : MSchedule(), MGraphImpl(GraphImpl), MPiCommandBuffers(),
         MPiSyncPoints(), MContext(Context) {}
+
+  /// Destructor
   ~exec_graph_impl();
+
   /// Add nodes to MSchedule
   void schedule();
+
   /// Enqueues the backend objects for the graph to the parametrized queue
-  sycl::event enqueue(const std::shared_ptr<sycl::detail::queue_impl> &);
+  /// @param Queue Command-queue to submit backend objects to
+  /// @return Event associated with enqueued object
+  sycl::event enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue);
+
   /// Called by handler::ext_oneapi_command_graph() to schedule graph for
   /// execution
-  sycl::event exec(const std::shared_ptr<sycl::detail::queue_impl> &);
+  /// @param Queue to schedule execution on.
+  /// @return Event associated with the execution of the graph
+  sycl::event exec(const std::shared_ptr<sycl::detail::queue_impl> &Queue);
+
   /// Turns our internal graph representation into PI command-buffers for a
   /// device
+  /// @param D Device to create backend command-buffers for
   void create_pi_command_buffers(sycl::device D);
 
+  /// Query for the context tied to this graph
+  /// @return context associated with graph
   sycl::context get_context() const { return MContext; }
 
+  /// Query the scheduling of node execution
+  /// @return List of nodes in execution order
   const std::list<std::shared_ptr<node_impl>> &get_schedule() const {
     return MSchedule;
   }
@@ -263,18 +354,23 @@ private:
                                          RT::PiExtCommandBuffer CommandBuffer,
                                          std::shared_ptr<node_impl> Node);
 
+  /// Iterates back through predecessors to find the real dependency.
+  /// @param[out] Deps Found dependencies
+  /// @param[in] CurrentNode Node to find dependencies for
   void find_real_deps(std::vector<RT::PiExtSyncPoint> &Deps,
                       std::shared_ptr<node_impl> CurrentNode);
+
+  /// Execution schedule of nodes in the graph
   std::list<std::shared_ptr<node_impl>> MSchedule;
-  // Pointer to the modifiable graph impl associated with this executable graph
+  /// Pointer to the modifiable graph impl associated with this executable graph
   std::shared_ptr<graph_impl> MGraphImpl;
-  // Map of devices to command buffers
+  /// Map of devices to command buffers
   std::unordered_map<sycl::device, RT::PiExtCommandBuffer> MPiCommandBuffers;
   /// Map of nodes in the exec graph to the sync point representing their
   /// execution in the command graph.
   std::unordered_map<std::shared_ptr<node_impl>, RT::PiExtSyncPoint>
       MPiSyncPoints;
-  // Context associated with this executable graph
+  /// Context associated with this executable graph
   sycl::context MContext;
   // List of requirements for enqueueing this command graph, accumulated from
   // all nodes enqueued to the graph.

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -186,8 +186,8 @@ struct graph_impl {
   void remove_root(const std::shared_ptr<node_impl> &Root);
 
   /// Create a kernel node in the graph
-  /// @param Kernel kernel to run when node executes
-  /// @param NDRDesc NDRange Decription for kernel
+  /// @param Kernel Kernel to run when node executes
+  /// @param NDRDesc NDRange decription for kernel
   /// @param OSModuleHandle Module handle for the kernel to be executed.
   /// @param KernelName Name of kernel
   /// @param AccStorage Accessor storage for node arguments
@@ -251,8 +251,8 @@ struct graph_impl {
   bool clear_queues();
 
   /// Associate a sycl event with a node in the graph
-  /// @param EventImpl event to associate with a node in map
-  /// @param NodeImpl node to associate with event in map
+  /// @param EventImpl Event to associate with a node in map
+  /// @param NodeImpl Node to associate with event in map
   void add_event_for_node(std::shared_ptr<sycl::detail::event_impl> EventImpl,
                           std::shared_ptr<node_impl> NodeImpl) {
     MEventsMap[EventImpl] = NodeImpl;
@@ -260,7 +260,7 @@ struct graph_impl {
 
   /// Find the sycl event associated with a node
   /// @param NodeImpl Node to find event for
-  /// @return event associated with node
+  /// @return Event associated with node
   std::shared_ptr<sycl::detail::event_impl>
   get_event_for_node(std::shared_ptr<node_impl> NodeImpl) const {
     if (auto EventImpl = std::find_if(
@@ -281,7 +281,7 @@ struct graph_impl {
   add_subgraph_nodes(const std::list<std::shared_ptr<node_impl>> &NodeList);
 
   /// Query for the context tied to this graph
-  /// @return context associated with graph
+  /// @return Context associated with graph
   sycl::context get_context() const { return MContext; }
 
   /// List of root nodes
@@ -305,7 +305,7 @@ private:
 class exec_graph_impl {
 public:
   /// Constructor
-  /// @param Context context to create graph with
+  /// @param Context Context to create graph with
   /// @param GraphImp Modifiable graph implementation to create with
   exec_graph_impl(sycl::context Context,
                   const std::shared_ptr<graph_impl> &GraphImpl)
@@ -335,7 +335,7 @@ public:
   void create_pi_command_buffers(sycl::device D);
 
   /// Query for the context tied to this graph
-  /// @return context associated with graph
+  /// @return Context associated with graph
   sycl::context get_context() const { return MContext; }
 
   /// Query the scheduling of node execution

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -28,27 +28,27 @@ namespace oneapi {
 namespace experimental {
 namespace detail {
 
-/// Implementation of node class from SYCL_EXT_ONEAPI_GRAPH
+/// Implementation of node class from SYCL_EXT_ONEAPI_GRAPH.
 struct node_impl {
   /// List of successors to this node.
   std::vector<std::shared_ptr<node_impl>> MSuccessors;
-  /// List of predecessors to this node
+  /// List of predecessors to this node.
   ///
   /// Using weak_ptr here to prevent circular references between nodes.
   std::vector<std::weak_ptr<node_impl>> MPredecessors;
-  /// Kernel to be executed by this node
+  /// Kernel to be executed by this node.
   std::shared_ptr<sycl::detail::kernel_impl> MKernel;
-  /// Description of the kernel global and local sizes as well as offset
+  /// Description of the kernel global and local sizes as well as offset.
   sycl::detail::NDRDescT MNDRDesc;
   /// Module handle for the kernel to be executed.
   sycl::detail::OSModuleHandle MOSModuleHandle =
       sycl::detail::OSUtil::ExeModuleHandle;
-  /// Kernel name inside the module
+  /// Kernel name inside the module.
   std::string MKernelName;
 
-  /// Accessor storage for node arguments
+  /// Accessor storage for node arguments.
   std::vector<sycl::detail::AccessorImplPtr> MAccStorage;
-  /// Local accessor storage for node arguments
+  /// Local accessor storage for node arguments.
   std::vector<sycl::detail::LocalAccessorImplPtr> MLocalAccStorage;
   std::vector<std::shared_ptr<sycl::detail::stream_impl>> MStreamStorage;
 
@@ -56,7 +56,7 @@ struct node_impl {
   std::vector<sycl::detail::AccessorImplHost *> MRequirements;
   sycl::detail::CG::CGTYPE MCGType = sycl::detail::CG::None;
 
-  /// Store arg descriptors for the kernel arguments
+  /// Store arg descriptors for the kernel arguments.
   std::vector<sycl::detail::ArgDesc> MArgs;
   /// We need to store local copies of the values pointed to by MArgs since they
   /// may go out of scope before execution.
@@ -65,37 +65,39 @@ struct node_impl {
   /// Stores auxiliary resources used by internal operations.
   std::vector<std::shared_ptr<const void>> MAuxiliaryResources;
 
-  /// True if an empty node, false otherwise
+  /// True if an empty node, false otherwise.
   bool MIsEmpty = false;
 
-  /// Add successor to the node
-  /// @param Node node to add as a sucessor
-  /// @param Prev Predecessor to node being added as successor.
-  /// Should be a shared_ptr to `this`.
+  /// Add successor to the node.
+  /// @param Node Node to add as a successor.
+  /// @param Prev Predecessor to \p node being added as successor.
+  ///
+  /// /p Prev should be a shared_ptr to an instance of this object, but can't
+  /// use a raw \p this pointer, so the extra \Prev parameter is passed.
   void register_successor(const std::shared_ptr<node_impl> &Node,
                           const std::shared_ptr<node_impl> &Prev) {
     MSuccessors.push_back(Node);
     Node->register_predecessor(Prev);
   }
 
-  /// Add predecessor to the node
-  /// @param Node node to add as a predecessor
+  /// Add predecessor to the node.
+  /// @param Node Node to add as a predecessor.
   void register_predecessor(const std::shared_ptr<node_impl> &Node) {
     MPredecessors.push_back(Node);
   }
 
-  /// Construct an empty node
+  /// Construct an empty node.
   node_impl() : MIsEmpty(true) {}
 
-  /// Construct a node representing a command-group
-  /// @param Kernel Kernel to run when node executes
-  /// @param NDRDesc NDRange Decription for kernel
+  /// Construct a node representing a command-group.
+  /// @param Kernel Kernel to run when node executes.
+  /// @param NDRDesc NDRange description for kernel.
   /// @param OSModuleHandle Module handle for the kernel to be executed.
-  /// @param KernelName Name of kernel
-  /// @param AccStorage Accessor storage for node arguments
-  /// @param LocalAccStorage Local accessor storage for node arguments
-  /// @param Requirements Scheduling requirements
-  /// @param Args Kernel arguments
+  /// @param KernelName Name of kernel.
+  /// @param AccStorage Accessor storage for node arguments.
+  /// @param LocalAccStorage Local accessor storage for node arguments.
+  /// @param Requirements Scheduling requirements.
+  /// @param Args Kernel arguments.
   node_impl(
       std::shared_ptr<sycl::detail::kernel_impl> Kernel,
       sycl::detail::NDRDescT NDRDesc,
@@ -128,9 +130,9 @@ struct node_impl {
     }
   }
 
-  /// Recursively add nodes to execution stack
-  /// @param NodeImpl Node to schedule
-  /// @param Schedule Execution ordering to add node to
+  /// Recursively add nodes to execution stack.
+  /// @param NodeImpl Node to schedule.
+  /// @param Schedule Execution ordering to add node to.
   void topology_sort(std::shared_ptr<node_impl> NodeImpl,
                      std::list<std::shared_ptr<node_impl>> &Schedule) {
     for (auto Next : MSuccessors) {
@@ -144,9 +146,9 @@ struct node_impl {
       Schedule.push_front(NodeImpl);
   }
 
-  /// Checks if this node has an argument
-  /// @param Arg Argument to lookup
-  /// @return True if argument is used in node, false otherwise
+  /// Checks if this node has an argument.
+  /// @param Arg Argument to lookup.
+  /// @return True if \p Arg is used in node, false otherwise.
   bool has_arg(const sycl::detail::ArgDesc &Arg) {
     for (auto &NodeArg : MArgs) {
       if (Arg.MType == NodeArg.MType && Arg.MSize == NodeArg.MSize) {
@@ -162,41 +164,40 @@ struct node_impl {
     return false;
   }
 
-  /// Query if this is an empty node
-  /// @return True if this is an empty node, false otherwise
+  /// Query if this is an empty node.
+  /// @return True if this is an empty node, false otherwise.
   bool is_empty() const { return MIsEmpty; }
 };
 
-/// Class resenting implementation details of command_graph<modifiable>
+/// Class resenting implementation details of command_graph<modifiable>.
 struct graph_impl {
-
-  /// Constructor
-  /// @param SyclContext context to use for graph
-  /// @param SyclDevice device to create nodes with
+  /// Constructor.
+  /// @param SyclContext Context to use for graph.
+  /// @param SyclDevice Device to create nodes with.
   graph_impl(const sycl::context &SyclContext, const sycl::device &SyclDevice)
       : MContext(SyclContext), MDevice(SyclDevice), MRecordingQueues(),
         MEventsMap() {}
 
-  /// Insert node into list of root nodes
-  /// @param Root Node to add to list of root nodes
+  /// Insert node into list of root nodes.
+  /// @param Root Node to add to list of root nodes.
   void add_root(const std::shared_ptr<node_impl> &Root);
 
-  /// Remove node from list of root nodes
-  /// @param Root Node to remove from list of root nodes
+  /// Remove node from list of root nodes.
+  /// @param Root Node to remove from list of root nodes.
   void remove_root(const std::shared_ptr<node_impl> &Root);
 
-  /// Create a kernel node in the graph
-  /// @param Kernel Kernel to run when node executes
-  /// @param NDRDesc NDRange decription for kernel
+  /// Create a kernel node in the graph.
+  /// @param Kernel Kernel to run when node executes.
+  /// @param NDRDesc NDRange description for kernel.
   /// @param OSModuleHandle Module handle for the kernel to be executed.
-  /// @param KernelName Name of kernel
-  /// @param AccStorage Accessor storage for node arguments
-  /// @param LocalAccStorage Local accessor storage for node arguments
-  /// @param Requirements Scheduling requirements
-  /// @param Args Node arguments
-  /// @param Dep Dependencies of the created node
-  /// @param DepEvents Dependent events of the created node
-  /// @return Created node in the graph
+  /// @param KernelName Name of kernel.
+  /// @param AccStorage Accessor storage for node arguments.
+  /// @param LocalAccStorage Local accessor storage for node arguments.
+  /// @param Requirements Scheduling requirements.
+  /// @param Args Node arguments.
+  /// @param Dep Dependencies of the created node.
+  /// @param DepEvents Dependent events of the created node.
+  /// @return Created node in the graph.
   std::shared_ptr<node_impl>
   add(std::shared_ptr<sycl::detail::kernel_impl> Kernel,
       sycl::detail::NDRDescT NDRDesc,
@@ -210,27 +211,27 @@ struct graph_impl {
       const std::vector<std::shared_ptr<sycl::detail::event_impl>> &DepEvents =
           {});
 
-  /// Create a CGF node in the graph
-  /// @param Impl Graph implementation pointer to create a handler with
-  /// @param CGF Command Group Function to create node with
-  /// @param Args Node arguments
-  /// @param Dep Dependencies of the created node
-  /// @return Created node in the graph
+  /// Create a CGF node in the graph.
+  /// @param Impl Graph implementation pointer to create a handler with.
+  /// @param CGF Command-group function to create node with.
+  /// @param Args Node arguments.
+  /// @param Dep Dependencies of the created node.
+  /// @return Created node in the graph.
   std::shared_ptr<node_impl>
   add(const std::shared_ptr<graph_impl> &Impl,
       std::function<void(handler &)> CGF,
       const std::vector<sycl::detail::ArgDesc> &Args,
       const std::vector<std::shared_ptr<node_impl>> &Dep = {});
 
-  /// Create an empty node in the graph
-  /// @param Dep List of predecessor node
-  /// @return Created node in the graph
+  /// Create an empty node in the graph.
+  /// @param Dep List of predecessor nodes.
+  /// @return Created node in the graph.
   std::shared_ptr<node_impl>
   add(const std::vector<std::shared_ptr<node_impl>> &Dep = {});
 
   /// Add a queue to the set of queues which are currently recording to this
   /// graph.
-  /// @param RecordingQueue Queue to add to set
+  /// @param RecordingQueue Queue to add to set.
   void
   add_queue(const std::shared_ptr<sycl::detail::queue_impl> &RecordingQueue) {
     MRecordingQueues.insert(RecordingQueue);
@@ -238,7 +239,7 @@ struct graph_impl {
 
   /// Remove a queue from the set of queues which are currently recording to
   /// this graph.
-  /// @param RecordingQueue Queue to remove from set
+  /// @param RecordingQueue Queue to remove from set.
   void remove_queue(
       const std::shared_ptr<sycl::detail::queue_impl> &RecordingQueue) {
     MRecordingQueues.erase(RecordingQueue);
@@ -250,17 +251,17 @@ struct graph_impl {
   /// @return True if any queues were removed.
   bool clear_queues();
 
-  /// Associate a sycl event with a node in the graph
-  /// @param EventImpl Event to associate with a node in map
-  /// @param NodeImpl Node to associate with event in map
+  /// Associate a sycl event with a node in the graph.
+  /// @param EventImpl Event to associate with a node in map.
+  /// @param NodeImpl Node to associate with event in map.
   void add_event_for_node(std::shared_ptr<sycl::detail::event_impl> EventImpl,
                           std::shared_ptr<node_impl> NodeImpl) {
     MEventsMap[EventImpl] = NodeImpl;
   }
 
-  /// Find the sycl event associated with a node
-  /// @param NodeImpl Node to find event for
-  /// @return Event associated with node
+  /// Find the sycl event associated with a node.
+  /// @param NodeImpl Node to find event for.
+  /// @return Event associated with node.
   std::shared_ptr<sycl::detail::event_impl>
   get_event_for_node(std::shared_ptr<node_impl> NodeImpl) const {
     if (auto EventImpl = std::find_if(
@@ -275,16 +276,16 @@ struct graph_impl {
         "No event has been recorded for the specified graph node");
   }
 
-  /// Adds subgraph nodes from an executable graph to this graph
-  /// @return An empty node is used to schedule dependencies on this sub graph.
+  /// Adds sub-graph nodes from an executable graph to this graph.
+  /// @return An empty node is used to schedule dependencies on this sub-graph.
   std::shared_ptr<node_impl>
   add_subgraph_nodes(const std::list<std::shared_ptr<node_impl>> &NodeList);
 
-  /// Query for the context tied to this graph
-  /// @return Context associated with graph
+  /// Query for the context tied to this graph.
+  /// @return Context associated with graph.
   sycl::context get_context() const { return MContext; }
 
-  /// List of root nodes
+  /// List of root nodes.
   std::set<std::shared_ptr<node_impl>> MRoots;
 
 private:
@@ -301,45 +302,47 @@ private:
       MEventsMap;
 };
 
-/// Class representing the implementation of command_graph<executable>
+/// Class representing the implementation of command_graph<executable>.
 class exec_graph_impl {
 public:
-  /// Constructor
-  /// @param Context Context to create graph with
-  /// @param GraphImp Modifiable graph implementation to create with
+  /// Constructor.
+  /// @param Context Context to create graph with.
+  /// @param GraphImpl Modifiable graph implementation to create with.
   exec_graph_impl(sycl::context Context,
                   const std::shared_ptr<graph_impl> &GraphImpl)
       : MSchedule(), MGraphImpl(GraphImpl), MPiCommandBuffers(),
         MPiSyncPoints(), MContext(Context) {}
 
-  /// Destructor
+  /// Destructor.
+  ///
+  /// Releases any PI command-buffers the object has created.
   ~exec_graph_impl();
 
-  /// Add nodes to MSchedule
+  /// Add nodes to MSchedule.
   void schedule();
 
-  /// Enqueues the backend objects for the graph to the parametrized queue
-  /// @param Queue Command-queue to submit backend objects to
-  /// @return Event associated with enqueued object
+  /// Enqueues the backend objects for the graph to the parametrized queue.
+  /// @param Queue Command-queue to submit backend objects to.
+  /// @return Event associated with enqueued object.
   sycl::event enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue);
 
   /// Called by handler::ext_oneapi_command_graph() to schedule graph for
-  /// execution
-  /// @param Queue to schedule execution on.
+  /// execution.
+  /// @param Queue Command-queue to schedule execution on.
   /// @return Event associated with the execution of the graph
   sycl::event exec(const std::shared_ptr<sycl::detail::queue_impl> &Queue);
 
   /// Turns our internal graph representation into PI command-buffers for a
-  /// device
-  /// @param D Device to create backend command-buffers for
+  /// device.
+  /// @param D Device to create backend command-buffers for.
   void create_pi_command_buffers(sycl::device D);
 
-  /// Query for the context tied to this graph
-  /// @return Context associated with graph
+  /// Query for the context tied to this graph.
+  /// @return Context associated with graph.
   sycl::context get_context() const { return MContext; }
 
-  /// Query the scheduling of node execution
-  /// @return List of nodes in execution order
+  /// Query the scheduling of node execution.
+  /// @return List of nodes in execution order.
   const std::list<std::shared_ptr<node_impl>> &get_schedule() const {
     return MSchedule;
   }
@@ -355,22 +358,25 @@ private:
                                          std::shared_ptr<node_impl> Node);
 
   /// Iterates back through predecessors to find the real dependency.
-  /// @param[out] Deps Found dependencies
-  /// @param[in] CurrentNode Node to find dependencies for
+  /// @param[out] Deps Found dependencies.
+  /// @param[in] CurrentNode Node to find dependencies for.
   void find_real_deps(std::vector<RT::PiExtSyncPoint> &Deps,
                       std::shared_ptr<node_impl> CurrentNode);
 
-  /// Execution schedule of nodes in the graph
+  /// Execution schedule of nodes in the graph.
   std::list<std::shared_ptr<node_impl>> MSchedule;
-  /// Pointer to the modifiable graph impl associated with this executable graph
+  /// Pointer to the modifiable graph impl associated with this executable
+  /// graph.
   std::shared_ptr<graph_impl> MGraphImpl;
-  /// Map of devices to command buffers
+  /// Map of devices to command buffers.
   std::unordered_map<sycl::device, RT::PiExtCommandBuffer> MPiCommandBuffers;
+  /// Map of devices to command buffers.
+  std::unordered_map<sycl::device, pi_ext_command_buffer> MPiCommandBuffers;
   /// Map of nodes in the exec graph to the sync point representing their
   /// execution in the command graph.
   std::unordered_map<std::shared_ptr<node_impl>, RT::PiExtSyncPoint>
       MPiSyncPoints;
-  /// Context associated with this executable graph
+  /// Context associated with this executable graph.
   sycl::context MContext;
   // List of requirements for enqueueing this command graph, accumulated from
   // all nodes enqueued to the graph.


### PR DESCRIPTION
As well as the doxygen comments there are some additional changes I found along the way:
* Pass queue by reference to `begin_recording()` & `end_recording()`
* Pass node by reference to `make_edge()`
* Add stubbed out `update()` entry-point
* Remove unused `MParent` variable