### PR TITLE
[SYCL][Graph] Improve threading tests

### DIFF
--- a/sycl/test-e2e/Graph/Threading/finalize.cpp
+++ b/sycl/test-e2e/Graph/Threading/finalize.cpp
@@ -10,33 +10,8 @@
 // ZE_DEBUG=4 testing capability.
 
 #include "../graph_common.hpp"
-#include <detail/graph_impl.hpp>
 
 #include <thread>
-
-bool checkExecGraphSchedule(
-    std::shared_ptr<sycl::ext::oneapi::experimental::detail::exec_graph_impl>
-        GraphA,
-    std::shared_ptr<sycl::ext::oneapi::experimental::detail::exec_graph_impl>
-        GraphB) {
-  auto ScheduleA = GraphA->getSchedule();
-  auto ScheduleB = GraphB->getSchedule();
-  if (ScheduleA.size() != ScheduleB.size())
-    return false;
-
-  std::vector<
-      std::shared_ptr<sycl::ext::oneapi::experimental::detail::node_impl>>
-      VScheduleA{std::begin(ScheduleA), std::end(ScheduleA)};
-  std::vector<
-      std::shared_ptr<sycl::ext::oneapi::experimental::detail::node_impl>>
-      VScheduleB{std::begin(ScheduleB), std::end(ScheduleB)};
-
-  for (size_t i = 0; i < VScheduleA.size(); i++) {
-    if (!VScheduleA[i]->isSimilar(VScheduleB[i]))
-      return false;
-  }
-  return true;
-}
 
 int main() {
   queue Queue;
@@ -71,15 +46,9 @@ int main() {
 
   Barrier SyncPoint{NumThreads};
 
-  std::map<int, exp_ext::command_graph<exp_ext::graph_state::executable>>
-      GraphsExecMap;
   auto FinalizeGraph = [&](int ThreadNum) {
     SyncPoint.wait();
     auto GraphExec = Graph.finalize();
-    GraphsExecMap.insert(
-        std::map<int,
-                 exp_ext::command_graph<exp_ext::graph_state::executable>>::
-            value_type(ThreadNum, GraphExec));
     Queue.submit([&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   };
 
@@ -100,37 +69,6 @@ int main() {
   Queue.copy(PtrB, DataB.data(), Size);
   Queue.copy(PtrC, DataC.data(), Size);
   Queue.wait_and_throw();
-
-  // Ref computation
-  queue QueueRef{Queue.get_context(), Queue.get_device()};
-  exp_ext::command_graph GraphRef{Queue.get_context(), Queue.get_device()};
-
-  T *PtrARef = malloc_device<T>(Size, QueueRef);
-  T *PtrBRef = malloc_device<T>(Size, QueueRef);
-  T *PtrCRef = malloc_device<T>(Size, QueueRef);
-
-  QueueRef.copy(DataA.data(), PtrARef, Size);
-  QueueRef.copy(DataB.data(), PtrBRef, Size);
-  QueueRef.copy(DataC.data(), PtrCRef, Size);
-  QueueRef.wait_and_throw();
-
-  GraphRef.begin_recording(QueueRef);
-  run_kernels_usm(QueueRef, Size, PtrA, PtrB, PtrC);
-  GraphRef.end_recording();
-
-  for (unsigned i = 0; i < NumThreads; ++i) {
-    auto GraphExecRef = GraphRef.finalize();
-    QueueRef.submit(
-        [&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExecRef); });
-    auto GraphExecImpl =
-        sycl::detail::getSyclObjImpl(GraphsExecMap.find(i)->second);
-    auto GraphExecRefImpl = sycl::detail::getSyclObjImpl(GraphExecRef);
-    assert(checkExecGraphSchedule(GraphExecImpl, GraphExecRefImpl));
-  }
-
-  free(PtrARef, QueueRef);
-  free(PtrBRef, QueueRef);
-  free(PtrCRef, QueueRef);
 
   free(PtrA, Queue);
   free(PtrB, Queue);

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -101,10 +101,6 @@ class SYCLEndToEndTest(lit.formats.ShTest):
         # -other restrictions).
         substitutions.append(('%{build}', '%clangxx -fsycl -fsycl-targets=%{sycl_triple} %s'))
 
-        # get GIT root path
-        stream = os.popen('git rev-parse --show-toplevel')
-        git_root_path = stream.read()[:-1]
-            
         compilation_cmd_pthread = "%clangxx -pthread -fsycl -fsycl-targets=%{sycl_triple} %s"
         substitutions.append(('%{build_pthread_inc}', compilation_cmd_pthread))
         

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -104,13 +104,8 @@ class SYCLEndToEndTest(lit.formats.ShTest):
         # get GIT root path
         stream = os.popen('git rev-parse --show-toplevel')
         git_root_path = stream.read()[:-1]
-
-        if 'windows' in test.config.available_features:
-            source_files_path = git_root_path+"\sycl\source" 
-        else:
-            source_files_path = git_root_path+"/sycl/source"
             
-        compilation_cmd_pthread = "%clangxx -I" + source_files_path + " -pthread -fsycl -fsycl-targets=%{sycl_triple} %s"
+        compilation_cmd_pthread = "%clangxx -pthread -fsycl -fsycl-targets=%{sycl_triple} %s"
         substitutions.append(('%{build_pthread_inc}', compilation_cmd_pthread))
         
         def get_extra_env(sycl_devices):

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -15,6 +15,7 @@
 #include <detail/config.hpp>
 #include <helpers/PiMock.hpp>
 #include <helpers/ScopedEnvVar.hpp>
+#include <helpers/TestKernel.hpp>
 
 #include <gtest/gtest.h>
 
@@ -310,18 +311,18 @@ bool depthSearchSuccessorCheck(
 /// @param Q Queue to submit nodes to.
 void runKernels(queue Q) {
   auto NodeA = Q.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto NodeB = Q.submit([&](sycl::handler &cgh) {
     cgh.depends_on(NodeA);
-    cgh.single_task<class TestKernel>([]() {});
+    cgh.single_task<TestKernel<>>([]() {});
   });
   auto NodeC = Q.submit([&](sycl::handler &cgh) {
     cgh.depends_on(NodeA);
-    cgh.single_task<class TestKernel>([]() {});
+    cgh.single_task<TestKernel<>>([]() {});
   });
   auto NodeD = Q.submit([&](sycl::handler &cgh) {
     cgh.depends_on({NodeB, NodeC});
-    cgh.single_task<class TestKernel>([]() {});
+    cgh.single_task<TestKernel<>>([]() {});
   });
 }
 
@@ -329,13 +330,13 @@ void runKernels(queue Q) {
 /// @param Q Queue to submit nodes to.
 void runKernelsInOrder(queue Q) {
   auto NodeA = Q.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto NodeB = Q.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto NodeC = Q.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto NodeD = Q.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 }
 
 /// Adds four kernels with diamond dependency to the Graph G
@@ -343,16 +344,40 @@ void runKernelsInOrder(queue Q) {
 void addKernels(
     experimental::command_graph<experimental::graph_state::modifiable> G) {
   auto NodeA = G.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
-  auto NodeB = G.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); },
-      {experimental::property::node::depends_on(NodeA)});
-  auto NodeC = G.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); },
-      {experimental::property::node::depends_on(NodeA)});
-  auto NodeD = G.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); },
-      {experimental::property::node::depends_on(NodeB, NodeC)});
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto NodeB =
+      G.add([&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); },
+            {experimental::property::node::depends_on(NodeA)});
+  auto NodeC =
+      G.add([&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); },
+            {experimental::property::node::depends_on(NodeA)});
+  auto NodeD =
+      G.add([&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); },
+            {experimental::property::node::depends_on(NodeB, NodeC)});
+}
+
+bool checkExecGraphSchedule(
+    std::shared_ptr<sycl::ext::oneapi::experimental::detail::exec_graph_impl>
+        GraphA,
+    std::shared_ptr<sycl::ext::oneapi::experimental::detail::exec_graph_impl>
+        GraphB) {
+  auto ScheduleA = GraphA->getSchedule();
+  auto ScheduleB = GraphB->getSchedule();
+  if (ScheduleA.size() != ScheduleB.size())
+    return false;
+
+  std::vector<
+      std::shared_ptr<sycl::ext::oneapi::experimental::detail::node_impl>>
+      VScheduleA{std::begin(ScheduleA), std::end(ScheduleA)};
+  std::vector<
+      std::shared_ptr<sycl::ext::oneapi::experimental::detail::node_impl>>
+      VScheduleB{std::begin(ScheduleB), std::end(ScheduleB)};
+
+  for (size_t i = 0; i < VScheduleA.size(); i++) {
+    if (!VScheduleA[i]->isSimilar(VScheduleB[i]))
+      return false;
+  }
+  return true;
 }
 
 } // anonymous namespace
