### PR TITLE
[SYCL][Doc] Correct property section level

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -530,7 +530,7 @@ associated with a buffer that was created using a host data pointer will
 outlive any executable graphs created from a modifiable graph which uses
 that buffer.
 
-==== No-Cycle Check
+===== No-Cycle-Check Property
 
 The `property::graph::no_cycle_check` property disables any checks if a newly
 added dependency will lead to a cycle in a specific `command_graph` and can be


### PR DESCRIPTION
Fix the section hierarchy of "No Cycle Check" so that is on the same level as "No Host Copy" and under "Graph Properties".

Additionally, hyphenate the section header and give "Property" suffix, so that section naming is consistent.

Resolves feedback: https://github.com/intel/llvm/pull/5626#discussion_r1230045468