### PR TITLE
[SYCL][Graph] Throw exception when using bindless images extension in a graph

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -37,7 +37,8 @@ enum class UnsupportedGraphFeatures {
   sycl_ext_oneapi_kernel_properties,
   sycl_ext_oneapi_enqueue_barrier,
   sycl_ext_oneapi_memcpy2d,
-  sycl_ext_oneapi_device_global
+  sycl_ext_oneapi_device_global,
+  sycl_ext_oneapi_bindless_images
 };
 
 constexpr const char *
@@ -58,6 +59,8 @@ UnsupportedFeatureToString(UnsupportedGraphFeatures Feature) {
     return "sycl_ext_oneapi_memcpy2d";
   case UGF::sycl_ext_oneapi_device_global:
     return "sycl_ext_oneapi_device_global";
+  case UGF::sycl_ext_oneapi_bindless_images:
+    return "sycl_ext_oneapi_bindless_images";
   default:
     return {};
   }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -903,8 +903,9 @@ void handler::ext_oneapi_memset2d_impl(void *Dest, size_t DestPitch, int Value,
 void handler::ext_oneapi_copy(
     void *Src, ext::oneapi::experimental::image_mem_handle Dest,
     const ext::oneapi::experimental::image_descriptor &Desc) {
-  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
-                             sycl_ext_oneapi_bindless_images>();
+  throwIfGraphAssociated<
+      ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
+          sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src;
   MDstPtr = Dest.raw_handle;
 
@@ -938,8 +939,9 @@ void handler::ext_oneapi_copy(
     ext::oneapi::experimental::image_mem_handle Dest, sycl::range<3> DestOffset,
     const ext::oneapi::experimental::image_descriptor &DestImgDesc,
     sycl::range<3> CopyExtent) {
-  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
-                             sycl_ext_oneapi_bindless_images>();
+  throwIfGraphAssociated<
+      ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
+          sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src;
   MDstPtr = Dest.raw_handle;
 
@@ -972,8 +974,9 @@ void handler::ext_oneapi_copy(
 void handler::ext_oneapi_copy(
     ext::oneapi::experimental::image_mem_handle Src, void *Dest,
     const ext::oneapi::experimental::image_descriptor &Desc) {
-  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
-                             sycl_ext_oneapi_bindless_images>();
+  throwIfGraphAssociated<
+      ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
+          sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src.raw_handle;
   MDstPtr = Dest;
 
@@ -1007,8 +1010,9 @@ void handler::ext_oneapi_copy(
     const ext::oneapi::experimental::image_descriptor &SrcImgDesc, void *Dest,
     sycl::range<3> DestOffset, sycl::range<3> DestExtent,
     sycl::range<3> CopyExtent) {
-  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
-                             sycl_ext_oneapi_bindless_images>();
+  throwIfGraphAssociated<
+      ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
+          sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src.raw_handle;
   MDstPtr = Dest;
 
@@ -1041,8 +1045,9 @@ void handler::ext_oneapi_copy(
 void handler::ext_oneapi_copy(
     void *Src, void *Dest,
     const ext::oneapi::experimental::image_descriptor &Desc, size_t Pitch) {
-  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
-                             sycl_ext_oneapi_bindless_images>();
+  throwIfGraphAssociated<
+      ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
+          sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src;
   MDstPtr = Dest;
 
@@ -1078,8 +1083,9 @@ void handler::ext_oneapi_copy(
     const ext::oneapi::experimental::image_descriptor &DeviceImgDesc,
     size_t DeviceRowPitch, sycl::range<3> HostExtent,
     sycl::range<3> CopyExtent) {
-  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
-                             sycl_ext_oneapi_bindless_images>();
+  throwIfGraphAssociated<
+      ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
+          sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src;
   MDstPtr = Dest;
 
@@ -1113,8 +1119,9 @@ void handler::ext_oneapi_copy(
 
 void handler::ext_oneapi_wait_external_semaphore(
     sycl::ext::oneapi::experimental::interop_semaphore_handle SemaphoreHandle) {
-  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
-                             sycl_ext_oneapi_bindless_images>();
+  throwIfGraphAssociated<
+      ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
+          sycl_ext_oneapi_bindless_images>();
   MImpl->MInteropSemaphoreHandle =
       (sycl::detail::pi::PiInteropSemaphoreHandle)SemaphoreHandle.raw_handle;
   setType(detail::CG::SemaphoreWait);
@@ -1122,8 +1129,9 @@ void handler::ext_oneapi_wait_external_semaphore(
 
 void handler::ext_oneapi_signal_external_semaphore(
     sycl::ext::oneapi::experimental::interop_semaphore_handle SemaphoreHandle) {
-  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
-                             sycl_ext_oneapi_bindless_images>();
+  throwIfGraphAssociated<
+      ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
+          sycl_ext_oneapi_bindless_images>();
   MImpl->MInteropSemaphoreHandle =
       (sycl::detail::pi::PiInteropSemaphoreHandle)SemaphoreHandle.raw_handle;
   setType(detail::CG::SemaphoreSignal);

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -903,6 +903,8 @@ void handler::ext_oneapi_memset2d_impl(void *Dest, size_t DestPitch, int Value,
 void handler::ext_oneapi_copy(
     void *Src, ext::oneapi::experimental::image_mem_handle Dest,
     const ext::oneapi::experimental::image_descriptor &Desc) {
+  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
+                             sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src;
   MDstPtr = Dest.raw_handle;
 
@@ -936,7 +938,8 @@ void handler::ext_oneapi_copy(
     ext::oneapi::experimental::image_mem_handle Dest, sycl::range<3> DestOffset,
     const ext::oneapi::experimental::image_descriptor &DestImgDesc,
     sycl::range<3> CopyExtent) {
-
+  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
+                             sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src;
   MDstPtr = Dest.raw_handle;
 
@@ -969,6 +972,8 @@ void handler::ext_oneapi_copy(
 void handler::ext_oneapi_copy(
     ext::oneapi::experimental::image_mem_handle Src, void *Dest,
     const ext::oneapi::experimental::image_descriptor &Desc) {
+  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
+                             sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src.raw_handle;
   MDstPtr = Dest;
 
@@ -1002,6 +1007,8 @@ void handler::ext_oneapi_copy(
     const ext::oneapi::experimental::image_descriptor &SrcImgDesc, void *Dest,
     sycl::range<3> DestOffset, sycl::range<3> DestExtent,
     sycl::range<3> CopyExtent) {
+  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
+                             sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src.raw_handle;
   MDstPtr = Dest;
 
@@ -1034,6 +1041,8 @@ void handler::ext_oneapi_copy(
 void handler::ext_oneapi_copy(
     void *Src, void *Dest,
     const ext::oneapi::experimental::image_descriptor &Desc, size_t Pitch) {
+  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
+                             sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src;
   MDstPtr = Dest;
 
@@ -1069,6 +1078,8 @@ void handler::ext_oneapi_copy(
     const ext::oneapi::experimental::image_descriptor &DeviceImgDesc,
     size_t DeviceRowPitch, sycl::range<3> HostExtent,
     sycl::range<3> CopyExtent) {
+  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
+                             sycl_ext_oneapi_bindless_images>();
   MSrcPtr = Src;
   MDstPtr = Dest;
 
@@ -1102,6 +1113,8 @@ void handler::ext_oneapi_copy(
 
 void handler::ext_oneapi_wait_external_semaphore(
     sycl::ext::oneapi::experimental::interop_semaphore_handle SemaphoreHandle) {
+  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
+                             sycl_ext_oneapi_bindless_images>();
   MImpl->MInteropSemaphoreHandle =
       (sycl::detail::pi::PiInteropSemaphoreHandle)SemaphoreHandle.raw_handle;
   setType(detail::CG::SemaphoreWait);
@@ -1109,6 +1122,8 @@ void handler::ext_oneapi_wait_external_semaphore(
 
 void handler::ext_oneapi_signal_external_semaphore(
     sycl::ext::oneapi::experimental::interop_semaphore_handle SemaphoreHandle) {
+  throwIfGraphAssociated<ext::oneapi::experimental::detail::SyclExtensions::
+                             sycl_ext_oneapi_bindless_images>();
   MImpl->MInteropSemaphoreHandle =
       (sycl::detail::pi::PiInteropSemaphoreHandle)SemaphoreHandle.raw_handle;
   setType(detail::CG::SemaphoreSignal);

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -311,6 +311,160 @@ void addMemcpy2D(experimental::detail::modifiable_command_graph &G, queue &Q,
   ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
 }
 
+/// Tries to add nodes including images bindless copy instructions
+/// to the graph G. It tests that an invalid exception has been thrown
+/// Since sycl_ext_oneapi_bindless_images extension can not be used
+/// along with SYCL Graph.
+///
+/// @param G Modifiable graph to add commands to.
+/// @param Q Queue to submit nodes to.
+/// @param Img Image memory
+/// @param HostData Host Pointer to the memory
+/// @param ImgUSM USM Pointer to Image memory
+/// @param Pitch image pitch
+/// @param Desc Image descriptor
+template <OperationPath PathKind>
+void addImagesCopies(experimental::detail::modifiable_command_graph &G,
+                     queue &Q, sycl::ext::oneapi::experimental::image_mem Img,
+                     std::vector<sycl::float4> HostData, void *ImgUSM,
+                     size_t Pitch,
+                     sycl::ext::oneapi::experimental::image_descriptor Desc) {
+  // simple copy Host to Device
+  std::error_code ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    if constexpr (PathKind == OperationPath::RecordReplay) {
+      Q.submit([&](handler &CGH) {
+        CGH.ext_oneapi_copy(HostData.data(), Img.get_handle(), Desc);
+      });
+    }
+    if constexpr (PathKind == OperationPath::Shortcut) {
+      Q.ext_oneapi_copy(HostData.data(), Img.get_handle(), Desc);
+    }
+    if constexpr (PathKind == OperationPath::Explicit) {
+      G.add([&](handler &CGH) {
+        CGH.ext_oneapi_copy(HostData.data(), Img.get_handle(), Desc);
+      });
+    }
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  // simple copy Device to Host
+  ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    if constexpr (PathKind == OperationPath::RecordReplay) {
+      Q.submit([&](handler &CGH) {
+        CGH.ext_oneapi_copy(Img.get_handle(), HostData.data(), Desc);
+      });
+    }
+    if constexpr (PathKind == OperationPath::Shortcut) {
+      Q.ext_oneapi_copy(Img.get_handle(), HostData.data(), Desc);
+    }
+    if constexpr (PathKind == OperationPath::Explicit) {
+      G.add([&](handler &CGH) {
+        CGH.ext_oneapi_copy(Img.get_handle(), HostData.data(), Desc);
+      });
+    }
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  // simple copy Host to Device USM
+  ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    if constexpr (PathKind == OperationPath::RecordReplay) {
+      Q.submit([&](handler &CGH) {
+        CGH.ext_oneapi_copy(HostData.data(), ImgUSM, Desc, Pitch);
+      });
+    }
+    if constexpr (PathKind == OperationPath::Shortcut) {
+      Q.ext_oneapi_copy(HostData.data(), ImgUSM, Desc, Pitch);
+    }
+    if constexpr (PathKind == OperationPath::Explicit) {
+      G.add([&](handler &CGH) {
+        CGH.ext_oneapi_copy(HostData.data(), ImgUSM, Desc, Pitch);
+      });
+    }
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  // subregion copy Host to Device
+  ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    if constexpr (PathKind == OperationPath::RecordReplay) {
+      Q.submit([&](handler &CGH) {
+        CGH.ext_oneapi_copy(HostData.data(), {0, 0, 0}, {0, 0, 0},
+                            Img.get_handle(), {0, 0, 0}, Desc, {0, 0, 0});
+      });
+    }
+    if constexpr (PathKind == OperationPath::Shortcut) {
+      Q.ext_oneapi_copy(HostData.data(), {0, 0, 0}, {0, 0, 0}, Img.get_handle(),
+                        {0, 0, 0}, Desc, {0, 0, 0});
+    }
+    if constexpr (PathKind == OperationPath::Explicit) {
+      G.add([&](handler &CGH) {
+        CGH.ext_oneapi_copy(HostData.data(), {0, 0, 0}, {0, 0, 0},
+                            Img.get_handle(), {0, 0, 0}, Desc, {0, 0, 0});
+      });
+    }
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  // subregion copy Device to Host
+  ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    if constexpr (PathKind == OperationPath::RecordReplay) {
+      Q.submit([&](handler &CGH) {
+        CGH.ext_oneapi_copy(Img.get_handle(), {0, 0, 0}, Desc, HostData.data(),
+                            {0, 0, 0}, {0, 0, 0}, {0, 0, 0});
+      });
+    }
+    if constexpr (PathKind == OperationPath::Shortcut) {
+      Q.ext_oneapi_copy(Img.get_handle(), {0, 0, 0}, Desc, HostData.data(),
+                        {0, 0, 0}, {0, 0, 0}, {0, 0, 0});
+    }
+    if constexpr (PathKind == OperationPath::Explicit) {
+      G.add([&](handler &CGH) {
+        CGH.ext_oneapi_copy(Img.get_handle(), {0, 0, 0}, Desc, HostData.data(),
+                            {0, 0, 0}, {0, 0, 0}, {0, 0, 0});
+      });
+    }
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  // subregion copy Host to Device USM
+  ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    if constexpr (PathKind == OperationPath::RecordReplay) {
+      Q.submit([&](handler &CGH) {
+        CGH.ext_oneapi_copy(HostData.data(), {0, 0, 0}, ImgUSM, {0, 0, 0}, Desc,
+                            Pitch, {0, 0, 0}, {0, 0, 0});
+      });
+    }
+    if constexpr (PathKind == OperationPath::Shortcut) {
+      Q.ext_oneapi_copy(HostData.data(), {0, 0, 0}, ImgUSM, {0, 0, 0}, Desc,
+                        Pitch, {0, 0, 0}, {0, 0, 0});
+    }
+    if constexpr (PathKind == OperationPath::Explicit) {
+      G.add([&](handler &CGH) {
+        CGH.ext_oneapi_copy(HostData.data(), {0, 0, 0}, ImgUSM, {0, 0, 0}, Desc,
+                            Pitch, {0, 0, 0}, {0, 0, 0});
+      });
+    }
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+}
+
 bool depthSearchSuccessorCheck(
     std::shared_ptr<sycl::ext::oneapi::experimental::detail::node_impl> Node) {
   if (Node->MSuccessors.size() > 1)
@@ -1248,6 +1402,47 @@ TEST_F(CommandGraphTest, Reductions) {
         }
       },
       sycl::exception);
+}
+
+TEST_F(CommandGraphTest, BindlessExceptionCheck) {
+  auto ctxt = Queue.get_context();
+
+  // declare image data
+  size_t height = 13;
+  size_t width = 7;
+  size_t depth = 11;
+  size_t N = height * width * depth;
+  std::vector<sycl::float4> out(N);
+  std::vector<float> expected(N);
+  std::vector<sycl::float4> dataIn(N);
+
+  // Extension: image descriptor - can use the same for both images
+  sycl::ext::oneapi::experimental::image_descriptor desc(
+      {width, height, depth}, sycl::image_channel_order::rgba,
+      sycl::image_channel_type::fp32);
+
+  // Extension: allocate memory on device and create the handle
+  // Input images memory
+  sycl::ext::oneapi::experimental::image_mem imgMem(desc, Dev, ctxt);
+  // Extension: returns the device pointer to USM allocated pitched memory
+  size_t pitch = 0;
+  auto imgMemUSM = sycl::ext::oneapi::experimental::pitched_alloc_device(
+      &pitch, desc, Queue);
+
+  Graph.begin_recording(Queue);
+
+  addImagesCopies<OperationPath::RecordReplay>(Graph, Queue, imgMem, dataIn,
+                                               imgMemUSM, pitch, desc);
+
+  addImagesCopies<OperationPath::Shortcut>(Graph, Queue, imgMem, dataIn,
+                                           imgMemUSM, pitch, desc);
+
+  Graph.end_recording();
+
+  addImagesCopies<OperationPath::Explicit>(Graph, Queue, imgMem, dataIn,
+                                           imgMemUSM, pitch, desc);
+
+  sycl::free(imgMemUSM, ctxt);
 }
 
 class MultiThreadGraphTest : public CommandGraphTest {

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1405,44 +1405,42 @@ TEST_F(CommandGraphTest, Reductions) {
 }
 
 TEST_F(CommandGraphTest, BindlessExceptionCheck) {
-  auto ctxt = Queue.get_context();
+  auto Ctxt = Queue.get_context();
 
   // declare image data
-  size_t height = 13;
-  size_t width = 7;
-  size_t depth = 11;
-  size_t N = height * width * depth;
-  std::vector<sycl::float4> out(N);
-  std::vector<float> expected(N);
-  std::vector<sycl::float4> dataIn(N);
+  size_t Height = 13;
+  size_t Width = 7;
+  size_t Depth = 11;
+  size_t N = Height * Width * Depth;
+  std::vector<sycl::float4> DataIn(N);
 
   // Extension: image descriptor - can use the same for both images
-  sycl::ext::oneapi::experimental::image_descriptor desc(
-      {width, height, depth}, sycl::image_channel_order::rgba,
+  sycl::ext::oneapi::experimental::image_descriptor Desc(
+      {Width, Height, Depth}, sycl::image_channel_order::rgba,
       sycl::image_channel_type::fp32);
 
   // Extension: allocate memory on device and create the handle
   // Input images memory
-  sycl::ext::oneapi::experimental::image_mem imgMem(desc, Dev, ctxt);
+  sycl::ext::oneapi::experimental::image_mem ImgMem(Desc, Dev, Ctxt);
   // Extension: returns the device pointer to USM allocated pitched memory
-  size_t pitch = 0;
-  auto imgMemUSM = sycl::ext::oneapi::experimental::pitched_alloc_device(
-      &pitch, desc, Queue);
+  size_t Pitch = 0;
+  auto ImgMemUSM = sycl::ext::oneapi::experimental::pitched_alloc_device(
+      &Pitch, Desc, Queue);
 
   Graph.begin_recording(Queue);
 
-  addImagesCopies<OperationPath::RecordReplay>(Graph, Queue, imgMem, dataIn,
-                                               imgMemUSM, pitch, desc);
+  addImagesCopies<OperationPath::RecordReplay>(Graph, Queue, ImgMem, DataIn,
+                                               ImgMemUSM, Pitch, Desc);
 
-  addImagesCopies<OperationPath::Shortcut>(Graph, Queue, imgMem, dataIn,
-                                           imgMemUSM, pitch, desc);
+  addImagesCopies<OperationPath::Shortcut>(Graph, Queue, ImgMem, DataIn,
+                                           ImgMemUSM, Pitch, Desc);
 
   Graph.end_recording();
 
-  addImagesCopies<OperationPath::Explicit>(Graph, Queue, imgMem, dataIn,
-                                           imgMemUSM, pitch, desc);
+  addImagesCopies<OperationPath::Explicit>(Graph, Queue, ImgMem, DataIn,
+                                           ImgMemUSM, Pitch, Desc);
 
-  sycl::free(imgMemUSM, ctxt);
+  sycl::free(ImgMemUSM, Ctxt);
 }
 
 class MultiThreadGraphTest : public CommandGraphTest {

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1392,7 +1392,7 @@ TEST_F(CommandGraphTest, Reductions) {
       {
         try {
           Graph.add([&](handler &CGH) {
-            CGH.parallel_for<class TestKernel>(
+            CGH.parallel_for<class CustomTestKernel>(
                 range<1>{1}, reduction(&ReduVar, int{0}, sycl::plus()),
                 [=](item<1> idx, auto &Sum) {});
           });


### PR DESCRIPTION
Throws an invalid exception when using bindless images extension in a graph. 
Adds Unitests to test the exception throwing.