### PR TITLE
[SYCL][Graph] Disable reduction test Windows leak check

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/reduction.cpp
@@ -1,11 +1,11 @@
 // REQUIRES: level_zero, gpu
 //
-// L0 leaks resources on Windows
-// XFAIL: windows
-//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// Only run leak checks on Linux, as there is a known leak with reductions
+// on Windows.
+// RUN: %if linux && ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
 //
 // CHECK-NOT: LEAK
 


### PR DESCRIPTION
Level Zero memory leaks with reductions are a known issue https://github.com/intel/llvm/pull/9764

Only run the leak component of the reduction test on Linux to avoid this issue.

Closes https://github.com/reble/llvm/issues/267