### PR TITLE
[SYCL][Doc] Expand on update() error wording for invalid device

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -884,8 +884,9 @@ Exceptions:
   which is not a kernel command or host-task, e.g.
   {handler-copy-functions}[memory operations].
 
-* Throws synchronously with error code `invalid` if the context associated with
-  `graph` does not match that of the `command_graph` being updated.
+* Throws synchronously with error code `invalid` if the context or device
+  associated with `graph` does not match that of the `command_graph` being
+  updated.
 |===
 
 ==== Graph Properties


### PR DESCRIPTION
Expand on the error wording around using `update()` when passing a graph with a different device. This is technically already covered on the node level by the definition of *topologically identical*, but defining an error at the graph level as well is more obvious to a reader.

Actions specfication feedback from https://github.com/intel/llvm/pull/5626#discussion_r1206832653