### PR TITLE
[SYCL][Graphs] Readme table of implementation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ is something we are interested in expanding on.
 | Extending lifetime of buffers used in a graph                      | Not implemented       |
 | Buffer taking a copy of host data when buffer is used in a graph   | Not implemented       |
 | Executable graph `update()`                                        | Not implemented       |
+| Recording an in-order queue preserves linear dependencies          | Not implemented       |
 | Using `handler::parallel_for` in a graph node                      | Implemented           |
 | Using `handler::single_task` in a graph node                       | Implemented           |
-| Using `handler::memcpy` in a graph node                            | Not implemented       |
+| Using `handler::memcpy` in a graph node                            | Implemented for USM, not implemented for buffer accessors |
 | Using `handler::copy` in a graph node                              | Not implemented       |
 | Using `handler::host_task` in a graph node                         | Not implemented       |
 | Using `handler::fill` in a graph node                              | Implemented for USM, not implemented for buffer accessors |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ is something we are interested in expanding on.
 | Profiling an event returned from graph submission                  | Not implemented       |
 | Querying the state of an event returned from graph submission      | Not implemented       |
 | Error checking                                                     | Throwing exceptions for invalid usage is only partially implemented |
->>>>>>> [SYCL][Graphs] Readme table of implementation coverage
 
 ### Other Material
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,47 @@ Limitations include:
 * LevelZero backend support only. A fallback emulation mode is used for correctness on other backends.
 * Accessors and reductions are currently not supported.
 
+#### Implementation Status
+
+| Feature                                                            | Implementation Status |
+| ------------------------------------------------------------------ | --------------------- |
+| Adding a command-group node with `command_graph::add()`            | Implemented           |
+| Begin & end queue recording to a graph to create nodes             | Implemented           |
+| Edges created from buffer accessor dependencies                    | Implemented           |
+| Edges created from `handler::depends_on` dependencies              | Implemented           |
+| Edges created using `make_edge()`                                  | Implemented           |
+| Edges created by passing a property list to `command_graph::add()` | Implemented           |
+| Empty node                                                         | Implemented           |
+| Queue `ext_oneapi_get_state()` query                               | Implemented           |
+| Vendor test macro                                                  | Implemented           |
+| Ability to add a graph as a node of another graph (Sub-graphs)     | Implemented           |
+| Using all capabilities of USM in a graph node                      | Implemented           |
+| Extending lifetime of buffers used in a graph                      | Not implemented       |
+| Buffer taking a copy of host data when buffer is used in a graph   | Not implemented       |
+| Executable graph `update()`                                        | Not implemented       |
+| Using `handler::parallel_for` in a graph node                      | Implemented           |
+| Using `handler::single_task` in a graph node                       | Implemented           |
+| Using `handler::memcpy` in a graph node                            | Not implemented       |
+| Using `handler::copy` in a graph node                              | Not implemented       |
+| Using `handler::host_task` in a graph node                         | Not implemented       |
+| Using `handler::fill` in a graph node                              | Implemented for USM, not implemented for buffer accessors |
+| Using `handler::memset` in a graph node                            | Not implemented       |
+| Using `handler::prefech` in a graph node                           | Not implemented       |
+| Using `handler::memadvise` in a graph node                         | Not implemented       |
+| Using specialization constants in a graph node                     | Not implemented       |
+| Using reductions in a graph node                                   | Not implemented       |
+| Using sycl streams in a graph node                                 | Not implemented       |
+| Thread safety of new methods                                       | Not implemented       |
+| Profiling an event returned from graph submission                  | Not implemented       |
+| Querying the state of an event returned from graph submission      | Not implemented       |
+| Error checking                                                     | Throwing exceptions for invalid usage is only partially implemented |
+>>>>>>> [SYCL][Graphs] Readme table of implementation coverage
+
 ### Other Material
 
 This extension was presented at the oneAPI Technical Advisory board (Sept'22 meeting). Slides: [https://github.com/oneapi-src/oneAPI-tab/blob/main/language/presentations/2022-09-28-TAB-SYCL-Graph.pdf](https://github.com/oneapi-src/oneAPI-tab/blob/main/language/presentations/2022-09-28-TAB-SYCL-Graph.pdf).
+
+Extension was presented at IWOCL 2023, and the [talk can be found on Youtube](https://www.youtube.com/watch?v=aOTAmyr04rM).
 
 ## Intel Project for LLVM\* technology
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,29 @@ A draft of our Command Graph extension proposal can be found here:
 Our current prototype implementation can be found here:
 [https://github.com/reble/llvm/tree/sycl-graph-develop](https://github.com/reble/llvm/tree/sycl-graph-develop).
 
-Limitations include:
-* LevelZero backend support only. A fallback emulation mode is used for correctness on other backends.
-* Accessors and reductions are currently not supported.
+#### Backends
+
+An application can query the SYCL library for the level of support it
+provides for using the extension with a device by using
+`ext::oneapi::experimental::info::device::graph_support`, which returns one of:
+
+* Native - Backend command-buffer construct is used to implement graphs.
+* Emulated - Graphs support is emulated by reissuing commands to the backend.
+* Unsupported - Extension is not supported on the device.
+
+Currently the Level Zero backend is the only supported SYCL backend for the
+`sycl_ext_oneapi_graph` extension. As the focus of the current prototype is good
+Level Zero support to prove the value of the extension, rather than emulated
+support for many backends. However, broadening the number of backends supported
+is something we are interested in expanding on.
+
+| Backend    | Implementation Support     |
+| ---------- | -------------------------- |
+| Level Zero | Native using command-lists |
+| CUDA       | Unsupported                |
+| OpenCL     | Unsupported                |
+| HIP        | Unsupported                |
+| Others     | Unsupported                |
 
 #### Implementation Status
 


### PR DESCRIPTION
We'll eventually need to add a table of current implementation status to our extension specification.

Create a table in our development branch readme first, allowing us to update it when new features are added, and making it easy to port over to the specification when the time arises.