### PR TITLE
[SYCL][Graph] Throw exception when creating graph for unsupported backend

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -730,7 +730,7 @@ void executable_command_graph::finalizeImpl() {
         info::graph_support_level::native;
 
 #if FORCE_EMULATION_MODE
-    setEmulationModeForced();
+    setEmulationModeForced(true);
 #endif
     if (impl->isEmulationModeForced()) {
       // Above query should still succeed in emulation mode, but ignore the

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -730,13 +730,10 @@ void executable_command_graph::finalizeImpl() {
         info::graph_support_level::native;
 
 #if FORCE_EMULATION_MODE
-    setEmulationModeForced(true);
+    // Above query should still succeed in emulation mode, but ignore the
+    // result and use emulation.
+    CmdBufSupport = false;
 #endif
-    if (impl->isEmulationModeForced()) {
-      // Above query should still succeed in emulation mode, but ignore the
-      // result and use emulation.
-      CmdBufSupport = false;
-    }
 
     if (CmdBufSupport) {
       impl->createCommandBuffers(Device);

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -730,10 +730,13 @@ void executable_command_graph::finalizeImpl() {
         info::graph_support_level::native;
 
 #if FORCE_EMULATION_MODE
-    // Above query should still succeed in emulation mode, but ignore the
-    // result and use emulation.
-    CmdBufSupport = false;
+    setEmulationModeForced();
 #endif
+    if (impl->isEmulationModeForced()) {
+      // Above query should still succeed in emulation mode, but ignore the
+      // result and use emulation.
+      CmdBufSupport = false;
+    }
 
     if (CmdBufSupport) {
       impl->createCommandBuffers(Device);

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -358,8 +358,7 @@ public:
       std::string BackendString = Stream.str();
       throw sycl::exception(
           sycl::make_error_code(errc::invalid),
-          BackendString +
-              " backend is not supported by SYCL Graph extension.");
+          BackendString + " backend is not supported by SYCL Graph extension.");
     }
   }
 
@@ -597,7 +596,7 @@ public:
   /// @param Forced true force to use an emulated backend
   ///               false enable the use of non-emulatated backend
   void setEmulationModeForced(bool Forced) { MEmulationModeForced = Forced; }
-  /// get the status of MEmulationModeForced member
+  /// Get the status of MEmulationModeForced member
   /// @return true is bakced is forced to emulation
   bool getEmulationModeForced() { return MEmulationModeForced; }
 
@@ -715,7 +714,9 @@ public:
   }
 
   /// @return true is emulated backend has been forced
-  bool isEmulationModeForced() const { return MGraphImpl->getEmulationModeForced(); }
+  bool isEmulationModeForced() const {
+    return MGraphImpl->getEmulationModeForced();
+  }
 
 private:
   /// Create a command-group for the node and add it to command-buffer by going

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -592,14 +592,6 @@ public:
   void makeEdge(std::shared_ptr<node_impl> Src,
                 std::shared_ptr<node_impl> Dest);
 
-  /// Force to use an emulated backend
-  /// @param Forced true force to use an emulated backend
-  ///               false enable the use of non-emulatated backend
-  void setEmulationModeForced(bool Forced) { MEmulationModeForced = Forced; }
-  /// Get the status of MEmulationModeForced member
-  /// @return true is bakced is forced to emulation
-  bool getEmulationModeForced() { return MEmulationModeForced; }
-
 private:
   /// Iterate over the graph depth-first and run \p NodeFunc on each node.
   /// @param NodeFunc A function which receives as input a node in the graph to
@@ -638,9 +630,6 @@ private:
   /// Controls whether we skip the cycle checks in makeEdge, set by the presence
   /// of the no_cycle_check property on construction.
   bool MSkipCycleChecks = false;
-
-  /// Force to use an emulated backend
-  bool MEmulationModeForced = false;
 };
 
 /// Class representing the implementation of command_graph<executable>.
@@ -711,11 +700,6 @@ public:
                                                    DebugPrint);
     }
     return false;
