### PR TITLE
[SYCL][Doc] Change `graph_support_level` namespace

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -40,6 +40,7 @@ John Pennycook, Intel +
 Guo Yejun, Intel +
 Dan Holmes, Intel +
 Greg Lueck, Intel +
+Steffen Larsen, Intel +
 Ewan Crawford, Codeplay +
 Ben Tracy, Codeplay +
 Duncan McBain, Codeplay +

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -330,15 +330,16 @@ class depends_on {
 // Device query for level of support
 namespace info {
 namespace device {
+
 struct graphs_support;
+
+} // namespace device
 
 enum class graph_support_level {
   unsupported,
   native,
   emulated
 };
-
-} // namespace device
 } // namespace info
 
 class node {};


### PR DESCRIPTION
Address [Steffen's spec feedback](https://github.com/intel/llvm/pull/5626#discussion_r1259846186) and move the `info::device::graph_support_level` enum up a namespace level to `info::graph_support_level`.

Using `info::device::graph_support` to return a `info::graph_support_level` is analogous with the `info::device::device_type` query in the main spec which returns a `info::device_type`, or `info::device::local_mem_type` which returns a `info::local_mem_type`.