### PR TITLE
[SYCL] Add check for empty nodes in check_for_arg()

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -60,8 +60,8 @@ bool check_for_arg(const sycl::detail::ArgDesc &Arg,
     SuccessorAddedDep |= check_for_arg(Arg, Successor, Deps);
   }
 
-  if (Deps.find(CurrentNode) == Deps.end() && CurrentNode->has_arg(Arg) &&
-      !SuccessorAddedDep) {
+  if (!CurrentNode->is_empty() && Deps.find(CurrentNode) == Deps.end() &&
+      CurrentNode->has_arg(Arg) && !SuccessorAddedDep) {
     Deps.insert(CurrentNode);
     return true;
   }


### PR DESCRIPTION
- Empty nodes have no args so prevent calling has_arg() for them.
-  Fixes failure in RecordReplay/sub_graph_reduction