### PR TITLE
[SYCL][Graph] Remove exec_graph_impl mutex lock in the destructor of this object

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -343,7 +343,6 @@ void exec_graph_impl::createCommandBuffers(sycl::device Device) {
 }
 
 exec_graph_impl::~exec_graph_impl() {
-  WriteLock Lock(MMutex);
   WriteLock LockImpl(MGraphImpl->MMutex);
 
   // clear all recording queue if not done before (no call to end_recording)


### PR DESCRIPTION
The way exec_graph_impl is used and C++ semantic prevent concurrent access the destructor of this object.