### PR TITLE
[SYCL][Graph] Add exceptions for inconsistent contexst or devices on begin_recording

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -510,6 +510,18 @@ modifiable_command_graph::finalize(const sycl::property_list &) const {
 
 bool modifiable_command_graph::begin_recording(queue &RecordingQueue) {
   auto QueueImpl = sycl::detail::getSyclObjImpl(RecordingQueue);
+
+  if (QueueImpl->get_context() != impl->getContext()) {
+    throw sycl::exception(sycl::make_error_code(errc::invalid),
+                          "begin_recording called for a queue whose context "
+                          "differs from the graph context.");
+  }
+  if (QueueImpl->get_device() != impl->getDevice()) {
+    throw sycl::exception(sycl::make_error_code(errc::invalid),
+                          "begin_recording called for a queue whose device "
+                          "differs from the graph device.");
+  }
+
   if (QueueImpl->getCommandGraph() == nullptr) {
     QueueImpl->setCommandGraph(impl);
     impl->addQueue(QueueImpl);
@@ -520,7 +532,6 @@ bool modifiable_command_graph::begin_recording(queue &RecordingQueue) {
                           "begin_recording called for a queue which is already "
                           "recording to a different graph.");
   }
-
   // Queue was already recording to this graph.
   return false;
 }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -288,6 +288,10 @@ public:
   /// @return Context associated with graph.
   sycl::context getContext() const { return MContext; }
 
+  /// Query for the device tied to this graph.
+  /// @return Device associated with graph.
+  sycl::device getDevice() const { return MDevice; }
+
   /// List of root nodes.
   std::set<std::shared_ptr<node_impl>> MRoots;
 

--- a/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_contexts.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_contexts.cpp
@@ -1,0 +1,28 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+//
+
+// This test checks that an expection is thrown when we try to
+// record a graph whose context differs from the queue context.
+// We ensure that the exception code matches the expected code.
+
+#include "../graph_common.hpp"
+
+int main() {
+  queue Queue;
+
+  context InOrderContext;
+
+  exp_ext::command_graph Graph{InOrderContext, Queue.get_device()};
+
+  std::error_code ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    Graph.begin_recording(Queue);
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  assert(ExceptionCode == sycl::errc::invalid);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_devices.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_devices.cpp
@@ -1,0 +1,46 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run-unfiltered-devices} %t.out
+//
+
+// This test checks that an expection is thrown when we try to
+// record a graph whose device differs from the queue device.
+// We ensure that the exception code matches the expected code.
+
+#include "../graph_common.hpp"
+
+int GetLZeroBackend(const sycl::device &Dev) {
+  // Return 1 if the device backend is "Level_zero" or 0 else.
+  // 0 does not prevent another device to be picked as a second choice
+  return Dev.get_backend() == backend::ext_oneapi_level_zero;
+}
+
+int GetOtherBackend(const sycl::device &Dev) {
+  // Return 1 if the device backend is not "Level_zero" or 0 else.
+  // 0 does not prevent another device to be picked as a second choice
+  return Dev.get_backend() != backend::ext_oneapi_level_zero;
+}
+
+int main() {
+  sycl::device Dev0{GetLZeroBackend};
+  sycl::device Dev1{GetOtherBackend};
+
+  if (Dev0 == Dev1) {
+    // Skip if we don't have two different devices
+    std::cout << "Test skipped: the devices are the same" << std::endl;
+    return 0;
+  }
+
+  queue Queue{Dev0};
+
+  exp_ext::command_graph Graph{Queue.get_context(), Dev1};
+
+  std::error_code ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    Graph.begin_recording(Queue);
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  assert(ExceptionCode == sycl::errc::invalid);
+
+  return 0;
+}

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -154,7 +154,7 @@ TEST_F(CommandGraphTest, MakeEdge) {
 }
 
 TEST_F(CommandGraphTest, BeginEndRecording) {
-  sycl::queue Queue2{Dev};
+  sycl::queue Queue2{Queue.get_context(), Dev};
 
   // Test throwing behaviour
   // Check we can repeatedly begin recording on the same queues


### PR DESCRIPTION
Adds exception throwing if Graph and Queue contexts/devices differ when calling begin_recording. 
Adds tests to check for thrown exceptions.