-  }
-
-  /// @return true if emulated backend has been forced
-  bool isEmulationModeForced() const {
-    return MGraphImpl->getEmulationModeForced();
   }
 
 private:

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -713,7 +713,7 @@ public:
     return false;
   }
 
-  /// @return true is emulated backend has been forced
+  /// @return true if emulated backend has been forced
   bool isEmulationModeForced() const {
     return MGraphImpl->getEmulationModeForced();
   }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -353,13 +353,13 @@ public:
     if (SyclDevice.get_info<
             ext::oneapi::experimental::info::device::graph_support>() ==
         info::graph_support_level::unsupported) {
-      std::stringstream ss;
-      ss << SyclDevice.get_backend();
-      std::string backendString = ss.str();
+      std::stringstream Stream;
+      Stream << SyclDevice.get_backend();
+      std::string BackendString = Stream.str();
       throw sycl::exception(
           sycl::make_error_code(errc::invalid),
-          backendString +
-              " backend is not yet supported by SYCL Graph extension.");
+          BackendString +
+              " backend is not supported by SYCL Graph extension.");
     }
   }
 

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -715,7 +715,7 @@ public:
   }
 
   /// @return true is emulated backend has been forced
-  bool isEmulationModeForced() { return MGraphImpl->getEmulationModeForced(); }
+  bool isEmulationModeForced() const { return MGraphImpl->getEmulationModeForced(); }
 
 private:
   /// Create a command-group for the node and add it to command-buffer by going

--- a/sycl/test-e2e/Graph/exception_unsupported_backend.cpp
+++ b/sycl/test-e2e/Graph/exception_unsupported_backend.cpp
@@ -2,12 +2,13 @@
 // RUN: %{run} %t.out
 
 // Tests the ability to finalize a empty command graph