@@ -394,7 +419,7 @@ TEST_F(CommandGraphTest, AddNode) {
   ASSERT_TRUE(GraphImpl->MRoots.empty());
 
   auto Node1 = Graph.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   ASSERT_NE(sycl::detail::getSyclObjImpl(Node1), nullptr);
   ASSERT_FALSE(sycl::detail::getSyclObjImpl(Node1)->isEmpty());
   ASSERT_EQ(GraphImpl->MRoots.size(), 1lu);
@@ -454,7 +479,7 @@ TEST_F(CommandGraphTest, Finalize) {
 
   // Add independent node
   auto Node2 = Graph.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   // Add a node that depends on Node1 due to the accessor
   auto Node3 = Graph.add([&](sycl::handler &cgh) {
@@ -485,7 +510,7 @@ TEST_F(CommandGraphTest, MakeEdge) {
 
   // Add two independent nodes
   auto Node1 = Graph.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto Node2 = Graph.add([&](sycl::handler &cgh) {});
   ASSERT_EQ(GraphImpl->MRoots.size(), 2ul);
   ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1)->MSuccessors.empty());
@@ -579,7 +604,7 @@ TEST_F(CommandGraphTest, BeginEndRecording) {
 TEST_F(CommandGraphTest, GetCGCopy) {
   auto Node1 = Graph.add([&](sycl::handler &cgh) {});
   auto Node2 = Graph.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); },
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); },
       {experimental::property::node::depends_on(Node1)});
 
   // Get copy of CG of Node2 and check equality
