### PR TITLE
[SYCL][Graph] Fix clang build

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_command_buffer.cpp
@@ -590,8 +590,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
     ur_exp_command_buffer_handle_t hCommandBuffer,
-    ur_mem_handle_t hBuffer, size_t offset, size_t size, const void *pSrc, 
-    uint32_t numSyncPointsInWaitList, 
+    ur_mem_handle_t hBuffer, size_t offset, size_t size, const void *pSrc,
+    uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint) {
 
@@ -608,7 +608,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
       UR_COMMAND_MEM_BUFFER_WRITE, hCommandBuffer,
       ZeHandleDst + offset, // dst
       pSrc,                 // src
-      size, numEventsInWaitList, pSyncPointWaitList, pSyncPoint);
+      size, numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteRectExp(

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -1290,7 +1290,7 @@ void MemoryManager::ext_oneapi_copyD2H_cmd_buffer(
     sycl::detail::ContextImplPtr Context, RT::PiExtCommandBuffer CommandBuffer,
     SYCLMemObjI *SYCLMemObj, void *SrcMem, unsigned int DimSrc,
     sycl::range<3> SrcSize, sycl::range<3> SrcAccessRange,
-    sycl::id<3> SrcOffset, unsigned int SrcElemSize, void *DstMem,
+    sycl::id<3> SrcOffset, unsigned int SrcElemSize, char *DstMem,
     unsigned int DimDst, sycl::range<3> DstSize,
     sycl::id<3> DstOffset, unsigned int DstElemSize,
     std::vector<RT::PiExtSyncPoint> Deps, RT::PiExtSyncPoint *OutSyncPoint) {
@@ -1345,7 +1345,7 @@ void MemoryManager::ext_oneapi_copyD2H_cmd_buffer(
 
 void MemoryManager::ext_oneapi_copyH2D_cmd_buffer(
     sycl::detail::ContextImplPtr Context, RT::PiExtCommandBuffer CommandBuffer,
-    SYCLMemObjI *SYCLMemObj, void *SrcMem, unsigned int DimSrc,
+    SYCLMemObjI *SYCLMemObj, char *SrcMem, unsigned int DimSrc,
     sycl::range<3> SrcSize, sycl::id<3> SrcOffset, unsigned int SrcElemSize, void *DstMem,
     unsigned int DimDst, sycl::range<3> DstSize, sycl::range<3> DstAccessRange,
     sycl::id<3> DstOffset, unsigned int DstElemSize,

--- a/sycl/source/detail/memory_manager.hpp
+++ b/sycl/source/detail/memory_manager.hpp
@@ -194,14 +194,14 @@ public:
       RT::PiExtCommandBuffer CommandBuffer, SYCLMemObjI *SYCLMemObj,
       void *SrcMem, unsigned int DimSrc, sycl::range<3> SrcSize,
       sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
-      unsigned int SrcElemSize, void *DstMem, unsigned int DimDst,
+      unsigned int SrcElemSize, char *DstMem, unsigned int DimDst,
       sycl::range<3> DstSize, sycl::id<3> DstOffset, unsigned int DstElemSize,
       std::vector<RT::PiExtSyncPoint> Deps, RT::PiExtSyncPoint *OutSyncPoint);
 
   static void ext_oneapi_copyH2D_cmd_buffer(
       sycl::detail::ContextImplPtr Context,
       RT::PiExtCommandBuffer CommandBuffer, SYCLMemObjI *SYCLMemObj,
-      void *SrcMem, unsigned int DimSrc, sycl::range<3> SrcSize,
+      char *SrcMem, unsigned int DimSrc, sycl::range<3> SrcSize,
       sycl::id<3> SrcOffset, unsigned int SrcElemSize, void *DstMem, unsigned int DimDst,
       sycl::range<3> DstSize, sycl::range<3> DstAccessRange,
       sycl::id<3> DstOffset, unsigned int DstElemSize,

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2639,7 +2639,7 @@ pi_int32 ExecCGCommand::enqueueImpCommandBuffer() {
     MemoryManager::ext_oneapi_copyD2H_cmd_buffer(
         MQueue->getContextImplPtr(), MCommandBuffer, AllocaCmd->getSYCLMemObj(),
         AllocaCmd->getMemAllocation(), Req->MDims, Req->MMemoryRange,
-        Req->MAccessRange, Req->MOffset, Req->MElemSize, Copy->getDst(),
+        Req->MAccessRange, Req->MOffset, Req->MElemSize, (char *)Copy->getDst(),
         Req->MDims, Req->MAccessRange,
         /*DstOffset=*/ {0, 0, 0}, Req->MElemSize, std::move(MSyncPointDeps),
         &OutSyncPoint);
@@ -2653,7 +2653,7 @@ pi_int32 ExecCGCommand::enqueueImpCommandBuffer() {
 
     MemoryManager::ext_oneapi_copyH2D_cmd_buffer(
         MQueue->getContextImplPtr(), MCommandBuffer, AllocaCmd->getSYCLMemObj(),
-        Copy->getSrc(), Req->MDims, Req->MAccessRange,
+        (char *)Copy->getSrc(), Req->MDims, Req->MAccessRange,
         /*SrcOffset*/ {0, 0, 0}, Req->MElemSize, AllocaCmd->getMemAllocation(),
         Req->MDims, Req->MMemoryRange, Req->MAccessRange, Req->MOffset,
         Req->MElemSize, std::move(MSyncPointDeps), &OutSyncPoint);


### PR DESCRIPTION
Fix some build errors I've seen with clang-17 after https://github.com/reble/llvm/pull/238 was merged.

1) Arithmetic on void pointer, fixed by passing a `char*` rather than `void*` when an offset is needed

```
/home/ewan/Development/dpcpp/sycl/source/detail/memory_manager.cpp:1316:44: error: arithmetic on a pointer to void
 1316 |           SrcAccessRangeWidthBytes, DstMem + DstXOffBytes, Deps.size(),
      |                                     ~~~~~~ ^
/home/ewan/Development/dpcpp/sycl/source/detail/memory_manager.cpp:1372:44: error: arithmetic on a pointer to void
 1372 |           DstAccessRangeWidthBytes, SrcMem + SrcXOffBytes, Deps.size(),
      |
	  ~~~~~~ ^
```
2) Fix-up use of `numEventsInWaitList` which should be `numSyncPointsInWaitList`
```
/home/ewan/Development/dpcpp/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_command_buffer.cpp:611:13: error: use of undeclared identifier 'numEventsInWaitList'
  611 |       size, numEventsInWaitList, pSyncPointWaitList, pSyncPoint);
```