### PR TITLE
[SYCL][Graph] Support in-order queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ is something we are interested in expanding on.
 | Extending lifetime of buffers used in a graph                      | Not implemented       |
 | Buffer taking a copy of host data when buffer is used in a graph   | Not implemented       |
 | Executable graph `update()`                                        | Not implemented       |
-| Recording an in-order queue preserves linear dependencies          | Not implemented       |
+| Recording an in-order queue preserves linear dependencies          | Implemented           |
 | Using `handler::parallel_for` in a graph node                      | Implemented           |
 | Using `handler::single_task` in a graph node                       | Implemented           |
 | Using `handler::memcpy` in a graph node                            | Implemented           |

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -188,7 +188,7 @@ public:
   /// @param SyclDevice Device to create nodes with.
   graph_impl(const sycl::context &SyclContext, const sycl::device &SyclDevice)
       : MContext(SyclContext), MDevice(SyclDevice), MRecordingQueues(),
-        MEventsMap() {}
+        MEventsMap(), MInorderQueueMap() {}
 
   /// Insert node into list of root nodes.
   /// @param Root Node to add to list of root nodes.
@@ -274,6 +274,7 @@ public:
   }
 
   /// Adds sub-graph nodes from an executable graph to this graph.
+  /// @param NodeList List of nodes from sub-graph in schedule order.
   /// @return An empty node is used to schedule dependencies on this sub-graph.
   std::shared_ptr<node_impl>
   add_subgraph_nodes(const std::list<std::shared_ptr<node_impl>> &NodeList);
@@ -284,6 +285,28 @@ public:
 
   /// List of root nodes.
   std::set<std::shared_ptr<node_impl>> MRoots;
+
+  /// Find the last node added to this graph from an in-order queue.
+  /// @param Queue In-order queue to find the last node added to the graph from.
+  /// @return Last node in this graph added from \p Queue recording, or empty
+  /// shared pointer if none.
+  std::shared_ptr<node_impl>
+  get_last_inorder_node(std::shared_ptr<sycl::detail::queue_impl> Queue) {
+    std::weak_ptr<sycl::detail::queue_impl> QueueWeakPtr(Queue);
+    if (0 == MInorderQueueMap.count(QueueWeakPtr)) {
+      return {};
+    }
+    return MInorderQueueMap[QueueWeakPtr];
+  }
+
+  /// Track the last node added to this graph from an in-order queue.
+  /// @param Queue In-order queue to register \p Node for.
+  /// @param Node Last node that was added to this graph from \p Queue.
+  void set_last_inorder_node(std::shared_ptr<sycl::detail::queue_impl> Queue,
+                             std::shared_ptr<node_impl> Node) {
+    std::weak_ptr<sycl::detail::queue_impl> QueueWeakPtr(Queue);
+    MInorderQueueMap[QueueWeakPtr] = Node;
+  }
 
 private:
   /// Context associated with this graph.
@@ -297,6 +320,13 @@ private:
   std::unordered_map<std::shared_ptr<sycl::detail::event_impl>,
                      std::shared_ptr<node_impl>>
       MEventsMap;
