### PR TITLE
[SYCL][Graphs] Fix Windows stdcpp_compat.cpp fail

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -50,7 +50,6 @@ private:
   friend T sycl::detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 
   std::shared_ptr<detail::node_impl> impl;
-  std::shared_ptr<detail::graph_impl> MGraph;
 };
 
 namespace property {

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -38,8 +38,20 @@ enum class graph_state {
   executable, ///< In executable state, the graph is ready to execute.
 };
 
-// Forward declaration
-class node;
+/// Class representing a node in the graph, returned by command_graph::add().
+class __SYCL_EXPORT node {
+private:
+  node(const std::shared_ptr<detail::node_impl> &Impl) : impl(Impl) {}
+
+  template <class Obj>
+  friend decltype(Obj::impl)
+  sycl::detail::getSyclObjImpl(const Obj &SyclObject);
+  template <class T>
+  friend T sycl::detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
+
+  std::shared_ptr<detail::node_impl> impl;
+  std::shared_ptr<detail::graph_impl> MGraph;
+};
 
 namespace property {
 namespace graph {
@@ -75,21 +87,6 @@ private:
 
 } // namespace node
 } // namespace property
-
-/// Class representing a node in the graph, returned by command_graph::add().
-class __SYCL_EXPORT node {
-private:
-  node(const std::shared_ptr<detail::node_impl> &Impl) : impl(Impl) {}
-
-  template <class Obj>
-  friend decltype(Obj::impl)
-  sycl::detail::getSyclObjImpl(const Obj &SyclObject);
-  template <class T>
-  friend T sycl::detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
-
-  std::shared_ptr<detail::node_impl> impl;
-  std::shared_ptr<detail::graph_impl> MGraph;
-};
 
 /// Class representing a graph in the modifiable state.
 template <graph_state State = graph_state::modifiable>


### PR DESCRIPTION
Fix for `basic_tests/stdcpp_compat.cpp` in the `check-sycl` target on windows, which fails when a compilation error is triggered when building with different command-line flags

This issue was arising from the `depends_on` class using the `node` class in the `MDeps` vector, when `node` was only declared and not defined. This lead to issues when the implicit destructor for `depends_on` was created before the `node` class was defined, triggering the error picked up by the test.

Fixed by moving the definition of the `node` class before `depends_on` so that we don't need the declaration.