### PR TITLE
[SYCL][Graph] Error when immediate command lists are used

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
@@ -661,6 +661,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t CommandBuffer, ur_queue_handle_t Queue,
     uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
     ur_event_handle_t *Event) {
+  // There are issues with immediate command lists so return an error if the
+  // queue is in that mode.
+  if (Queue->UsingImmCmdLists) {
+    return UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES;
+  }
+
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
   // Use compute engine rather than copy engine
   const auto UseCopyEngine = false;

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -528,7 +528,14 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
               ->call_nocheck<
                   sycl::detail::PiApiKind::piextEnqueueCommandBuffer>(
                   CommandBuffer, Queue->getHandleRef(), 0, nullptr, OutEvent);
-      if (Res != pi_result::PI_SUCCESS) {
+      if (Res == pi_result::PI_ERROR_INVALID_QUEUE_PROPERTIES) {
+        throw sycl::exception(
+            make_error_code(errc::invalid),
+            "Graphs cannot be submitted to a queue which uses "
+            "immediate command lists. Use "
+            "sycl::ext::intel::property::queue::no_immediate_"
+            "command_list to disable them.");
+      } else if (Res != pi_result::PI_SUCCESS) {
         throw sycl::exception(
             errc::event,
             "Failed to enqueue event for command buffer submission");

--- a/sycl/test-e2e/Graph/immediate_command_list_error.cpp
+++ b/sycl/test-e2e/Graph/immediate_command_list_error.cpp
@@ -1,0 +1,47 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// CHECK-NOT: LEAK
+
+// Tests that graph submission will throw if the target queue is using immediate
+// command lists and not throw if they are using regular command queues.
+
+#include "graph_common.hpp"
+
+int main() {
+  queue QueueImmediate{
+      {sycl::ext::intel::property::queue::immediate_command_list{}}};
+  queue QueueNoImmediate{
+      QueueImmediate.get_context(),
+      QueueImmediate.get_device(),
+      {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  exp_ext::command_graph Graph{QueueNoImmediate.get_context(),
+                               QueueNoImmediate.get_device()};
+
+  std::error_code ErrorCode = make_error_code(sycl::errc::success);
+  try {
+    auto GraphExec = Graph.finalize();
+    QueueNoImmediate.submit(
+        [&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+  } catch (sycl::exception &E) {
+    ErrorCode = E.code();
+  }
+
+  assert(ErrorCode == make_error_code(errc::success));
+
+  ErrorCode = make_error_code(sycl::errc::success);
+  try {
+    auto GraphExec = Graph.finalize();
+    QueueImmediate.submit(
+        [&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+  } catch (sycl::exception &E) {
+    ErrorCode = E.code();
+  }
+
+  assert(ErrorCode == make_error_code(errc::invalid));
+
+  return 0;
+}


### PR DESCRIPTION
- Error when we detected immediate command lists
- Throws exception with sycl::invalid
- Test which uses property::queue::<no_>immediate_command_list to test errors.