### PR TITLE
[SYCL][Graph] Fix issue with CUDA device in E2E test

### DIFF
--- a/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_devices.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_devices.cpp
@@ -30,9 +30,9 @@ int main() {
     return 0;
   }
 
-  queue Queue{Dev0};
+  queue Queue{Dev1};
 
-  exp_ext::command_graph Graph{Queue.get_context(), Dev1};
+  exp_ext::command_graph Graph{Queue.get_context(), Dev0};
 
   std::error_code ExceptionCode = make_error_code(sycl::errc::success);
   try {


### PR DESCRIPTION
- Fix an issue in the inconsistent device test where if a CUDA device was selected the test would terminate due to the CUDA backend stubs implementation.
- Adjusted to always use the level zero device for making the command buffer.