### PR TITLE
[SYCL][Graph] Update scheduler regresion test to use shared_ptr

### DIFF
--- a/sycl/include/sycl/detail/cg.hpp
+++ b/sycl/include/sycl/detail/cg.hpp
@@ -169,7 +169,7 @@ public:
   std::vector<std::shared_ptr<const void>> MAuxiliaryResources;
   RT::PiKernelCacheConfig MKernelCacheConfig;
 
-  CGExecKernel(NDRDescT NDRDesc, std::unique_ptr<HostKernelBase> HKernel,
+  CGExecKernel(NDRDescT NDRDesc, std::shared_ptr<HostKernelBase> HKernel,
                std::shared_ptr<detail::kernel_impl> SyclKernel,
                std::shared_ptr<detail::kernel_bundle_impl> KernelBundle,
                CG::StorageInitHelper CGData, std::vector<ArgDesc> Args,

--- a/sycl/unittests/scheduler/Regression.cpp
+++ b/sycl/unittests/scheduler/Regression.cpp
@@ -38,10 +38,10 @@ static pi_result redefinedEnqueueNativeKernel(
   EXPECT_EQ(Reqs[0]->MAccessRange[1], MockReq.MAccessRange[1]);
   EXPECT_EQ(Reqs[0]->MAccessRange[2], MockReq.MAccessRange[2]);
 
-  detail::HostKernelBase *HostKernel =
-      static_cast<detail::HostKernelBase *>(CastedBlob[1]);
+  std::shared_ptr<detail::HostKernelBase> *HostKernel =
+      static_cast<std::shared_ptr<detail::HostKernelBase> *>(CastedBlob[1]);
   testing::internal::CaptureStdout();
-  HostKernel->call(NDRDesc, nullptr);
+  (*HostKernel)->call(NDRDesc, nullptr);
   std::string Output = testing::internal::GetCapturedStdout();
   EXPECT_EQ(Output, "Blablabla");
 

--- a/sycl/unittests/scheduler/Regression.cpp
+++ b/sycl/unittests/scheduler/Regression.cpp
@@ -73,7 +73,7 @@ TEST_F(SchedulerTest, CheckArgsBlobInPiEnqueueNativeKernelIsValid) {
   std::unique_ptr<detail::CG> CG{new detail::CGExecKernel(
       /*NDRDesc*/ NDRDesc,
       /*HKernel*/
-      std::make_unique<detail::HostKernel<decltype(Kernel), void, 1>>(HKernel),
+      std::make_shared<detail::HostKernel<decltype(Kernel), void, 1>>(HKernel),
       /*SyclKernel*/ nullptr,
       /*KernelBundle*/ nullptr, std::move(CGData),
       /*Args*/ {},


### PR DESCRIPTION
Fix for test regression is identical to https://github.com/reble/llvm/pull/214 that was missed as part of https://github.com/reble/llvm/pull/226

Also includes change taken from https://github.com/reble/llvm/pull/227 but with an update to the `detail::CGExecKernel` constructor so it compiles