### PR TITLE
[SYCL][Graphs] Implement device support query

### DIFF
--- a/sycl/include/sycl/info/ext_oneapi_device_traits.def
+++ b/sycl/include/sycl/info/ext_oneapi_device_traits.def
@@ -6,6 +6,8 @@ __SYCL_PARAM_TRAITS_SPEC(ext::oneapi::experimental,device, max_global_work_group
 __SYCL_PARAM_TRAITS_TEMPLATE_SPEC(ext::oneapi::experimental,device, max_work_groups<1>, id<1>, PI_EXT_ONEAPI_DEVICE_INFO_MAX_WORK_GROUPS_1D)
 __SYCL_PARAM_TRAITS_TEMPLATE_SPEC(ext::oneapi::experimental,device, max_work_groups<2>, id<2>, PI_EXT_ONEAPI_DEVICE_INFO_MAX_WORK_GROUPS_2D)
 __SYCL_PARAM_TRAITS_TEMPLATE_SPEC(ext::oneapi::experimental,device, max_work_groups<3>, id<3>, PI_EXT_ONEAPI_DEVICE_INFO_MAX_WORK_GROUPS_3D)
+__SYCL_PARAM_TRAITS_SPEC(ext::oneapi::experimental,device, graph_support, ext::oneapi::experimental::info::device::graph_support_level, PI_EXT_ONEAPI_DEVICE_INFO_COMMAND_BUFFER_SUPPORT)
+
 #ifdef __SYCL_PARAM_TRAITS_TEMPLATE_SPEC_NEEDS_UNDEF
 #undef __SYCL_PARAM_TRAITS_TEMPLATE_SPEC
 #undef __SYCL_PARAM_TRAITS_TEMPLATE_SPEC_NEEDS_UNDEF

--- a/sycl/include/sycl/info/info_desc.hpp
+++ b/sycl/include/sycl/info/info_desc.hpp
@@ -186,6 +186,9 @@ template <typename T, T param> struct compatibility_param_traits {};
 
 namespace ext::oneapi::experimental::info::device {
 template <int Dimensions> struct max_work_groups;
+
+enum class graph_support_level { unsupported = 0, native, emulated };
+
 } // namespace ext::oneapi::experimental::info::device
 #include <sycl/info/ext_codeplay_device_traits.def>
 #include <sycl/info/ext_intel_device_traits.def>

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -804,6 +804,31 @@ struct get_device_info_impl<
   }
 };
 
+// Specialization for graph extension support
+template <>
+struct get_device_info_impl<
+    ext::oneapi::experimental::info::device::graph_support_level,
+    ext::oneapi::experimental::info::device::graph_support> {
+  static ext::oneapi::experimental::info::device::graph_support_level
+  get(const DeviceImplPtr &Dev) {
+    // Level zero is currently only supported backend
+    if (Dev->getBackend() != backend::ext_oneapi_level_zero) {
+      return ext::oneapi::experimental::info::device::graph_support_level::
+          unsupported;
+    }
+
+    pi_bool CmdBufSupport = false;
+    Dev->getPlugin()->call<PiApiKind::piDeviceGetInfo>(
+        Dev->getHandleRef(), PI_EXT_ONEAPI_DEVICE_INFO_COMMAND_BUFFER_SUPPORT,
+        sizeof(pi_bool), &CmdBufSupport, nullptr);
+
+    return CmdBufSupport ? ext::oneapi::experimental::info::device::
+                               graph_support_level::native
+                         : ext::oneapi::experimental::info::device::
+                               graph_support_level::emulated;
+  }
+};
+
 template <typename Param>
 typename Param::return_type get_device_info(const DeviceImplPtr &Dev) {
   static_assert(is_device_info_desc<Param>::value,
@@ -1690,6 +1715,14 @@ inline uint32_t get_device_info_host<
   throw runtime_error("Obtaining the maximum number of available registers per "
                       "work-group is not supported on HOST device",
                       PI_ERROR_INVALID_DEVICE);
+}
+
+template <>
+inline ext::oneapi::experimental::info::device::graph_support_level
+get_device_info_host<ext::oneapi::experimental::info::device::graph_support>() {
+  // No support for graphs on the host device.
+  return ext::oneapi::experimental::info::device::graph_support_level::
+      unsupported;
 }
 
 } // namespace detail

--- a/sycl/test-e2e/Graph/device_query.cpp
+++ b/sycl/test-e2e/Graph/device_query.cpp
@@ -1,0 +1,25 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests the using device query for graphs support, and that the return value
+// matches expectations.
+
+#include "graph_common.hpp"
+
+int main() {
+  queue Queue;
+
+  auto Device = Queue.get_device();
+
+  exp_ext::info::device::graph_support_level SupportsGraphs =
+      Device.get_info<exp_ext::info::device::graph_support>();
+  auto Backend = Device.get_backend();
+
+  if (Backend == backend::ext_oneapi_level_zero) {
+    assert(SupportsGraphs ==
+           exp_ext::info::device::graph_support_level::native);
+  } else {
+    assert(SupportsGraphs ==
+           exp_ext::info::device::graph_support_level::unsupported);
+  }
+}

--- a/sycl/test-e2e/Graph/vendor_test_macro.cpp
+++ b/sycl/test-e2e/Graph/vendor_test_macro.cpp
@@ -1,5 +1,3 @@
-// REQUIRES: level_zero, gpu
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Implement the device info `graph_support` query defined by spec PR https://github.com/reble/llvm/pull/178

This only reports that graphs are supported on Level Zero devices, as it's the only platform we test on.