+  /// Map for every in-order queue thats recorded a node to the graph, what
+  /// the last node added was. We can use this to create new edges on the last
+  /// node if any more nodes are added to the graph from the queue.
+  std::map<std::weak_ptr<sycl::detail::queue_impl>, std::shared_ptr<node_impl>,
+           std::owner_less<std::weak_ptr<sycl::detail::queue_impl>>>
+
+      MInorderQueueMap;
 };
 
 /// Class representing the implementation of command_graph<executable>.

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -431,11 +431,28 @@ event handler::finalize() {
   // it to the graph to create a node, rather than submit it to the scheduler.
   if (auto GraphImpl = MQueue->getCommandGraph(); GraphImpl) {
     auto EventImpl = std::make_shared<detail::event_impl>();
-
-    // Extract relevant data from the handler and pass to graph to create a
-    // new node representing this command group.
     std::shared_ptr<ext::oneapi::experimental::detail::node_impl> NodeImpl =
-        GraphImpl->add(MCGType, std::move(CommandGroup));
+        nullptr;
+
+    // Create a new node in the graph representing this command-group
+    if (MQueue->isInOrder()) {
+      // In-order queues create implicit linear dependencies between nodes.
+      // Find the last node added to the graph from this queue, so our new
+      // node can set it as a predecessor.
+      auto DependentNode = GraphImpl->get_last_inorder_node(MQueue);
+
+      NodeImpl = DependentNode
+                     ? GraphImpl->add(MCGType, std::move(CommandGroup),
+                                      {DependentNode})
+                     : GraphImpl->add(MCGType, std::move(CommandGroup));
+
+      // If we are recording an in-order queue remember the new node, so it
+      // can be used as a dependency for any more nodes recorded from this
+      // queue.
+      GraphImpl->set_last_inorder_node(MQueue, NodeImpl);
+    } else {
+      NodeImpl = GraphImpl->add(MCGType, std::move(CommandGroup));
+    }
 
     // Associate an event with this new node and return the event.
     GraphImpl->add_event_for_node(EventImpl, NodeImpl);
@@ -1040,6 +1057,12 @@ void handler::ext_oneapi_graph(
     // Store the node representing the subgraph in the handler so that we can
     // return it to the user later.
     MSubgraphNode = ParentGraph->add_subgraph_nodes(GraphImpl->get_schedule());
+
+    // If we are recording an in-order queue remember the subgraph node, so it
+    // can be used as a dependency for any more nodes recorded from this queue.
+    if (MQueue && MQueue->isInOrder()) {
+      ParentGraph->set_last_inorder_node(MQueue, MSubgraphNode);
+    }
     // Associate an event with the subgraph node.
     auto SubgraphEvent = std::make_shared<event_impl>();
     ParentGraph->add_event_for_node(SubgraphEvent, MSubgraphNode);

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
@@ -1,0 +1,76 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests a dotp operation split between 2 in-order queues using device USM.
+
+#include "../graph_common.hpp"
+
+int main() {
+
+  property_list properties{property::queue::in_order()};
+  queue QueueA{gpu_selector_v, properties};
+  queue QueueB{gpu_selector_v, properties};
+
+  exp_ext::command_graph Graph{QueueA.get_context(), QueueA.get_device()};
+
+  float *Dotp = malloc_device<float>(1, QueueA);
+
+  const size_t N = 10;
+  float *X = malloc_device<float>(N, QueueA);
+  float *Y = malloc_device<float>(N, QueueA);
+  float *Z = malloc_device<float>(N, QueueA);
+
+  Graph.begin_recording(QueueA);
+  Graph.begin_recording(QueueB);
+
+  QueueA.submit([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] = 1.0f;
+      Y[i] = 2.0f;
+      Z[i] = 3.0f;
+    });
+  });
+
+  auto Event = QueueA.submit([&](handler &CGH) {
+    CGH.parallel_for(range<1>{N}, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] = Alpha * X[i] + Beta * Y[i];
+    });
+  });
+
+  QueueB.submit([&](handler &CGH) {
+    CGH.depends_on(Event); // needed for cross queue dependency
+    CGH.parallel_for(range<1>{N}, [=](id<1> it) {
+      const size_t i = it[0];
+      Z[i] = Gamma * Z[i] + Beta * Y[i];
+    });
+  });
+
+  QueueB.submit([&](handler &CGH) {
+    CGH.single_task([=]() {
+      for (size_t j = 0; j < N; j++) {
+        Dotp[0] += X[j] * Z[j];
+      }
+    });
+  });
+
+  Graph.end_recording();
+
+  auto ExecGraph = Graph.finalize();
+
+  QueueA.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+
+  float Output;
+  QueueA.memcpy(&Output, Dotp, sizeof(float)).wait();
+
+  assert(Output == dotp_reference_result(N));
+
+  sycl::free(Dotp, QueueA);
+  sycl::free(X, QueueA);
+  sycl::free(Y, QueueA);
+  sycl::free(Z, QueueA);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/subgraph_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/subgraph_in_order.cpp
@@ -1,0 +1,71 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests adding a sub-graph to an in-order queue.
+
+#include "../graph_common.hpp"
+
+int main() {
+  property_list properties{property::queue::in_order()};
+  queue Queue{gpu_selector_v, properties};
+
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
+  exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
+
+  const size_t N = 10;
+  float *X = malloc_device<float>(N, Queue);
+
+  SubGraph.begin_recording(Queue);
+
+  Queue.submit([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] *= 2.0f;
+    });
+  });
+
+  Queue.submit([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] += 0.5f;
+    });
+  });
+
+  SubGraph.end_recording(Queue);
+
+  auto ExecSubGraph = SubGraph.finalize();
+
+  Graph.begin_recording(Queue);
+
+  Queue.submit([&](handler &CGH) {
+    CGH.parallel_for(N, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] = 1.0f;
+    });
+  });
+
+  Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecSubGraph); });
+
+  Queue.submit([&](handler &CGH) {
+    CGH.parallel_for(range<1>{N}, [=](id<1> it) {
+      const size_t i = it[0];
+      X[i] += 3.0f;
+    });
+  });
+
+  Graph.end_recording();
+
+  auto ExecGraph = Graph.finalize();
+
+  Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+
+  float Output;
+  Queue.memcpy(&Output, X, sizeof(float)).wait();
+
+  assert(Output == 5.5f);
+
+  sycl::free(X, Queue);
+
+  return 0;
+}


### PR DESCRIPTION
Implements using Record & Replay graph construction to record an in-order queue and keep linear dependencies between nodes.

Done by storing in the graph the last node added to the graph from each in-order queue, and using that to create a dependency edge on any new nodes added from that in-order queue.

Actions https://github.com/reble/llvm/issues/188