### PR TITLE
[SYCL][Doc] Rephrase "recording to"

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -41,6 +41,7 @@ Guo Yejun, Intel +
 Dan Holmes, Intel +
 Greg Lueck, Intel +
 Steffen Larsen, Intel +
+Jaime Arteaga Molina, Intel +
 Ewan Crawford, Codeplay +
 Ben Tracy, Codeplay +
 Duncan McBain, Codeplay +
@@ -50,6 +51,7 @@ Gordon Brown, Codeplay +
 Erik Tomusk, Codeplay +
 Bjoern Knafla, Codeplay +
 Lukas Sommer, Codeplay +
+Maxime France-Pillois, Codeplay +
 Ronan Keryell, AMD +
 
 == Dependencies
@@ -169,13 +171,13 @@ what data is internal to the graph for optimization, and dependencies don't need
 to be inferred.
 
 It is valid to combine these two mechanisms, however it is invalid to modify
-a graph using the explicit API while that graph is currently being recorded to,
-for example:
+a graph using the explicit API while that graph is currently recording commands
+from any queue, for example:
 
 [source, c++]
 ----
 graph.begin_recording(queue);
-graph.add(/*command group*/);    // Invalid as graph is being recorded to
+graph.add(/*command group*/);    // Invalid as graph is recording a queue
 graph.end_recording();
 ----
 


### PR DESCRIPTION
[Review feedback](https://github.com/intel/llvm/pull/5626#discussion_r1260071204) questioned the phrase "graph is currently being recorded to" as to whether "to" should be "too". I don't think it should be "too", but rephrasing to "graph is currently recording any queues" avoids any confusion over grammar.

Also updated the contributors to add Maxime and Jaime (who made the comment).