### PR TITLE
[SYCL][Graphs] Wait for graph events before destruction

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_command_buffer.cpp
@@ -77,8 +77,8 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
     : Context(hContext), Device(hDevice), ZeCommandList(CommandList),
       ZeCommandListDesc(ZeDesc), QueueProperties(), SyncPoints(),
       NextSyncPoint(0), CommandListMap() {
-  hContext->RefCount.increment();
-  hDevice->RefCount.increment();
+  urContextRetain(hContext);
+  urDeviceRetain(hDevice);
   // TODO: Do we actually need the queue properties? Removed from the UR feature
   // for now.
 }
@@ -88,6 +88,9 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
 ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() {
   // Release the memory allocated to the Context stored in the command_buffer
   urContextRelease(Context);
+
+  // Release the device
+  urDeviceRelease(Device);
 
   // Release the memory allocated to the CommandList stored in the
   // command_buffer

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_command_buffer.cpp
@@ -588,20 +588,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_queue_handle_t hQueue,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
-
-  // Submit dependent open command lists for execution, if any
-  for (uint32_t I = 0; I < numEventsInWaitList; I++) {
-    ur_event_handle_t_ *Event =
-        ur_cast<ur_event_handle_t_ *>(phEventWaitList[I]);
-    auto UrQueue = Event->UrQueue;
-    if (UrQueue) {
-      // Lock automatically releases when this goes out of scope.
-      std::scoped_lock<ur_shared_mutex> lock(UrQueue->Mutex);
-
-      UR_CALL(UrQueue->executeAllOpenCommandLists());
-    }
-  }
-
   UR_ASSERT(hCommandBuffer, UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP);
 
   std::scoped_lock<ur_shared_mutex> lock(hQueue->Mutex);

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_command_buffer.cpp
@@ -78,6 +78,7 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
       ZeCommandListDesc(ZeDesc), QueueProperties(), SyncPoints(),
       NextSyncPoint(0), CommandListMap() {
   hContext->RefCount.increment();
+  hDevice->RefCount.increment();
   // TODO: Do we actually need the queue properties? Removed from the UR feature
   // for now.
 }
@@ -587,6 +588,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_queue_handle_t hQueue,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
+
+  // Submit dependent open command lists for execution, if any
+  for (uint32_t I = 0; I < numEventsInWaitList; I++) {
+    ur_event_handle_t_ *Event =
+        ur_cast<ur_event_handle_t_ *>(phEventWaitList[I]);
+    auto UrQueue = Event->UrQueue;
+    if (UrQueue) {
+      // Lock automatically releases when this goes out of scope.
+      std::scoped_lock<ur_shared_mutex> lock(UrQueue->Mutex);
+
+      UR_CALL(UrQueue->executeAllOpenCommandLists());
+    }
+  }
+
   UR_ASSERT(hCommandBuffer, UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP);
 
   std::scoped_lock<ur_shared_mutex> lock(hQueue->Mutex);

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -422,6 +422,8 @@ private:
   /// List of requirements for enqueueing this command graph, accumulated from
   /// all nodes enqueued to the graph.
   std::vector<sycl::detail::AccessorImplHost *> MRequirements;
+  /// List of all execution events returned from command buffer enqueue calls.
+  std::vector<sycl::detail::EventImplPtr> MExecutionEvents;
 };
 
 } // namespace detail


### PR DESCRIPTION
- Track command buffer execution events and wait on them before releasing.
- Fixes issue seen in multiple_exec_graphs when command buffers are finalized, executed and deleted in a loop
- Retain and release device associated with command buffer (not related to issue but seems like something we should be doing).