### PR TITLE
[SYCL][Doc] Device query for graphs support

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -323,6 +323,20 @@ class depends_on {
 } // namespace node
 } // namespace property
 
+// Device query for level of support
+namespace info {
+namespace device {
+struct graphs_support;
+
+enum class graph_support_level {
+  unsupported = 0,
+  native,
+  emulated
+};
+
+} // namespace device
+} // namespace info
+
 class node {};
 
 // State of a graph
@@ -408,15 +422,25 @@ public:
 
 Due to the experimental nature of the extension, support is not available across
 all devices. The following device support query is added to report devices which
-are currently supported.
+are currently supported, and how that support is implemented.
 
-[source, c++]
-----
-sycl::ext::oneapi::experimental::info::device::graph_support;
-----
 
-When passed to `device::get_info<...>()`, the function returns `true` if the SYCL
-`device` supports using this graph extension.
+Table {counter: tableNumber}. Device Info Queries.
+[%header]
+|===
+| Device Descriptors | Return Type | Description
+
+|`info::device::graph_support`
+|`info::device::graph_support_level`
+|When passed to `device::get_info<...>()`, the function returns `native`
+if there is an underlying SYCL backend command-buffer construct which is used
+to propagate the graph to the backend. If no backend construct exists, or
+building on top of it has not yet been implemented, then `emulated` is
+returned. Otherwise `unsupported` is returned if the SYCL device doesn't
+support using this graph extension.
+
+|===
+
 
 === Node
 
@@ -562,8 +586,8 @@ Exceptions:
 * Throws synchronously with error code `invalid` if `syclDevice` is not
 associated with `syclContext`.
 
-* Throws synchronously with error code `invalid` if `syclDevice` does not
-  <<device-info-query, report support for this extension>>.
+* Throws synchronously with error code `invalid` if `syclDevice`
+  <<device-info-query, reports this extension as unsupported>>.
 
 |===
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -404,6 +404,20 @@ public:
 }  // namespace sycl
 ----
 
+=== Device Info Query
+
+Due to the experimental nature of the extension, support is not available across
+all devices. The following device support query is added to report devices which
+are currently supported.
+
+[source, c++]
+----
+sycl::ext::oneapi::experimental::info::device::graph_support;
+----
+
+When passed to `device::get_info<...>()`, the function returns `true` if the SYCL
+`device` supports using this graph extension.
+
 === Node
 
 :crs: https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:reference-semantics
@@ -547,6 +561,9 @@ Exceptions:
 
 * Throws synchronously with error code `invalid` if `syclDevice` is not
 associated with `syclContext`.
+
+* Throws synchronously with error code `invalid` if `syclDevice` does not
+  <<device-info-query, report support for this extension>>.
 
 |===
 


### PR DESCRIPTION
Although we have implemented an emulation mode for when a SYCL backend doesn't support PI/UR command-buffers, we don't have good implementation coverage across its usage on all possible backends.

Providing an extension support query would allow us to limit the backends we support while in experimental status. This could be to say CUDA and Level Zero, and maybe OpenCL, but we don't need to specify that here. Otherwise, users with backends we've not tested could try to use the extension and crash, even with emulation mode.

Longer term, I think we could remove this query once the implementation is more mature and we have faith in emulation mode support on all backends, but I don't think that's the case at the moment.