### PR TITLE
[SYCL][Graph] Test using USM fill operation in nodes

### DIFF
--- a/sycl/test/graph/graph-explicit-fill-usm.cpp
+++ b/sycl/test/graph/graph-explicit-fill-usm.cpp
@@ -1,0 +1,31 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+int main() {
+
+  sycl::queue q{sycl::gpu_selector_v};
+
+  sycl::ext::oneapi::experimental::command_graph g{q.get_context(),
+                                                   q.get_device()};
+
+  const size_t n = 10;
+  float *arr = sycl::malloc_shared<float>(n, q);
+
+  float pattern = 3.14;
+  auto nodeA = g.add([&](sycl::handler &h) { h.fill(arr, pattern, n); });
+
+  auto executable_graph = g.finalize();
+
+  q.submit([&](sycl::handler &h) {
+     h.ext_oneapi_graph(executable_graph);
+   }).wait();
+
+  for (int i = 0; i < n; i++)
+    assert(arr[i] == pattern);
+
+  sycl::free(arr, q);
+
+  return 0;
+}

--- a/sycl/test/graph/graph-explicit-fill-usm.cpp
+++ b/sycl/test/graph/graph-explicit-fill-usm.cpp
@@ -13,7 +13,7 @@ int main() {
   const size_t n = 10;
   float *arr = sycl::malloc_shared<float>(n, q);
 
-  float pattern = 3.14;
+  float pattern = 3.14f;
   auto nodeA = g.add([&](sycl::handler &h) { h.fill(arr, pattern, n); });
 
   auto executable_graph = g.finalize();

--- a/sycl/test/graph/graph-record-fill-usm.cpp
+++ b/sycl/test/graph/graph-record-fill-usm.cpp
@@ -1,0 +1,63 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+int main() {
+
+  sycl::queue q{sycl::gpu_selector_v};
+
+  syclexp::command_graph g{q.get_context(), q.get_device()};
+
+  const size_t n = 10;
+  float *arr = sycl::malloc_shared<float>(n, q);
+
+  g.begin_recording(q);
+  float patternA = 1.0f;
+  auto eventA = q.fill(arr, patternA, n);
+  g.end_recording(q);
+  auto execGraphA = g.finalize();
+
+  g.begin_recording(q);
+  float patternB = 2.0f;
+  auto eventB = q.fill(arr, patternB, n, eventA);
+  g.end_recording(q);
+  auto execGraphB = g.finalize();
+
+  g.begin_recording(q);
+  float patternC = 3.0f;
+  auto eventC = q.fill(arr, patternC, n, {eventA, eventB});
+  g.end_recording(q);
+  auto execGraphC = g.finalize();
+
+  g.begin_recording(q);
+  float patternD = 3.14f;
+  q.submit([&](sycl::handler &h) {
+    h.depends_on(eventC);
+    h.fill(arr, patternD, n);
+  });
+  g.end_recording(q);
+  auto execGraphD = g.finalize();
+
+  auto verifyLambda =
+      [&](syclexp::command_graph<syclexp::graph_state::executable> execGraph,
+          float pattern) {
+        q.submit([&](sycl::handler &h) {
+           h.ext_oneapi_graph(execGraph);
+         }).wait();
+
+        for (int i = 0; i < n; i++)
+          assert(arr[i] == pattern);
+      };
+
+  verifyLambda(execGraphA, patternA);
+  verifyLambda(execGraphB, patternB);
+  verifyLambda(execGraphC, patternC);
+  verifyLambda(execGraphD, patternD);
+
+  sycl::free(arr, q);
+
+  return 0;
+}


### PR DESCRIPTION
Using a `handler::fill()` operation in nodes works without any further modifications because the DPC++ runtime implements it as a `parallel_for` which we already support.

See [handler.hpp](https://github.com/intel/llvm/blob/sycl/sycl/include/sycl/handler.hpp#L2453-L2467)
```cpp
  /// Fills the specified memory with the specified pattern.
  ///
  /// \param Ptr is the pointer to the memory to fill
  /// \param Pattern is the pattern to fill into the memory.  T should be
  /// trivially copyable.
  /// \param Count is the number of times to fill Pattern into Ptr.
  template <typename T> void fill(void *Ptr, const T &Pattern, size_t Count) {
    throwIfActionIsCreated();
    static_assert(std::is_trivially_copyable<T>::value,
                  "Pattern must be trivially copyable");
    parallel_for<class __usmfill<T>>(range<1>(Count), [=](id<1> Index) {
      T *CastedPtr = static_cast<T *>(Ptr);
      CastedPtr[Index] = Pattern;
    });
  }
```

Not that there is a different fill implementation for buffer accessors, which this PR doesn't cover, but is tracked as work in [issue 146](https://github.com/reble/llvm/issues/146)

Closes https://github.com/reble/llvm/issues/149