### PR TITLE
[SYCL][Graph] Throw exception when calling profiling

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -274,6 +274,11 @@ void event_impl::checkProfilingPreconditions() const {
         "Profiling information is unavailable as the queue associated with "
         "the event does not have the 'enable_profiling' property.");
   }
+  if (EventFromSubmitedExecCommandBuffer) {
+    throw sycl::exception(make_error_code(sycl::errc::invalid),
+                          "Profiling information is unavailable for events "
+                          "returned by a graph submission.");
+  }
 }
 
 template <>

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -278,6 +278,14 @@ public:
     return MGraph.lock();
   }
 
+  void setEventFromSubmitedExecCommandBuffer(bool value) {
+    EventFromSubmitedExecCommandBuffer = value;
+  }
+
+  bool isEventFromSubmitedExecCommandBuffer() const {
+    return EventFromSubmitedExecCommandBuffer;
+  }
+
 protected:
   // When instrumentation is enabled emits trace event for event wait begin and
   // returns the telemetry event generated for the wait
@@ -327,6 +335,8 @@ protected:
   /// Store the command graph associated with this event, if any.
   /// This event is also be stored in the graph so a weak_ptr is used.
   std::weak_ptr<ext::oneapi::experimental::detail::graph_impl> MGraph;
+  /// Indicates that the event results from a command graph submission
+  bool EventFromSubmitedExecCommandBuffer = false;
 
   // If this event represents a submission to a
   // sycl::detail::pi::PiExtCommandBuffer the sync point for that submission is

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -536,6 +536,7 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
     auto NewEvent = std::make_shared<sycl::detail::event_impl>(Queue);
     NewEvent->setContextImpl(Queue->getContextImplPtr());
     NewEvent->setStateIncomplete();
+    NewEvent->setEventFromSubmitedExecCommandBuffer(true);
     return NewEvent;
   });
 

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1443,6 +1443,76 @@ TEST_F(CommandGraphTest, BindlessExceptionCheck) {
   sycl::free(ImgMemUSM, Ctxt);
 }
 
+TEST_F(CommandGraphTest, GetProfilingInfoExceptionCheck) {
+  sycl::context Ctx{Dev};
+  sycl::queue QueueProfile{
+      Ctx, Dev, sycl::property_list{sycl::property::queue::enable_profiling{}}};
+  experimental::command_graph<experimental::graph_state::modifiable>
+      GraphProfile{QueueProfile.get_context(), Dev};
+
+  GraphProfile.begin_recording(QueueProfile);
+  auto Event = QueueProfile.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  // Checks that exception is thrown when get_profile_info is called on "event"
+  // returned by a queue in recording mode.
+  std::error_code ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    Event.get_profiling_info<sycl::info::event_profiling::command_submit>();
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    Event.get_profiling_info<sycl::info::event_profiling::command_start>();
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    Event.get_profiling_info<sycl::info::event_profiling::command_end>();
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  GraphProfile.end_recording();
+
+  auto GraphExec = GraphProfile.finalize();
+  auto EventSub = QueueProfile.submit(
+      [&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+
+  // Checks that exception is thrown when get_profile_info is called on "event"
+  // returned by a graph submission.
+  ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    EventSub.get_profiling_info<sycl::info::event_profiling::command_submit>();
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    EventSub.get_profiling_info<sycl::info::event_profiling::command_start>();
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    EventSub.get_profiling_info<sycl::info::event_profiling::command_end>();
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+}
+
 class MultiThreadGraphTest : public CommandGraphTest {
 public:
   MultiThreadGraphTest()


### PR DESCRIPTION
Throws an invalid exception when calling `event::get_profiling_info()` on an event returned by a graph submission. 
Adds unitests checking that exceptions are throws if `event::get_profiling_info()` is called on an event returned from a queue in recording mode or an event returned by a graph submission.