### PR TITLE
[SYCL][Graph] Use same context for e2e queues

### DIFF
--- a/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
@@ -1,8 +1,4 @@
 // REQUIRES: level_zero, gpu
-//
-// A non-zero exit code is returned on Windows
-// XFAIL: windows
-//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
@@ -17,7 +13,7 @@ int main() {
 
   property_list properties{property::queue::in_order()};
   queue QueueA{gpu_selector_v, properties};
-  queue QueueB{gpu_selector_v, properties};
+  queue QueueB{QueueA.get_context(), QueueA.get_device(), properties};
 
   exp_ext::command_graph Graph{QueueA.get_context(), QueueA.get_device()};
 

--- a/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
@@ -1,8 +1,4 @@
 // REQUIRES: level_zero, gpu
-//
-// A non-zero exit code is returned on Windows
-// XFAIL: windows
-//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
@@ -21,7 +17,7 @@ int main() {
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   {
-    queue MyQueue;
+    queue MyQueue(Queue.get_context(), Queue.get_device());
     Graph.begin_recording(MyQueue);
   }
 


### PR DESCRIPTION
Both the E2E tests `Graph/RecordReplay/dotp_multiple_queues.cpp` and `Graph/RecordReplay/valid_no_end.cpp` use multiple queues. However, they currently fail on Windows because a different context is used for each queue.

Fix this by forcing the same context to be used for all queues used in a test. Already cherry-picked to `sycl-graph-patch-4` for verification.

Closes https://github.com/reble/llvm/issues/269