### PR TITLE
[SYCL][Graph] Disable failing Windows tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/reduction.cpp
@@ -1,4 +1,8 @@
 // REQUIRES: level_zero, gpu
+//
+// L0 leaks resources on Windows
+// XFAIL: windows
+//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}

--- a/sycl/test-e2e/Graph/RecordReplay/concurrent_graph.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/concurrent_graph.cpp
@@ -1,4 +1,6 @@
-// REQUIRES: level_zero, gpu
+// Test unexpectedly passes on Windows, require Linux until fixed
+// REQUIRES: level_zero, gpu, linux
+//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
@@ -1,4 +1,8 @@
 // REQUIRES: level_zero, gpu
+//
+// A non-zero exit code is returned on Windows
+// XFAIL: windows
+//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}

--- a/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
@@ -1,4 +1,8 @@
 // REQUIRES: level_zero, gpu
+//
+// A non-zero exit code is returned on Windows
+// XFAIL: windows
+//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}


### PR DESCRIPTION
Cherry-pick commit https://github.com/intel/llvm/pull/10216/commits/b78844b374eebdee72971d669582ba126689e326 from `sycl-graph-patch-4` back to `sycl-graph-develop`. Disabling the failing tests on Windows until they are investigated and resolved

* https://github.com/reble/llvm/issues/267
* https://github.com/reble/llvm/issues/268
* https://github.com/reble/llvm/issues/269