-// without submitting the graph.
+// The test checks that invalid exception is thrown
+// when trying to create a graph with an unsupported backend.
 
 #include "graph_common.hpp"
 
 int GetUnsupportedBackend(const sycl::device &Dev) {
-  // Return 1 if the device backend is "cuda" or 0 else.
+  // Return 1 if the device backend is unsupported or 0 else.
   // 0 does not prevent another device to be picked as a second choice
   return Dev.get_info<
              ext::oneapi::experimental::info::device::graph_support>() ==

--- a/sycl/test-e2e/Graph/exception_unsupported_backend.cpp
+++ b/sycl/test-e2e/Graph/exception_unsupported_backend.cpp
@@ -1,0 +1,34 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests the ability to finalize a empty command graph
+// without submitting the graph.
+
+#include "graph_common.hpp"
+
+int GetUnsupportedBackend(const sycl::device &Dev) {
+  // Return 1 if the device backend is "cuda" or 0 else.
+  // 0 does not prevent another device to be picked as a second choice
+  return Dev.get_info<
+             ext::oneapi::experimental::info::device::graph_support>() ==
+         ext::oneapi::experimental::info::graph_support_level::unsupported;
+}
+
+int main() {
+  sycl::device Dev{GetUnsupportedBackend};
+  queue Queue{Dev};
+
+  if (Dev.get_info<ext::oneapi::experimental::info::device::graph_support>() !=
+      ext::oneapi::experimental::info::graph_support_level::unsupported)
+    return 0;
+
+  std::error_code ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    exp_ext::command_graph Graph{Queue.get_context(), Dev};
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  assert(ExceptionCode == sycl::errc::invalid);
+
+  return 0;
+}

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -20,14 +20,21 @@
 using namespace sycl;
 using namespace sycl::ext::oneapi;
 
+namespace {
+void forceEmulatedBackend(
+    experimental::command_graph<experimental::graph_state::modifiable> Graph) {
+  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  GraphImpl->setEmulationModeForced(true);
+}
+} // anonymous namespace
+
 class CommandGraphTest : public ::testing::Test {
 public:
   CommandGraphTest()
       : Mock{}, Plat{Mock.getPlatform()}, Dev{Plat.get_devices()[0]},
         Queue{Dev}, Graph{Queue.get_context(), Dev} {
     // We need to disable backend for unitests as backends are not loaded
-    auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-    GraphImpl->setEmulationModeForced(true);
+    forceEmulatedBackend(Graph);
   }
 
 protected:
@@ -287,8 +294,7 @@ TEST_F(CommandGraphTest, SubGraph) {
             1lu);
 
   // We need to disable backend for unitests as backends are not loaded
-  auto MainGraphImpl = sycl::detail::getSyclObjImpl(MainGraph);
-  MainGraphImpl->setEmulationModeForced(true);
+  forceEmulatedBackend(MainGraph);
 
   // Finalize main graph and check schedule
   auto MainGraphExec = MainGraph.finalize();
@@ -334,8 +340,7 @@ TEST_F(CommandGraphTest, RecordSubGraph) {
   MainGraph.end_recording(Queue);
 
   // We need to disable backend for unitests as backends are not loaded
-  auto MainGraphImpl = sycl::detail::getSyclObjImpl(MainGraph);
-  MainGraphImpl->setEmulationModeForced(true);
+  forceEmulatedBackend(MainGraph);
 
   // Finalize main graph and check schedule
   auto MainGraphExec = MainGraph.finalize();
@@ -420,8 +425,7 @@ TEST_F(CommandGraphTest, InOrderQueue) {
   InOrderGraph.end_recording(InOrderQueue);
 
   // We need to disable backend for unitests as backends are not loaded
-  auto InOrderGraphImpl = sycl::detail::getSyclObjImpl(InOrderGraph);
-  InOrderGraphImpl->setEmulationModeForced(true);
+  forceEmulatedBackend(InOrderGraph);
 
   // Finalize main graph and check schedule
   auto GraphExec = InOrderGraph.finalize();
@@ -483,8 +487,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmpty) {
   InOrderGraph.end_recording(InOrderQueue);
 
   // We need to disable backend for unitests as backends are not loaded
-  auto InOrderGraphImpl = sycl::detail::getSyclObjImpl(InOrderGraph);
-  InOrderGraphImpl->setEmulationModeForced(true);
+  forceEmulatedBackend(InOrderGraph);
 
   // Finalize main graph and check schedule
   // Note that empty nodes are not scheduled
@@ -544,8 +547,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyFirst) {
   InOrderGraph.end_recording(InOrderQueue);
 
   // We need to disable backend for unitests as backends are not loaded
-  auto InOrderGraphImpl = sycl::detail::getSyclObjImpl(InOrderGraph);
-  InOrderGraphImpl->setEmulationModeForced(true);
+  forceEmulatedBackend(InOrderGraph);
 
   // Finalize main graph and check schedule
   // Note that empty nodes are not scheduled
@@ -605,8 +607,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
   InOrderGraph.end_recording(InOrderQueue);
 
   // We need to disable backend for unitests as backends are not loaded
-  auto InOrderGraphImpl = sycl::detail::getSyclObjImpl(InOrderGraph);
-  InOrderGraphImpl->setEmulationModeForced(true);
+  forceEmulatedBackend(InOrderGraph);
 
   // Finalize main graph and check schedule
   // Note that empty nodes are not scheduled

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -24,7 +24,11 @@ class CommandGraphTest : public ::testing::Test {
 public:
   CommandGraphTest()
       : Mock{}, Plat{Mock.getPlatform()}, Dev{Plat.get_devices()[0]},
-        Queue{Dev}, Graph{Queue.get_context(), Dev} {}
+        Queue{Dev}, Graph{Queue.get_context(), Dev} {
+    // We need to disable backend for unitests as backends are not loaded
+    auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+    GraphImpl->setEmulationModeForced(true);
+  }
 
 protected:
   void SetUp() override {}
@@ -282,6 +286,10 @@ TEST_F(CommandGraphTest, SubGraph) {
   ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2MainGraph)->MPredecessors.size(),
             1lu);
 
+  // We need to disable backend for unitests as backends are not loaded
+  auto MainGraphImpl = sycl::detail::getSyclObjImpl(MainGraph);
+  MainGraphImpl->setEmulationModeForced(true);
+
   // Finalize main graph and check schedule
   auto MainGraphExec = MainGraph.finalize();
   auto MainGraphExecImpl = sycl::detail::getSyclObjImpl(MainGraphExec);
@@ -324,6 +332,10 @@ TEST_F(CommandGraphTest, RecordSubGraph) {
     cgh.single_task<class TestKernel>([]() {});
   });
   MainGraph.end_recording(Queue);
+
+  // We need to disable backend for unitests as backends are not loaded
+  auto MainGraphImpl = sycl::detail::getSyclObjImpl(MainGraph);
+  MainGraphImpl->setEmulationModeForced(true);
 
   // Finalize main graph and check schedule
   auto MainGraphExec = MainGraph.finalize();
@@ -407,6 +419,10 @@ TEST_F(CommandGraphTest, InOrderQueue) {
 
   InOrderGraph.end_recording(InOrderQueue);
 
+  // We need to disable backend for unitests as backends are not loaded
+  auto InOrderGraphImpl = sycl::detail::getSyclObjImpl(InOrderGraph);
+  InOrderGraphImpl->setEmulationModeForced(true);
+
   // Finalize main graph and check schedule
   auto GraphExec = InOrderGraph.finalize();
   auto GraphExecImpl = sycl::detail::getSyclObjImpl(GraphExec);
@@ -466,6 +482,10 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmpty) {
 
   InOrderGraph.end_recording(InOrderQueue);
 
+  // We need to disable backend for unitests as backends are not loaded
+  auto InOrderGraphImpl = sycl::detail::getSyclObjImpl(InOrderGraph);
+  InOrderGraphImpl->setEmulationModeForced(true);
+
   // Finalize main graph and check schedule
   // Note that empty nodes are not scheduled
   auto GraphExec = InOrderGraph.finalize();
@@ -523,6 +543,10 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyFirst) {
 
   InOrderGraph.end_recording(InOrderQueue);
 
+  // We need to disable backend for unitests as backends are not loaded
+  auto InOrderGraphImpl = sycl::detail::getSyclObjImpl(InOrderGraph);
+  InOrderGraphImpl->setEmulationModeForced(true);
+
   // Finalize main graph and check schedule
   // Note that empty nodes are not scheduled
   auto GraphExec = InOrderGraph.finalize();
@@ -579,6 +603,10 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
   ASSERT_EQ(PtrNode3->MPredecessors.front().lock(), PtrNode2);
 
   InOrderGraph.end_recording(InOrderQueue);
+
+  // We need to disable backend for unitests as backends are not loaded
+  auto InOrderGraphImpl = sycl::detail::getSyclObjImpl(InOrderGraph);
+  InOrderGraphImpl->setEmulationModeForced(true);
 
   // Finalize main graph and check schedule
   // Note that empty nodes are not scheduled

--- a/sycl/unittests/helpers/PiMockPlugin.hpp
+++ b/sycl/unittests/helpers/PiMockPlugin.hpp
@@ -163,7 +163,7 @@ inline pi_result mock_piDeviceGetInfo(pi_device device,
                                       size_t *param_value_size_ret) {
   constexpr char MockDeviceName[] = "Mock device";
   constexpr char MockSupportedExtensions[] =
-      "cl_khr_fp64 cl_khr_fp16 cl_khr_il_program";
+      "cl_khr_fp64 cl_khr_fp16 cl_khr_il_program ur_exp_command_buffer";
   switch (param_name) {
   case PI_DEVICE_INFO_TYPE: {
     // Act like any device is a GPU.


### PR DESCRIPTION
Checks backend when creating graphs and
throws an exception is the backend is not supported. Adds an e2e test to verify this exception throwing. Adapts Unitests to pass through the backend exception even if backends are not available for Unitests
by forcing emulation mode.