### PR TITLE
Bring back some sycl-graph-release-patch1 branch to sycl-graph-develop

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -87,7 +87,7 @@ private:
 } // namespace node
 } // namespace property
 
-/// Class representing a graph in the modifiable state.
+/// Graph in the modifiable state.
 template <graph_state State = graph_state::modifiable>
 class __SYCL_EXPORT command_graph {
 public:
@@ -153,7 +153,7 @@ public:
   /// executing.
   bool end_recording();
 
-  /// Set a queues currently recording to this graph to the executing state.
+  /// Set a queue currently recording to this graph to the executing state.
   /// @param RecordingQueue The queue to change state on.
   /// @return True if the queue had its state changed from recording to
   /// executing.

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -1921,7 +1921,7 @@ public:
         [&](handler &CGH) { CGH.ext_oneapi_graph(Graph); } _CODELOCFW(CodeLoc));
   }
 
-  /// Shortcut for executing a graph of commands.
+  /// Shortcut for executing a graph of commands with a single dependency.
   ///
   /// \param Graph the graph of commands to execute
   /// \param DepEvent is an event that specifies the graph execution
@@ -1937,7 +1937,7 @@ public:
     } _CODELOCFW(CodeLoc));
   }
 
-  /// Shortcut for executing a graph of commands.
+  /// Shortcut for executing a graph of commands with multiple dependencies.
   ///
   /// \param Graph the graph of commands to execute
   /// \param DepEvents is a vector of events that specifies the graph

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -146,7 +146,7 @@ graph_impl::add(const std::shared_ptr<graph_impl> &Impl,
     return Handler.MSubgraphNode;
   }
   if (Handler.MCGType == sycl::detail::CG::None) {
-      return this->add(Dep);
+    return this->add(Dep);
   }
   return this->add(Handler.MCGType, std::move(Handler.MGraphNodeCG), Dep);
 }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -50,7 +50,7 @@ public:
   /// @param Node Node to add as a successor.
   /// @param Prev Predecessor to \p node being added as successor.
   ///
-  /// /p Prev should be a shared_ptr to an instance of this object, but can't
+  /// \p Prev should be a shared_ptr to an instance of this object, but can't
   /// use a raw \p this pointer, so the extra \Prev parameter is passed.
   void register_successor(const std::shared_ptr<node_impl> &Node,
                           const std::shared_ptr<node_impl> &Prev) {
@@ -180,7 +180,7 @@ private:
   }
 };
 
-/// Class representing implementation details of command_graph<modifiable>.
+/// Implementation details of command_graph<modifiable>.
 class graph_impl {
 public:
   /// Constructor.

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -32,8 +32,6 @@
 #include <sycl/queue.hpp>
 #include <sycl/stl.hpp>
 
-#include "detail/graph_impl.hpp"
-
 #include <utility>
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
@@ -43,6 +41,13 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
+
+// forward declaration
+
+namespace ext::oneapi::experimental::detail {
+class graph_impl;
+}
+
 namespace detail {
 
 using ContextImplPtr = std::shared_ptr<detail::context_impl>;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -116,10 +116,8 @@ event handler::finalize() {
   // they have already been added, and return the event associated with the
   // subgraph node.
   if (MQueue && MQueue->getCommandGraph() && MSubgraphNode) {
-    {
-      return detail::createSyclObjFromImpl<event>(
-          MQueue->getCommandGraph()->get_event_for_node(MSubgraphNode));
-    }
+    return detail::createSyclObjFromImpl<event>(
+        MQueue->getCommandGraph()->get_event_for_node(MSubgraphNode));
   }
 
   // According to 4.7.6.9 of SYCL2020 spec, if a placeholder accessor is passed


### PR DESCRIPTION
Bring some commits made directly to the sycl-graph-release1 branch back into develop to avoid us diverging too much.

* [Apply suggestions from code review](https://github.com/intel/llvm/pull/9728/commits/e29548b3ce7e3741a7b7043998a5ae7461f45f1e)
* [[SYCL] Apply more suggestions from code review](https://github.com/intel/llvm/pull/9728/commits/24a3bfe943a455ec831e886f6521d499c6fe4d6e)
* [clang-format](https://github.com/intel/llvm/pull/9728/commits/28fa5442f312d7ee14df560051535b35a8180aad)

Draft as I'm not sure we should actually merge this as it could cause pain down the line, but might still have some value as an open PR to see diff of changes.