### PR TITLE
[SYCL] Fixing type deduction and declaration mismatch

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -223,6 +223,11 @@ private:
   std::shared_ptr<detail::exec_graph_impl> impl;
 };
 
+// additional deduction guide
+template <graph_state State = graph_state::modifiable>
+command_graph(const context &SyclContext, const device &SyclDevice,
+              const property_list &PropList) -> command_graph<State>;
+
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -26,7 +26,7 @@ namespace oneapi {
 namespace experimental {
 
 namespace detail {
-struct node_impl;
+class node_impl;
 class graph_impl;
 class exec_graph_impl;
 

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -223,7 +223,7 @@ private:
   std::shared_ptr<detail::exec_graph_impl> impl;
 };
 
-// additional deduction guide
+/// Additional CTAD deduction guide.
 template <graph_state State = graph_state::modifiable>
 command_graph(const context &SyclContext, const device &SyclDevice,
               const property_list &PropList) -> command_graph<State>;

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -29,7 +29,8 @@ namespace experimental {
 namespace detail {
 
 /// Implementation of node class from SYCL_EXT_ONEAPI_GRAPH.
-struct node_impl {
+class node_impl {
+public:
   /// List of successors to this node.
   std::vector<std::shared_ptr<node_impl>> MSuccessors;
   /// List of predecessors to this node.
@@ -172,7 +173,8 @@ struct node_impl {
 };
 
 /// Class resenting implementation details of command_graph<modifiable>.
-struct graph_impl {
+class graph_impl {
+public:
   /// Constructor.
   /// @param SyclContext Context to use for graph.
   /// @param SyclDevice Device to create nodes with.


### PR DESCRIPTION
Mixing struct vs class declarations causing warnings on Windows.

Adding a deduction guide to suppress warning. 
And fixing error when compiling with flag -Werror=ctad-maybe-unsupported