### PR TITLE
[SYCL][Graph] Expand Subgraph testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ is something we are interested in expanding on.
 | Empty node                                                         | Implemented           |
 | Queue `ext_oneapi_get_state()` query                               | Implemented           |
 | Vendor test macro                                                  | Implemented           |
-| Ability to add a graph as a node of another graph (Sub-graphs)     | Implemented           |
+| Ability to add a graph as a node of another graph (Sub-graphs)     | Implemented, with the limitations that a subgraph can only be added as a node to any parent graph once, and will not correctly execute by itself after being added as a sub-graph. |
 | Using all capabilities of USM in a graph node                      | Implemented           |
 | Extending lifetime of buffers used in a graph                      | Not implemented       |
 | Buffer taking a copy of host data when buffer is used in a graph   | Not implemented       |

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_nested.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_nested.cpp
@@ -1,0 +1,149 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// This tests nesting sub-graphs two deep inside a parent graph.
+
+#include "../graph_common.hpp"
+
+namespace {
+// Calculates reference result at index i
+float reference(size_t i) {
+  float x = static_cast<float>(i);
+  float y = static_cast<float>(i);
+  float z = static_cast<float>(i);
+
+  x = x * 2.0f + 0.5f;  // XSubSubGraph
+  y = y * 3.0f + 0.14f; // YSubSubGraph
+
+  // SubGraph
+  x = -x;
+  y = -y;
+
+  // Graph
+  z = z * x - y;
+
+  return z;
+}
+} // namespace
+
+int main() {
+  queue Queue{gpu_selector_v};
+
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
+  exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
+  exp_ext::command_graph XSubSubGraph{Queue.get_context(), Queue.get_device()};
+  exp_ext::command_graph YSubSubGraph{Queue.get_context(), Queue.get_device()};
+
+  const size_t N = 10;
+  float *X = malloc_device<float>(N, Queue);
+  float *Y = malloc_device<float>(N, Queue);
+  float *Z = malloc_device<float>(N, Queue);
+
+  // XSubSubGraph is a multiply-add operation on USM allocation X
+  auto XSS1 = XSubSubGraph.add([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] *= 2.0f;
+    });
+  });
+
+  XSubSubGraph.add(
+      [&](handler &CGH) {
+        CGH.parallel_for(N, [=](id<1> it) {
+          const size_t i = it[0];
+          X[i] += 0.5f;
+        });
+      },
+      {exp_ext::property::node::depends_on(XSS1)});
+
+  auto XExecSubSubGraph = XSubSubGraph.finalize();
+
+  // YSubSubGraph is a multiply-add operation on USM allocation Y
+  auto YSS1 = YSubSubGraph.add([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      Y[i] *= 3.0f;
+    });
+  });
+
+  YSubSubGraph.add(
+      [&](handler &CGH) {
+        CGH.parallel_for(N, [=](id<1> it) {
+          const size_t i = it[0];
+          Y[i] += 0.14f;
+        });
+      },
+      {exp_ext::property::node::depends_on(YSS1)});
+
+  auto YExecSubSubGraph = YSubSubGraph.finalize();
+
+  // SubGraph initializes X & Y inputs, adds both subgraphs, then negates
+  // the results
+  auto S1 = SubGraph.add([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] = static_cast<float>(i);
+      Y[i] = static_cast<float>(i);
+    });
+  });
+
+  auto S2 = SubGraph.add(
+      [&](handler &CGH) { CGH.ext_oneapi_graph(XExecSubSubGraph); },
+      {exp_ext::property::node::depends_on(S1)});
+
+  auto S3 = SubGraph.add(
+      [&](handler &CGH) { CGH.ext_oneapi_graph(YExecSubSubGraph); },
+      {exp_ext::property::node::depends_on(S1)});
+
+  SubGraph.add(
+      [&](handler &CGH) {
+        CGH.parallel_for(N, [=](id<1> it) {
+          const size_t i = it[0];
+          X[i] = -X[i];
+          Y[i] = -Y[i];
+        });
+      },
+      {exp_ext::property::node::depends_on(S2, S3)});
+
+  auto ExecSubGraph = SubGraph.finalize();
+
+  // Parent Graph initializes Z allocation, adds the sub-graph,then
+  // does a multiply add with X & Y allocation results.
+  auto G1 = Graph.add([&](handler &CGH) {
+    CGH.parallel_for(range<1>{N}, [=](id<1> it) {
+      const size_t i = it[0];
+      Z[i] = static_cast<float>(i);
+    });
+  });
+
+  auto G2 =
+      Graph.add([&](handler &CGH) { CGH.ext_oneapi_graph(ExecSubGraph); });
+
+  Graph.add(
+      [&](handler &CGH) {
+        CGH.parallel_for(range<1>{N}, [=](id<1> it) {
+          const size_t i = it[0];
+          Z[i] = Z[i] * X[i] - Y[i];
+        });
+      },
+      {exp_ext::property::node::depends_on(G1, G2)});
+
+  auto ExecGraph = Graph.finalize();
+
+  auto E = Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+
+  std::vector<float> Output(N);
+  Queue.memcpy(Output.data(), Z, N * sizeof(float), E).wait();
+
+  for (size_t i = 0; i < N; i++) {
+    float ref = reference(i);
+    assert(Output[i] == ref);
+  }
+
+  sycl::free(X, Queue);
+  sycl::free(Y, Queue);
+  sycl::free(Z, Queue);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Explicit/subgraph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/Explicit/subgraph_execute_without_parent.cpp
@@ -1,0 +1,85 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// XFAIL: *
+// Subgraph nodes get parent graph precessor nodes when added as a subgraph
+// which affects stand alone execution.
+
+// Tests creating a parent graph with the same sub-graph interleaved with
+// other nodes.
+
+#include "../graph_common.hpp"
+
+int main() {
+  queue Queue{gpu_selector_v};
+
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
+  exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
+
+  const size_t N = 10;
+  float *X = malloc_device<float>(N, Queue);
+
+  auto S1 = SubGraph.add([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] *= 2.0f;
+    });
+  });
+
+  SubGraph.add(
+      [&](handler &CGH) {
+        CGH.parallel_for(N, [=](id<1> it) {
+          const size_t i = it[0];
+          X[i] += 0.5f;
+        });
+      },
+      {exp_ext::property::node::depends_on(S1)});
+
+  auto ExecSubGraph = SubGraph.finalize();
+
+  auto G1 = Graph.add([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] = 1.0f;
+    });
+  });
+
+  auto G2 = Graph.add([&](handler &CGH) { CGH.ext_oneapi_graph(ExecSubGraph); },
+                      {exp_ext::property::node::depends_on(G1)});
+
+  Graph.add(
+      [&](handler &CGH) {
+        CGH.parallel_for(range<1>{N}, [=](id<1> it) {
+          const size_t i = it[0];
+          X[i] *= -1.0f;
+        });
+      },
+      {exp_ext::property::node::depends_on(G2)});
+
+  auto ExecGraph = Graph.finalize();
+
+  auto Event1 = Queue.submit([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] = 3.14f;
+    });
+  });
+
+  auto Event2 = Queue.submit([&](handler &CGH) {
+    CGH.depends_on(Event1);
+    CGH.ext_oneapi_graph(ExecGraph);
+  });
+
+  std::vector<float> Output(N);
+  Queue.memcpy(Output.data(), X, N * sizeof(float), Event2).wait();
+
+  const float ref = 3.14f * 2.0f + 0.5f;
+  for (size_t i = 0; i < N; i++) {
+    assert(Output[i] == ref);
+  }
+
+  sycl::free(X, Queue);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/subgraph_interleaved_submit.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/subgraph_interleaved_submit.cpp
@@ -1,0 +1,86 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// XFAIL:*
+// Submit a graph as a subgraph more than once doesn't yet work.
+
+// Tests creating a parent graph with the same sub-graph interleaved with
+// other nodes.
+
+#include "../graph_common.hpp"
+
+int main() {
+  queue Queue{gpu_selector_v};
+
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
+  exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
+
+  const size_t N = 10;
+  float *X = malloc_device<float>(N, Queue);
+
+  SubGraph.begin_recording(Queue);
+
+  auto S1 = Queue.submit([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] *= 2.0f;
+    });
+  });
+
+  Queue.submit([&](handler &CGH) {
+    CGH.depends_on(S1);
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] += 0.5f;
+    });
+  });
+
+  SubGraph.end_recording(Queue);
+
+  auto ExecSubGraph = SubGraph.finalize();
+
+  Graph.begin_recording(Queue);
+
+  auto P1 = Queue.submit([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] = 1.0f;
+    });
+  });
+
+  auto P2 = Queue.submit([&](handler &CGH) {
+    CGH.depends_on(P1);
+    CGH.ext_oneapi_graph(ExecSubGraph);
+  });
+
+  auto P3 = Queue.submit([&](handler &CGH) {
+    CGH.depends_on(P2);
+    CGH.parallel_for(range<1>{N}, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] *= -1.0f;
+    });
+  });
+
+  Queue.submit([&](handler &CGH) {
+    CGH.depends_on(P3);
+    CGH.ext_oneapi_graph(ExecSubGraph);
+  });
+
+  Graph.end_recording();
+
+  auto ExecGraph = Graph.finalize();
+
+  auto E = Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+
+  std::vector<float> Output(N);
+  Queue.memcpy(Output.data(), X, N * sizeof(float), E).wait();
+
+  for (size_t i = 0; i < N; i++) {
+    assert(Output[i] == -6.25f);
+  }
+
+  sycl::free(X, Queue);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/subgraph_two_parent_graphs.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/subgraph_two_parent_graphs.cpp
@@ -1,0 +1,123 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// XFAIL: *
+// Subgraph doesn't work properly in second parent graph
+
+// Tests adding an executable graph object as a sub-graph of two different
+// parent graphs.
+
+#include "../graph_common.hpp"
+
+int main() {
+  queue Queue{gpu_selector_v};
+
+  exp_ext::command_graph GraphA{Queue.get_context(), Queue.get_device()};
+  exp_ext::command_graph GraphB{Queue.get_context(), Queue.get_device()};
+  exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
+
+  const size_t N = 10;
+  float *X = malloc_device<float>(N, Queue);
+
+  SubGraph.begin_recording(Queue);
+
+  auto S1 = Queue.submit([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] *= 2.0f;
+    });
+  });
+
+  Queue.submit([&](handler &CGH) {
+    CGH.depends_on(S1);
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] += 0.5f;
+    });
+  });
+
+  SubGraph.end_recording(Queue);
+
+  auto ExecSubGraph = SubGraph.finalize();
+
+  GraphA.begin_recording(Queue);
+
+  auto A1 = Queue.submit([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] = 1.0f;
+    });
+  });
+
+  auto A2 = Queue.submit([&](handler &CGH) {
+    CGH.depends_on(A1);
+    CGH.ext_oneapi_graph(ExecSubGraph);
+  });
+
+  Queue.submit([&](handler &CGH) {
+    CGH.depends_on(A2);
+    CGH.parallel_for(range<1>{N}, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] *= -1.0f;
+    });
+  });
+
+  GraphA.end_recording();
+
+  auto ExecGraphA = GraphA.finalize();
+
+  GraphB.begin_recording(Queue);
+
+  auto B1 = Queue.submit([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] = static_cast<float>(i);
+    });
+  });
+
+  auto B2 = Queue.submit([&](handler &CGH) {
+    CGH.depends_on(B1);
+    CGH.ext_oneapi_graph(ExecSubGraph);
+  });
+
+  Queue.submit([&](handler &CGH) {
+    CGH.depends_on(B2);
+    CGH.parallel_for(range<1>{N}, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] *= X[i];
+    });
+  });
+
+  GraphB.end_recording();
+  auto ExecGraphB = GraphB.finalize();
+
+  auto EventA1 =
+      Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraphA); });
+  std::vector<float> OutputA(N);
+  auto EventA2 = Queue.memcpy(OutputA.data(), X, N * sizeof(float), EventA1);
+
+  auto EventB1 = Queue.submit([&](handler &CGH) {
+    CGH.depends_on(EventA2);
+    CGH.ext_oneapi_graph(ExecGraphB);
+  });
+  std::vector<float> OutputB(N);
+  Queue.memcpy(OutputB.data(), X, N * sizeof(float), EventB1);
+  Queue.wait();
+
+  auto refB = [](size_t i) {
+    float result = static_cast<float>(i);
+    result = result * 2.0f + 0.5f;
+    result *= result;
+    return result;
+  };
+
+  for (size_t i = 0; i < N; i++) {
+    assert(OutputA[i] == -2.5f);
+    assert(OutputB[i] == refB(i));
+  }
+
+  sycl::free(X, Queue);
+
+  return 0;
+}


### PR DESCRIPTION
When a user adds a sub-graph we currently link all the nodes in a sub-graph to the parent graph. This causes issues in the following cases:

* User submits sub-graph object to execute standalone, as it exit nodes now have successors to a parent graph
* Sub-graph object is added to another graph as a node (or the same graph again), as its original root nodes now have predecessors.

Documented these limitations in the README and created ticket https://github.com/reble/llvm/issues/201 to resolve this later

Actions https://github.com/reble/llvm/issues/142 as this also has a test for nested sub-graphs, which is a usage that does work.