### PR TITLE
[SYCL][Graph] Clang format for e2e tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // This test adds a new node with the explicit API to an already finalized
 // modifiable graph, before finalizing and executing the graph for a second
 // time.

--- a/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests adding nodes to a graph using explicit API, and submitting the graph
 // using buffers accessors for inputs and outputs.
 // The second run is to check that there are no leaks reported with the embedded

--- a/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests basic adding of nodes using explicit API with USM pointers,
 // and submission of the graph.
 // The second run is to check that there are no leaks reported with the embedded

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests adding a buffer copy node using the explicit API and submitting
 // the graph.
 // The second run is to check that there are no leaks reported with the embedded

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_2d.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests adding buffer 2d copy nodes using the explicit API and submitting
 // the graph.
 // The second run is to check that there are no leaks reported with the embedded

--- a/sycl/test-e2e/Graph/Explicit/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_ordering.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests that buffer accessors exhibit the correct behaviour when:
 // * A node is added to the graph between two queue submissions which
 //   use the same buffer, but are not added to the graph.

--- a/sycl/test-e2e/Graph/Explicit/depends_on.cpp
+++ b/sycl/test-e2e/Graph/Explicit/depends_on.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests that an event returned from adding a graph node using the queue
 // recording API can be passed to `handler::depends_on` inside a node
 // added using the explicit API. This should create a graph edge.

--- a/sycl/test-e2e/Graph/Explicit/dotp.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests constructing a graph using the explicit API to perform a dotp
 // operation using USM memory.
 // The second run is to check that there are no leaks reported with the embedded

--- a/sycl/test-e2e/Graph/Explicit/dotp_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_buffer.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests creating a dotp operation through explicit graph creation with
 // buffers.
 // The second run is to check that there are no leaks reported with the embedded

--- a/sycl/test-e2e/Graph/Explicit/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_buffer_reduction.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Expected fail as reduction support is not complete.
 // XFAIL: *
 

--- a/sycl/test-e2e/Graph/Explicit/dotp_host_mem.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_host_mem.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests using USM host memory with an explicitly constructed graph.
 // The second run is to check that there are no leaks reported with the embedded
 // ZE_DEBUG=4 testing capability.

--- a/sycl/test-e2e/Graph/Explicit/dotp_host_shared.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_host_shared.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests using USM shared and host memory with an explicitly constructed graph.
 // The second run is to check that there are no leaks reported with the embedded
 // ZE_DEBUG=4 testing capability.

--- a/sycl/test-e2e/Graph/Explicit/dotp_mixed.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_mixed.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests mixing buffers and USM in the same graph.
 // The second run is to check that there are no leaks reported with the embedded
 // ZE_DEBUG=4 testing capability.

--- a/sycl/test-e2e/Graph/Explicit/dotp_shared_mem.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_shared_mem.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests using USM shared memory with an explicitly constructed graph.
 // The second run is to check that there are no leaks reported with the embedded
 // ZE_DEBUG=4 testing capability.

--- a/sycl/test-e2e/Graph/Explicit/dotp_system_mem.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_system_mem.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests using USM system memory with an explicitly constructed graph.
 // The second run is to check that there are no leaks reported with the embedded
 // ZE_DEBUG=4 testing capability.

--- a/sycl/test-e2e/Graph/Explicit/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_usm_reduction.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Expected fail as reduction support is not complete.
 // XFAIL: *
 

--- a/sycl/test-e2e/Graph/Explicit/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/double_buffer.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Expected fail as executable graph update isn't implemented yet
 // XFAIL: *
 

--- a/sycl/test-e2e/Graph/Explicit/empty.cpp
+++ b/sycl/test-e2e/Graph/Explicit/empty.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests the explicit API interface for adding empty nodes, and that
 // no_cycle_check is accepted as a command_graph construction property.
 // The second run is to check that there are no leaks reported with the embedded

--- a/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
@@ -85,6 +85,6 @@ int main() {
 
   // Free the allocated memory
   sycl::free(Arr, Queue);
-    
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Explicit/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/Explicit/event_status_querying.cpp
@@ -24,7 +24,6 @@
 // We therefore only check that the complete state of the event
 // in this test.
 
-
 #include "../graph_common.hpp"
 
 std::string event_status_name(sycl::info::event_command_status status) {
@@ -125,8 +124,9 @@ int main() {
       Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   auto Info = Event.get_info<info::event::command_execution_status>();
   std::cout << event_status_name(Info) << std::endl;
-  while ((Info = Event.get_info<sycl::info::event::command_execution_status>()) !=
-         sycl::info::event_command_status::complete) {
+  while (
+      (Info = Event.get_info<sycl::info::event::command_execution_status>()) !=
+      sycl::info::event_command_status::complete) {
   }
   std::cout << event_status_name(Info) << std::endl;
 

--- a/sycl/test-e2e/Graph/Explicit/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill_shared.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests adding a shared USM fill operation as a graph node with the explicit
 // API.
 // The second run is to check that there are no leaks reported with the embedded

--- a/sycl/test-e2e/Graph/Explicit/while_recording.cpp
+++ b/sycl/test-e2e/Graph/Explicit/while_recording.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Expected Fail as exception not implemented yet
 // XFAIL: *
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
@@ -5,9 +5,9 @@
 //
 // CHECK-NOT: LEAK
 
-// Tests a dotp operation using device USM and an in-order queue with empty nodes.
-// The second run is to check that there are no leaks reported with the embedded
-// ZE_DEBUG=4 testing capability.
+// Tests a dotp operation using device USM and an in-order queue with empty
+// nodes. The second run is to check that there are no leaks reported with the
+// embedded ZE_DEBUG=4 testing capability.
 
 #include "../graph_common.hpp"
 

--- a/sycl/test-e2e/Graph/RecordReplay/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/event_status_querying.cpp
@@ -128,8 +128,9 @@ int main() {
       Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   auto Info = Event.get_info<info::event::command_execution_status>();
   std::cout << event_status_name(Info) << std::endl;
-  while ((Info = Event.get_info<sycl::info::event::command_execution_status>()) !=
-         sycl::info::event_command_status::complete) {
+  while (
+      (Info = Event.get_info<sycl::info::event::command_execution_status>()) !=
+      sycl::info::event_command_status::complete) {
   }
   std::cout << event_status_name(Info) << std::endl;
 

--- a/sycl/test-e2e/Graph/RecordReplay/subgraph_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/subgraph_in_order.cpp
@@ -5,7 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-
 // Tests adding a sub-graph to an in-order queue.
 
 #include "../graph_common.hpp"

--- a/sycl/test-e2e/Graph/graph_common.hpp
+++ b/sycl/test-e2e/Graph/graph_common.hpp
@@ -7,7 +7,7 @@
 // Test constants.
 constexpr size_t Size = 1024;      // Number of data elements in a buffer.
 constexpr unsigned Iterations = 5; // Iterations of graph to execute.
-constexpr size_t Offset = 100;     // Number of offset elements for Buffer accessors
+constexpr size_t Offset = 100; // Number of offset elements for Buffer accessors
 
 // Namespace alias to use in test code.
 namespace exp_ext = sycl::ext::oneapi::experimental;


### PR DESCRIPTION
Port back changes from [PR #10216](https://github.com/intel/llvm/pull/10216) to fix clang-format issues.

Changes have been applied to https://github.com/reble/llvm/tree/sycl-graph-patch-4