@@ -601,21 +626,21 @@ TEST_F(CommandGraphTest, GetCGCopy) {
 TEST_F(CommandGraphTest, SubGraph) {
   // Add sub-graph with two nodes
   auto Node1Graph = Graph.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto Node2Graph = Graph.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); },
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); },
       {experimental::property::node::depends_on(Node1Graph)});
   auto GraphExec = Graph.finalize();
 
   // Add node to main graph followed by sub-graph and another node
   experimental::command_graph MainGraph(Queue.get_context(), Dev);
   auto Node1MainGraph = MainGraph.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto Node2MainGraph =
       MainGraph.add([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); },
                     {experimental::property::node::depends_on(Node1MainGraph)});
   auto Node3MainGraph = MainGraph.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); },
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); },
       {experimental::property::node::depends_on(Node2MainGraph)});
 
   // Assert order of the added sub-graph
@@ -653,10 +678,10 @@ TEST_F(CommandGraphTest, RecordSubGraph) {
   // Record sub-graph with two nodes
   Graph.begin_recording(Queue);
   auto Node1Graph = Queue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto Node2Graph = Queue.submit([&](sycl::handler &cgh) {
     cgh.depends_on(Node1Graph);
-    cgh.single_task<class TestKernel>([]() {});
+    cgh.single_task<TestKernel<>>([]() {});
   });
   Graph.end_recording(Queue);
   auto GraphExec = Graph.finalize();
@@ -665,14 +690,14 @@ TEST_F(CommandGraphTest, RecordSubGraph) {
   experimental::command_graph MainGraph(Queue.get_context(), Dev);
   MainGraph.begin_recording(Queue);
   auto Node1MainGraph = Queue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto Node2MainGraph = Queue.submit([&](handler &cgh) {
     cgh.depends_on(Node1MainGraph);
     cgh.ext_oneapi_graph(GraphExec);
   });
   auto Node3MainGraph = Queue.submit([&](sycl::handler &cgh) {
     cgh.depends_on(Node2MainGraph);
-    cgh.single_task<class TestKernel>([]() {});
+    cgh.single_task<TestKernel<>>([]() {});
   });
   MainGraph.end_recording(Queue);
 
@@ -722,7 +747,7 @@ TEST_F(CommandGraphTest, InOrderQueue) {
   // Record in-order queue with three nodes
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   auto PtrNode1 =
       sycl::detail::getSyclObjImpl(InOrderGraph)
@@ -731,7 +756,7 @@ TEST_F(CommandGraphTest, InOrderQueue) {
   ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
   auto Node2Graph = InOrderQueue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   auto PtrNode2 =
       sycl::detail::getSyclObjImpl(InOrderGraph)
@@ -744,7 +769,7 @@ TEST_F(CommandGraphTest, InOrderQueue) {
   ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
 
   auto Node3Graph = InOrderQueue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   auto PtrNode3 =
       sycl::detail::getSyclObjImpl(InOrderGraph)
@@ -782,7 +807,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmpty) {
   // node
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   auto PtrNode1 =
       sycl::detail::getSyclObjImpl(InOrderGraph)
@@ -803,7 +828,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmpty) {
   ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
 
   auto Node3Graph = InOrderQueue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   auto PtrNode3 =
       sycl::detail::getSyclObjImpl(InOrderGraph)
@@ -847,7 +872,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyFirst) {
   ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
   auto Node2Graph = InOrderQueue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   auto PtrNode2 =
       sycl::detail::getSyclObjImpl(InOrderGraph)
@@ -860,7 +885,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyFirst) {
   ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
 
   auto Node3Graph = InOrderQueue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   auto PtrNode3 =
       sycl::detail::getSyclObjImpl(InOrderGraph)
@@ -896,7 +921,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
   // Record in-order queue with two regular nodes then an empty node
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   auto PtrNode1 =
       sycl::detail::getSyclObjImpl(InOrderGraph)
@@ -905,7 +930,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
   ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
   auto Node2Graph = InOrderQueue.submit(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   auto PtrNode2 =
       sycl::detail::getSyclObjImpl(InOrderGraph)
@@ -947,9 +972,9 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
 TEST_F(CommandGraphTest, MakeEdgeErrors) {
   // Set up some nodes in the graph
   auto NodeA = Graph.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto NodeB = Graph.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   // Test error on calling make_edge when a queue is recording to the graph
   Graph.begin_recording(Queue);
@@ -982,7 +1007,7 @@ TEST_F(CommandGraphTest, MakeEdgeErrors) {
   experimental::command_graph<experimental::graph_state::modifiable> GraphOther{
       Queue.get_context(), Queue.get_device()};
   auto NodeOther = GraphOther.add(
-      [&](sycl::handler &cgh) { cgh.single_task<class TestKernel>([]() {}); });
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
   ASSERT_THROW(
       {
@@ -1299,5 +1324,48 @@ TEST_F(MultiThreadGraphTest, RecordAddNodesInOrderQueue) {
   // Check structure graph
   for (auto Node : GraphImpl->MRoots) {
     ASSERT_EQ(depthSearchSuccessorCheck(Node), true);
+  }
+}
+
+TEST_F(MultiThreadGraphTest, Finalize) {
+  addKernels(Graph);
+
+  std::map<int,
+           experimental::command_graph<experimental::graph_state::executable>>
+      GraphsExecMap;
+  auto FinalizeGraph = [&](int ThreadNum) {
+    SyncPoint.wait();
+    auto GraphExec = Graph.finalize();
+
+    GraphsExecMap.insert(
+        std::map<int, experimental::command_graph<
+                          experimental::graph_state::executable>>::
+            value_type(ThreadNum, GraphExec));
+    Queue.submit([&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+  };
+
+  for (unsigned i = 0; i < NumThreads; ++i) {
+    Threads.emplace_back(FinalizeGraph, i);
+  }
+
+  for (unsigned i = 0; i < NumThreads; ++i) {
+    Threads[i].join();
+  }
+
+  // Reference computation
+  queue QueueRef;
+  experimental::command_graph<experimental::graph_state::modifiable> GraphRef{
+      Queue.get_context(), Queue.get_device()};
+
+  addKernels(GraphRef);
+
+  for (unsigned i = 0; i < NumThreads; ++i) {
+    auto GraphExecRef = GraphRef.finalize();
+    QueueRef.submit(
+        [&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExecRef); });
+    auto GraphExecImpl =
+        sycl::detail::getSyclObjImpl(GraphsExecMap.find(i)->second);
+    auto GraphExecRefImpl = sycl::detail::getSyclObjImpl(GraphExecRef);
+    ASSERT_EQ(checkExecGraphSchedule(GraphExecImpl, GraphExecRefImpl), true);
   }
 }


### PR DESCRIPTION
Improves threading tests by removing the dependency of test-e2e to graph_impl.hpp.
The part of the test requesting graph_impl has been moved to unitest. Finalize e2e test is kept as still useful for memory leak checking.