### PR TITLE
Fix adding empty nodes to the graph results in two root nodes

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -146,9 +146,6 @@ graph_impl::add(const std::shared_ptr<graph_impl> &Impl,
   if (Handler.MSubgraphNode) {
     return Handler.MSubgraphNode;
   }
-  if (Handler.MCGType == sycl::detail::CG::None) {
-    return this->add(Dep);
-  }
   return this->add(Handler.MCGType, std::move(Handler.MGraphNodeCG), Dep);
 }
 

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -106,7 +106,11 @@ public:
 
   /// Query if this is an empty node.
   /// @return True if this is an empty node, false otherwise.
-  bool isEmpty() const { return MIsEmpty; }
+  bool isEmpty() const {
+    if (MCGType == sycl::detail::CG::None)
+      return true;
+    return MIsEmpty;
+  }
 
   /// Get a deep copy of this node's command group
   /// @return A unique ptr to the new command group object.
@@ -367,7 +371,7 @@ public:
   /// Turns the internal graph representation into UR command-buffers for a
   /// device.
   /// @param D Device to create backend command-buffers for.
-  void createURCommandBuffers(sycl::device Device);                    
+  void createURCommandBuffers(sycl::device Device);
 
   /// Query for the context tied to this graph.
   /// @return Context associated with graph.

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -43,9 +43,6 @@ public:
   /// Command group object which stores all args etc needed to enqueue the node
   std::unique_ptr<sycl::detail::CG> MCommandGroup;
 
-  /// True if an empty node, false otherwise.
-  bool MIsEmpty = false;
-
   /// Add successor to the node.
   /// @param Node Node to add as a successor.
   /// @param Prev Predecessor to \p node being added as successor.
@@ -65,7 +62,7 @@ public:
   }
 
   /// Construct an empty node.
-  node_impl() : MIsEmpty(true) {}
+  node_impl() {}
 
   /// Construct a node representing a command-group.
   /// @param CGType Type of the command-group.
@@ -106,11 +103,7 @@ public:
 
   /// Query if this is an empty node.
   /// @return True if this is an empty node, false otherwise.
-  bool isEmpty() const {
-    if (MCGType == sycl::detail::CG::None)
-      return true;
-    return MIsEmpty;
-  }
+  bool isEmpty() const { return MCGType == sycl::detail::CG::None; }
 
   /// Get a deep copy of this node's command group
   /// @return A unique ptr to the new command group object.

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -363,7 +363,7 @@ public:
 
   /// Turns the internal graph representation into UR command-buffers for a
   /// device.
-  /// @param D Device to create backend command-buffers for.
+  /// @param Device Device to create backend command-buffers for.
   void createURCommandBuffers(sycl::device Device);
 
   /// Query for the context tied to this graph.

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -385,6 +385,7 @@ event handler::finalize() {
       GraphImpl = MGraph;
       CommandGroup.reset(
           new detail::CG(detail::CG::None, std::move(CGData), MCodeLoc));
+      MGraphNodeCG = std::move(CommandGroup);
     } else if (auto QueueGraph = MQueue->getCommandGraph(); QueueGraph) {
       GraphImpl = QueueGraph;
       auto EventImpl = std::make_shared<detail::event_impl>();

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -380,23 +380,20 @@ event handler::finalize() {
     if (detail::pi::trace(detail::pi::TraceLevel::PI_TRACE_ALL)) {
       std::cout << "WARNING: An empty command group is submitted." << std::endl;
     }
-    std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> GraphImpl;
     if (MGraph) {
-      GraphImpl = MGraph;
       CommandGroup.reset(
           new detail::CG(detail::CG::None, std::move(CGData), MCodeLoc));
       MGraphNodeCG = std::move(CommandGroup);
     } else if (auto QueueGraph = MQueue->getCommandGraph(); QueueGraph) {
-      GraphImpl = QueueGraph;
       auto EventImpl = std::make_shared<detail::event_impl>();
 
       // Extract relevant data from the handler and pass to graph to create a
       // new node representing this command group.
       std::shared_ptr<ext::oneapi::experimental::detail::node_impl> NodeImpl =
-          GraphImpl->add(CGData.MEvents);
+          QueueGraph->add(CGData.MEvents);
 
       // Associate an event with this new node and return the event.
-      GraphImpl->addEventForNode(EventImpl, NodeImpl);
+      QueueGraph->addEventForNode(EventImpl, NodeImpl);
 
       return detail::createSyclObjFromImpl<event>(EventImpl);
     }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -383,11 +383,10 @@ event handler::finalize() {
     std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> GraphImpl;
     if (MGraph) {
       GraphImpl = MGraph;
+      CommandGroup.reset(
+          new detail::CG(detail::CG::None, std::move(CGData), MCodeLoc));
     } else if (auto QueueGraph = MQueue->getCommandGraph(); QueueGraph) {
       GraphImpl = QueueGraph;
-    }
-
-    if (GraphImpl) {
       auto EventImpl = std::make_shared<detail::event_impl>();
 
       // Extract relevant data from the handler and pass to graph to create a


### PR DESCRIPTION
Fixes an issue revealed in `CommandGraphTest.AddNode` where an empty node without dependencies would lead to two root nodes being added to the graph. The first is added in the special Graph case in `handler::finalize()` and the second in `graph_impl::add(const std::vector<std::shared_ptr<node_impl>> &Dep)`. This patch adds a node in `handler::finalize()` only during queue recording. Explicitly added empty nodes use a new command group with none-type and follow the regular kernel `graph_impl::add` path. `isEmpty()` is extended to include command groups with none-type.

This supersedes #236 which lacked support for record and replay mode.