### PR TITLE
[SYCL][Graph] missing colon in hip

### DIFF
--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2001,7 +2001,7 @@ pi_result hip_piDeviceGetInfo(pi_device device, pi_device_info param_name,
                     PI_ERROR_INVALID_ARG_VALUE);
     return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
 
-  case PI_EXT_ONEAPI_DEVICE_INFO_COMMAND_BUFFER_SUPPORT {
+  case PI_EXT_ONEAPI_DEVICE_INFO_COMMAND_BUFFER_SUPPORT: {
     // Using HIP-Graphs as a backend for PI command-buffers no yet supported
     return getInfo<pi_bool>(param_value_size, param_value, param_value_size_ret,
                             false);


### PR DESCRIPTION
The `PI_EXT_ONEAPI_DEVICE_INFO_COMMAND_BUFFER_SUPPORT` switch case in the HIP backend should have a colon to compile.

Matches a commit on `sycl-graph-release` https://github.com/intel/llvm/pull/9375/commits/ad8dbffde013a0cc6ec857f23ca2466ff4598068