### PR TITLE
[SYCL][Graph] Enable empty nodes in Subgraphs

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -526,7 +526,7 @@ void exec_graph_impl::createCommandBuffers(sycl::device Device) {
 
   // TODO extract kernel bundle logic from enqueueImpKernel
   for (auto Node : MSchedule) {
-    // Empty nodes are node processed as other nodes, but only their
+    // Empty nodes are not processed as other nodes, but only their
     // dependencies are propagated in findRealDeps
     if (Node->isEmpty())
       continue;

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -176,23 +176,19 @@ std::shared_ptr<node_impl> graph_impl::addNodesToExits(
 std::shared_ptr<node_impl> graph_impl::addSubgraphNodes(
     const std::shared_ptr<exec_graph_impl> &SubGraphExec) {
   std::map<std::shared_ptr<node_impl>, std::shared_ptr<node_impl>> NodesMap;
-  std::list<std::shared_ptr<node_impl>> NewNodeList;
+  std::list<std::shared_ptr<node_impl>> NewNodesList;
 
-  // Create a list of nodes from the graph structure
-  std::list<std::shared_ptr<node_impl>> NodeList;
-  for (auto Node : SubGraphExec->getGraphImpl()->MRoots) {
-    Node->sortTopological(Node, NodeList, true);
-  }
+  std::list<std::shared_ptr<node_impl>> NodesList = SubGraphExec->getSchedule();
 
   // Duplication of nodes
   for (std::list<std::shared_ptr<node_impl>>::const_iterator NodeIt =
-           NodeList.end();
-       NodeIt != NodeList.begin();) {
+           NodesList.end();
+       NodeIt != NodesList.begin();) {
     --NodeIt;
     auto Node = *NodeIt;
     std::shared_ptr<node_impl> NodeCopy;
     duplicateNode(Node, NodeCopy);
-    NewNodeList.push_back(NodeCopy);
+    NewNodesList.push_back(NodeCopy);
     NodesMap.insert({Node, NodeCopy});
     for (auto &NextNode : Node->MSuccessors) {
       if (NodesMap.find(NextNode) != NodesMap.end()) {
@@ -204,7 +200,7 @@ std::shared_ptr<node_impl> graph_impl::addSubgraphNodes(
     }
   }
 
-  return addNodesToExits(NewNodeList);
+  return addNodesToExits(NewNodesList);
 }
 
 void graph_impl::addRoot(const std::shared_ptr<node_impl> &Root) {
@@ -530,6 +526,11 @@ void exec_graph_impl::createCommandBuffers(sycl::device Device) {
 
   // TODO extract kernel bundle logic from enqueueImpKernel
   for (auto Node : MSchedule) {
+    // Empty nodes are node processed as other nodes, but only their
+    // dependencies are propagated in findRealDeps
+    if (Node->isEmpty())
+      continue;
+
     sycl::detail::CG::CGTYPE type = Node->MCGType;
     // If the node is a kernel with no special requirements we can enqueue it
     // directly.
@@ -669,8 +670,9 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
               "Error during emulated graph command group submission.");
         }
         ScheduledEvents.push_back(NewEvent);
-      } else {
-
+      } else if (!NodeImpl->isEmpty()) {
+        // Empty nodes are node processed as other nodes, but only their
+        // dependencies are propagated in findRealDeps
         sycl::detail::EventImplPtr EventImpl =
             sycl::detail::Scheduler::getInstance().addCG(NodeImpl->getCGCopy(),
                                                          Queue);

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -178,8 +178,13 @@ std::shared_ptr<node_impl> graph_impl::addSubgraphNodes(
   std::map<std::shared_ptr<node_impl>, std::shared_ptr<node_impl>> NodesMap;
   std::list<std::shared_ptr<node_impl>> NewNodeList;
 
-  std::list<std::shared_ptr<node_impl>> NodeList = SubGraphExec->getSchedule();
+  // Create a list of nodes from the graph structure
+  std::list<std::shared_ptr<node_impl>> NodeList;
+  for (auto Node : SubGraphExec->getGraphImpl()->MRoots) {
+    Node->sortTopological(Node, NodeList, true);
+  }
 
+  // Duplication of nodes
   for (std::list<std::shared_ptr<node_impl>>::const_iterator NodeIt =
            NodeList.end();
        NodeIt != NodeList.begin();) {
@@ -193,6 +198,8 @@ std::shared_ptr<node_impl> graph_impl::addSubgraphNodes(
       if (NodesMap.find(NextNode) != NodesMap.end()) {
         auto Successor = NodesMap[NextNode];
         NodeCopy->registerSuccessor(Successor, NodeCopy);
+      } else {
+        assert("Node duplication failed. A duplicated node is missing.");
       }
     }
   }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -135,19 +135,15 @@ public:
   /// Recursively add nodes to execution stack.
   /// @param NodeImpl Node to schedule.
   /// @param Schedule Execution ordering to add node to.
-  /// @param ForcePush is true force to push empty nodes to the list Schedule
   void sortTopological(std::shared_ptr<node_impl> NodeImpl,
-                       std::list<std::shared_ptr<node_impl>> &Schedule,
-                       bool ForcePush = false) {
+                       std::list<std::shared_ptr<node_impl>> &Schedule) {
     for (auto Next : MSuccessors) {
       // Check if we've already scheduled this node
       if (std::find(Schedule.begin(), Schedule.end(), Next) == Schedule.end())
-        Next->sortTopological(Next, Schedule, ForcePush);
+        Next->sortTopological(Next, Schedule);
     }
-    // We don't need to schedule empty nodes as they are only used when
-    // calculating dependencies
-    if (ForcePush || !NodeImpl->isEmpty())
-      Schedule.push_front(NodeImpl);
+
+    Schedule.push_front(NodeImpl);
   }
 
   /// Checks if this node has a given requirement.

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -135,16 +135,18 @@ public:
   /// Recursively add nodes to execution stack.
   /// @param NodeImpl Node to schedule.
   /// @param Schedule Execution ordering to add node to.
+  /// @param ForcePush is true force to push empty nodes to the list Schedule
   void sortTopological(std::shared_ptr<node_impl> NodeImpl,
-                       std::list<std::shared_ptr<node_impl>> &Schedule) {
+                       std::list<std::shared_ptr<node_impl>> &Schedule,
+                       bool ForcePush = false) {
     for (auto Next : MSuccessors) {
       // Check if we've already scheduled this node
       if (std::find(Schedule.begin(), Schedule.end(), Next) == Schedule.end())
-        Next->sortTopological(Next, Schedule);
+        Next->sortTopological(Next, Schedule, ForcePush);
     }
     // We don't need to schedule empty nodes as they are only used when
     // calculating dependencies
-    if (!NodeImpl->isEmpty())
+    if (ForcePush || !NodeImpl->isEmpty())
       Schedule.push_front(NodeImpl);
   }
 


### PR DESCRIPTION
The implementation uses the list of scheduled nodes to add a subgraph to a main graph. 
However, since empty nodes are not scheduled, empty nodes were not listed in this list, resulting in inconsistent graphs when subgraph with empty node(s) were added to a main graph. 

Edit:
This PR changes the definition of MSchedule (schedule list) as it now contains all types of nodes (including empty nodes).
Empty nodes are now filtered out when creating the commandbuffer and/or enqueuing nodes to only keep their dependencies.
This PR updates a few unitests to make them compliant to the new schedule list definition