### PR TITLE
[SYCL][Graph] Throw exception when explicit add called on a graph recording a queue

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -305,11 +305,7 @@ bool graph_impl::checkForCycles() {
 
 void graph_impl::makeEdge(std::shared_ptr<node_impl> Src,
                           std::shared_ptr<node_impl> Dest) {
-  if (MRecordingQueues.size()) {
-    throw sycl::exception(make_error_code(sycl::errc::invalid),
-                          "make_edge() cannot be called when a queue is "
-                          "currently recording commands to a graph.");
-  }
+  throwIfGraphRecordingQueue("make_edge()");
   if (Src == Dest) {
     throw sycl::exception(
         make_error_code(sycl::errc::invalid),
@@ -610,6 +606,7 @@ modifiable_command_graph::modifiable_command_graph(
                                                 PropList)) {}
 
 node modifiable_command_graph::addImpl(const std::vector<node> &Deps) {
+  impl->throwIfGraphRecordingQueue("Explicit API \"Add()\" function");
   std::vector<std::shared_ptr<detail::node_impl>> DepImpls;
   for (auto &D : Deps) {
     DepImpls.push_back(sycl::detail::getSyclObjImpl(D));
@@ -621,6 +618,7 @@ node modifiable_command_graph::addImpl(const std::vector<node> &Deps) {
 
 node modifiable_command_graph::addImpl(std::function<void(handler &)> CGF,
                                        const std::vector<node> &Deps) {
+  impl->throwIfGraphRecordingQueue("Explicit API \"Add()\" function");
   std::vector<std::shared_ptr<detail::node_impl>> DepImpls;
   for (auto &D : Deps) {
     DepImpls.push_back(sycl::detail::getSyclObjImpl(D));

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -583,7 +583,7 @@ public:
                 std::shared_ptr<node_impl> Dest);
 
   /// Throws an invalid exception if this function is called
-  /// while the graph is recording a queue.
+  /// while a queue is recording commands to the graph.
   /// @param ExceptionMsg Message to append to the exception message
   void throwIfGraphRecordingQueue(const std::string ExceptionMsg) {
     if (MRecordingQueues.size()) {

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -585,7 +585,7 @@ public:
   /// Throws an invalid exception if this function is called
   /// while a queue is recording commands to the graph.
   /// @param ExceptionMsg Message to append to the exception message
-  void throwIfGraphRecordingQueue(const std::string ExceptionMsg) {
+  void throwIfGraphRecordingQueue(const std::string ExceptionMsg) const  {
     if (MRecordingQueues.size()) {
       throw sycl::exception(make_error_code(sycl::errc::invalid),
                             ExceptionMsg +

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -582,7 +582,7 @@ public:
   void makeEdge(std::shared_ptr<node_impl> Src,
                 std::shared_ptr<node_impl> Dest);
 
-  /// Throws an invalid exception if this function called
+  /// Throws an invalid exception if this function is called
   /// while the graph is recording a queue.
   /// @param ExceptionMsg Message to append to the exception message
   void throwIfGraphRecordingQueue(const std::string ExceptionMsg) {

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -582,6 +582,18 @@ public:
   void makeEdge(std::shared_ptr<node_impl> Src,
                 std::shared_ptr<node_impl> Dest);
 
+  /// Throws an invalid exception if this function called
+  /// while the graph is recording a queue.
+  /// @param ExceptionMsg Message to append to the exception message
+  void throwIfGraphRecordingQueue(const std::string ExceptionMsg) {
+    if (MRecordingQueues.size()) {
+      throw sycl::exception(make_error_code(sycl::errc::invalid),
+                            ExceptionMsg +
+                                " cannot be called when a queue "
+                                "is currently recording commands to a graph.");
+    }
+  }
+
 private:
   /// Iterate over the graph depth-first and run \p NodeFunc on each node.
   /// @param NodeFunc A function which receives as input a node in the graph to

--- a/sycl/test-e2e/Graph/Explicit/while_recording.cpp
+++ b/sycl/test-e2e/Graph/Explicit/while_recording.cpp
@@ -34,10 +34,7 @@ int main() {
   try {
     Graph.add({});
   } catch (sycl::exception &E) {
-    auto StdErrc = E.code().value();
-    if (StdErrc == static_cast<int>(errc::invalid)) {
-      Success = true;
-    }
+    Success = E.code() == static_cast<int>(errc::invalid)
   }
   assert(Success);
 

--- a/sycl/test-e2e/Graph/Explicit/while_recording.cpp
+++ b/sycl/test-e2e/Graph/Explicit/while_recording.cpp
@@ -5,9 +5,6 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected Fail as exception not implemented yet
-// XFAIL: *
-
 // Tests attempting to add a node to a command_graph while it is being
 // recorded to by a queue is an error.
 // The second run is to check that there are no leaks reported with the embedded
@@ -31,8 +28,19 @@ int main() {
       Success = true;
     }
   }
+  assert(Success);
+
+  Success = false;
+  try {
+    Graph.add({});
+  } catch (sycl::exception &E) {
+    auto StdErrc = E.code().value();
+    if (StdErrc == static_cast<int>(errc::invalid)) {
+      Success = true;
+    }
+  }
+  assert(Success);
 
   Graph.end_recording();
-  assert(Success);
   return 0;
 }


### PR DESCRIPTION
Factorizes the exception throwing method when the explicit API is used on a graph recording a queue Improves the test while_recording to test throwing an invalid exception for the two explicit graph:add entry points.

Addresses issue #271