### PR TITLE
[SYCL][Graph] Fix scheduler regression test

### DIFF
--- a/sycl/unittests/scheduler/Regression.cpp
+++ b/sycl/unittests/scheduler/Regression.cpp
@@ -38,10 +38,10 @@ static pi_result redefinedEnqueueNativeKernel(
   EXPECT_EQ(Reqs[0]->MAccessRange[1], MockReq.MAccessRange[1]);
   EXPECT_EQ(Reqs[0]->MAccessRange[2], MockReq.MAccessRange[2]);
 
-  std::unique_ptr<detail::HostKernelBase> *HostKernel =
-      static_cast<std::unique_ptr<detail::HostKernelBase> *>(CastedBlob[1]);
+  detail::HostKernelBase *HostKernel =
+      static_cast<detail::HostKernelBase *>(CastedBlob[1]);
   testing::internal::CaptureStdout();
-  (*HostKernel)->call(NDRDesc, nullptr);
+  HostKernel->call(NDRDesc, nullptr);
   std::string Output = testing::internal::GetCapturedStdout();
   EXPECT_EQ(Output, "Blablabla");
 


### PR DESCRIPTION
Fixes scheduer unit test caught by CI, this assumes that the second element in the binary blob is a pointer to a `std::unqiue_ptr`, but it is actually just a raw pointer after our changes [here](https://github.com/reble/llvm/blob/sycl-graph-develop/sycl/source/detail/scheduler/commands.cpp#L2655)

I've also made comment on our upstream PR about another place that could be affected but haven't seen regress in  a test yet https://github.com/intel/llvm/pull/9728/files#r1222909672