### PR TITLE
[SYCL][Graph] Add support for memory copy operations for CUDA backend

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
@@ -71,6 +71,41 @@ static ur_result_t getNodesFromSyncPoints(
   return UR_RESULT_SUCCESS;
 }
 
+/// Set parameter for General 1D memory copy.
+/// If the source and/or destination is on the device, SrcPtr and/or DstPtr
+/// must be a pointer to a CUdeviceptr
+static void setCopyParams(const void *SrcPtr, const CUmemorytype_enum SrcType,
+                          void *DstPtr, const CUmemorytype_enum DstType,
+                          size_t Size, CUDA_MEMCPY3D &Params) {
+
+  Params.srcMemoryType = SrcType;
+  Params.srcDevice = SrcType == CU_MEMORYTYPE_DEVICE
+                         ? *static_cast<const CUdeviceptr *>(SrcPtr)
+                         : 0;
+  Params.srcHost = SrcType == CU_MEMORYTYPE_HOST ? SrcPtr : nullptr;
+  Params.srcXInBytes = 0;
+  Params.srcY = 0;
+  Params.srcZ = 0;
+  Params.srcLOD = 0;
+  Params.srcPitch = 0;
+  Params.srcHeight = 0;
+
+  Params.dstMemoryType = DstType;
+  Params.dstDevice =
+      DstType == CU_MEMORYTYPE_DEVICE ? *static_cast<CUdeviceptr *>(DstPtr) : 0;
+  Params.dstHost = DstType == CU_MEMORYTYPE_HOST ? DstPtr : nullptr;
+  Params.dstXInBytes = 0;
+  Params.dstY = 0;
+  Params.dstZ = 0;
+  Params.dstLOD = 0;
+  Params.dstPitch = 0;
+  Params.dstHeight = 0;
+
+  Params.WidthInBytes = Size;
+  Params.Height = 1;
+  Params.Depth = 1;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     const ur_exp_command_buffer_desc_t *hCommandBufferDesc,
@@ -211,17 +246,29 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
     size_t size, uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint) {
-  (void)hCommandBuffer;
-  (void)pDst;
-  (void)pSrc;
-  (void)size;
-  (void)numSyncPointsInWaitList;
-  (void)pSyncPointWaitList;
-  (void)pSyncPoint;
+  ur_result_t Result;
+  CUgraphNode GraphNode;
+  std::vector<CUgraphNode> DepsList;
+  UR_CALL(getNodesFromSyncPoints(hCommandBuffer, numSyncPointsInWaitList,
+                                 pSyncPointWaitList, DepsList));
 
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for CUDA adapter.");
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  try {
+    CUDA_MEMCPY3D nodeParams = {};
+    setCopyParams(pSrc, CU_MEMORYTYPE_HOST, pDst, CU_MEMORYTYPE_HOST, size,
+                  nodeParams);
+
+    Result = UR_CHECK_ERROR(cuGraphAddMemcpyNode(
+        &GraphNode, hCommandBuffer->CudaGraph, DepsList.data(), DepsList.size(),
+        &nodeParams, hCommandBuffer->Device->getContext()));
+
+    // Get sync point and register the event with it.
+    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
+    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
+                                      std::make_shared<CUgraphNode>(GraphNode));
+  } catch (ur_result_t Err) {
+    Result = Err;
+  }
+  return Result;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
@@ -230,19 +277,32 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint) {
-  (void)hCommandBuffer;
-  (void)hSrcMem;
-  (void)hDstMem;
-  (void)srcOffset;
-  (void)dstOffset;
-  (void)size;
-  (void)numSyncPointsInWaitList;
-  (void)pSyncPointWaitList;
-  (void)pSyncPoint;
+  ur_result_t Result;
+  CUgraphNode GraphNode;
+  std::vector<CUgraphNode> DepsList;
+  UR_CALL(getNodesFromSyncPoints(hCommandBuffer, numSyncPointsInWaitList,
+                                 pSyncPointWaitList, DepsList));
 
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for CUDA adapter.");
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  try {
+    auto Src = hSrcMem->Mem.BufferMem.get() + srcOffset;
+    auto Dst = hDstMem->Mem.BufferMem.get() + dstOffset;
+
+    CUDA_MEMCPY3D nodeParams = {};
+    setCopyParams(&Src, CU_MEMORYTYPE_DEVICE, &Dst, CU_MEMORYTYPE_DEVICE, size,
+                  nodeParams);
+
+    Result = UR_CHECK_ERROR(cuGraphAddMemcpyNode(
+        &GraphNode, hCommandBuffer->CudaGraph, DepsList.data(), DepsList.size(),
+        &nodeParams, hCommandBuffer->Device->getContext()));
+
+    // Get sync point and register the event with it.
+    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
+    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
+                                      std::make_shared<CUgraphNode>(GraphNode));
+  } catch (ur_result_t Err) {
+    Result = Err;
+  }
+  return Result;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
@@ -253,23 +313,33 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint) {
-  (void)hCommandBuffer;
-  (void)hSrcMem;
-  (void)hDstMem;
-  (void)srcOrigin;
-  (void)dstOrigin;
-  (void)region;
-  (void)srcRowPitch;
-  (void)srcSlicePitch;
-  (void)dstRowPitch;
-  (void)dstSlicePitch;
-  (void)numSyncPointsInWaitList;
-  (void)pSyncPointWaitList;
-  (void)pSyncPoint;
+  ur_result_t Result;
+  CUgraphNode GraphNode;
+  std::vector<CUgraphNode> DepsList;
+  UR_CALL(getNodesFromSyncPoints(hCommandBuffer, numSyncPointsInWaitList,
+                                 pSyncPointWaitList, DepsList));
 
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for CUDA adapter.");
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  try {
+    CUdeviceptr SrcPtr = hSrcMem->Mem.BufferMem.get();
+    CUdeviceptr DstPtr = hDstMem->Mem.BufferMem.get();
+    CUDA_MEMCPY3D nodeParams = {};
+
+    setCopyRectParams(region, &SrcPtr, CU_MEMORYTYPE_DEVICE, srcOrigin,
+                      srcRowPitch, srcSlicePitch, &DstPtr, CU_MEMORYTYPE_DEVICE,
+                      dstOrigin, dstRowPitch, dstSlicePitch, nodeParams);
+
+    Result = UR_CHECK_ERROR(cuGraphAddMemcpyNode(
+        &GraphNode, hCommandBuffer->CudaGraph, DepsList.data(), DepsList.size(),
+        &nodeParams, hCommandBuffer->Device->getContext()));
+
+    // Get sync point and register the event with it.
+    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
+    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
+                                      std::make_shared<CUgraphNode>(GraphNode));
+  } catch (ur_result_t Err) {
+    Result = Err;
+  }
+  return Result;
 }
 
 UR_APIEXPORT
@@ -279,18 +349,31 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint) {
-  (void)hCommandBuffer;
-  (void)hBuffer;
-  (void)offset;
-  (void)size;
-  (void)pSrc;
-  (void)numSyncPointsInWaitList;
-  (void)pSyncPointWaitList;
-  (void)pSyncPoint;
+  ur_result_t Result;
+  CUgraphNode GraphNode;
+  std::vector<CUgraphNode> DepsList;
+  UR_CALL(getNodesFromSyncPoints(hCommandBuffer, numSyncPointsInWaitList,
+                                 pSyncPointWaitList, DepsList));
 
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for CUDA adapter.");
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  try {
+    auto Dst = hBuffer->Mem.BufferMem.get() + offset;
+
+    CUDA_MEMCPY3D nodeParams = {};
+    setCopyParams(pSrc, CU_MEMORYTYPE_HOST, &Dst, CU_MEMORYTYPE_DEVICE, size,
+                  nodeParams);
+
+    Result = UR_CHECK_ERROR(cuGraphAddMemcpyNode(
+        &GraphNode, hCommandBuffer->CudaGraph, DepsList.data(), DepsList.size(),
+        &nodeParams, hCommandBuffer->Device->getContext()));
+
+    // Get sync point and register the event with it.
+    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
+    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
+                                      std::make_shared<CUgraphNode>(GraphNode));
+  } catch (ur_result_t Err) {
+    Result = Err;
+  }
+  return Result;
 }
 
 UR_APIEXPORT
@@ -299,18 +382,31 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferReadExp(
     size_t offset, size_t size, void *pDst, uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint) {
-  (void)hCommandBuffer;
-  (void)hBuffer;
-  (void)offset;
-  (void)size;
-  (void)pDst;
-  (void)numSyncPointsInWaitList;
-  (void)pSyncPointWaitList;
-  (void)pSyncPoint;
+  ur_result_t Result;
+  CUgraphNode GraphNode;
+  std::vector<CUgraphNode> DepsList;
+  UR_CALL(getNodesFromSyncPoints(hCommandBuffer, numSyncPointsInWaitList,
+                                 pSyncPointWaitList, DepsList));
 
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for CUDA adapter.");
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  try {
+    auto Src = hBuffer->Mem.BufferMem.get() + offset;
+
+    CUDA_MEMCPY3D nodeParams = {};
+    setCopyParams(&Src, CU_MEMORYTYPE_DEVICE, pDst, CU_MEMORYTYPE_HOST, size,
+                  nodeParams);
+
+    Result = UR_CHECK_ERROR(cuGraphAddMemcpyNode(
+        &GraphNode, hCommandBuffer->CudaGraph, DepsList.data(), DepsList.size(),
+        &nodeParams, hCommandBuffer->Device->getContext()));
+
+    // Get sync point and register the event with it.
+    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
+    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
+                                      std::make_shared<CUgraphNode>(GraphNode));
+  } catch (ur_result_t Err) {
+    Result = Err;
+  }
+  return Result;
 }
 
 UR_APIEXPORT
@@ -322,23 +418,33 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteRectExp(
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint) {
-  (void)hCommandBuffer;
-  (void)hBuffer;
-  (void)bufferOffset;
-  (void)hostOffset;
-  (void)region;
-  (void)bufferRowPitch;
-  (void)bufferSlicePitch;
-  (void)hostRowPitch;
-  (void)hostSlicePitch;
-  (void)pSrc;
-  (void)numSyncPointsInWaitList;
-  (void)pSyncPointWaitList;
-  (void)pSyncPoint;
+  ur_result_t Result;
+  CUgraphNode GraphNode;
+  std::vector<CUgraphNode> DepsList;
+  UR_CALL(getNodesFromSyncPoints(hCommandBuffer, numSyncPointsInWaitList,
+                                 pSyncPointWaitList, DepsList));
 
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for CUDA adapter.");
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  try {
+    CUdeviceptr DstPtr = hBuffer->Mem.BufferMem.get();
+    CUDA_MEMCPY3D nodeParams = {};
+
+    setCopyRectParams(region, pSrc, CU_MEMORYTYPE_HOST, hostOffset,
+                      hostRowPitch, hostSlicePitch, &DstPtr,
+                      CU_MEMORYTYPE_DEVICE, bufferOffset, bufferRowPitch,
+                      bufferSlicePitch, nodeParams);
+
+    Result = UR_CHECK_ERROR(cuGraphAddMemcpyNode(
+        &GraphNode, hCommandBuffer->CudaGraph, DepsList.data(), DepsList.size(),
+        &nodeParams, hCommandBuffer->Device->getContext()));
+
+    // Get sync point and register the event with it.
+    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
+    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
+                                      std::make_shared<CUgraphNode>(GraphNode));
+  } catch (ur_result_t Err) {
+    Result = Err;
+  }
+  return Result;
 }
 
 UR_APIEXPORT
@@ -350,24 +456,33 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferReadRectExp(
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint) {
-  (void)hCommandBuffer;
-  (void)hBuffer;
-  (void)bufferOffset;
-  (void)hostOffset;
-  (void)region;
-  (void)bufferRowPitch;
-  (void)bufferSlicePitch;
-  (void)hostRowPitch;
-  (void)hostSlicePitch;
-  (void)pDst;
+  ur_result_t Result;
+  CUgraphNode GraphNode;
+  std::vector<CUgraphNode> DepsList;
+  UR_CALL(getNodesFromSyncPoints(hCommandBuffer, numSyncPointsInWaitList,
+                                 pSyncPointWaitList, DepsList));
 
-  (void)numSyncPointsInWaitList;
-  (void)pSyncPointWaitList;
-  (void)pSyncPoint;
+  try {
+    CUdeviceptr SrcPtr = hBuffer->Mem.BufferMem.get();
+    CUDA_MEMCPY3D nodeParams = {};
 
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for CUDA adapter.");
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    setCopyRectParams(region, &SrcPtr, CU_MEMORYTYPE_DEVICE, bufferOffset,
+                      bufferRowPitch, bufferSlicePitch, pDst,
+                      CU_MEMORYTYPE_HOST, hostOffset, hostRowPitch,
+                      hostSlicePitch, nodeParams);
+
+    Result = UR_CHECK_ERROR(cuGraphAddMemcpyNode(
+        &GraphNode, hCommandBuffer->CudaGraph, DepsList.data(), DepsList.size(),
+        &nodeParams, hCommandBuffer->Device->getContext()));
+
+    // Get sync point and register the event with it.
+    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
+    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
+                                      std::make_shared<CUgraphNode>(GraphNode));
+  } catch (ur_result_t Err) {
+    Result = Err;
+  }
+  return Result;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
@@ -407,5 +522,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
   } catch (ur_result_t Err) {
     Result = Err;
   }
+
   return Result;
 }

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
@@ -184,9 +184,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
                               DepsList.data(), DepsList.size()));
 
       // Get sync point and register the cuNode with it.
-      *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
-      hCommandBuffer->RegisterSyncPoint(
-          *pSyncPoint, std::make_shared<CUgraphNode>(GraphNode));
+      *pSyncPoint = hCommandBuffer->AddSyncPoint(
+          std::make_shared<CUgraphNode>(GraphNode));
     } catch (ur_result_t Err) {
       Result = Err;
     }
@@ -232,9 +231,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
       hKernel->clearLocalSize();
 
     // Get sync point and register the cuNode with it.
-    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
-    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
-                                      std::make_shared<CUgraphNode>(GraphNode));
+    *pSyncPoint =
+        hCommandBuffer->AddSyncPoint(std::make_shared<CUgraphNode>(GraphNode));
   } catch (ur_result_t Err) {
     Result = Err;
   }
@@ -262,9 +260,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
         &NodeParams, hCommandBuffer->Device->getContext()));
 
     // Get sync point and register the cuNode with it.
-    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
-    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
-                                      std::make_shared<CUgraphNode>(GraphNode));
+    *pSyncPoint =
+        hCommandBuffer->AddSyncPoint(std::make_shared<CUgraphNode>(GraphNode));
   } catch (ur_result_t Err) {
     Result = Err;
   }
@@ -296,9 +293,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
         &NodeParams, hCommandBuffer->Device->getContext()));
 
     // Get sync point and register the cuNode with it.
-    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
-    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
-                                      std::make_shared<CUgraphNode>(GraphNode));
+    *pSyncPoint =
+        hCommandBuffer->AddSyncPoint(std::make_shared<CUgraphNode>(GraphNode));
   } catch (ur_result_t Err) {
     Result = Err;
   }
@@ -333,9 +329,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
         &NodeParams, hCommandBuffer->Device->getContext()));
 
     // Get sync point and register the cuNode with it.
-    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
-    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
-                                      std::make_shared<CUgraphNode>(GraphNode));
+    *pSyncPoint =
+        hCommandBuffer->AddSyncPoint(std::make_shared<CUgraphNode>(GraphNode));
   } catch (ur_result_t Err) {
     Result = Err;
   }
@@ -367,9 +362,8 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
         &NodeParams, hCommandBuffer->Device->getContext()));
 
     // Get sync point and register the cuNode with it.
-    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
-    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
-                                      std::make_shared<CUgraphNode>(GraphNode));
+    *pSyncPoint =
+        hCommandBuffer->AddSyncPoint(std::make_shared<CUgraphNode>(GraphNode));
   } catch (ur_result_t Err) {
     Result = Err;
   }
@@ -400,9 +394,8 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferReadExp(
         &NodeParams, hCommandBuffer->Device->getContext()));
 
     // Get sync point and register the cuNode with it.
-    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
-    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
-                                      std::make_shared<CUgraphNode>(GraphNode));
+    *pSyncPoint =
+        hCommandBuffer->AddSyncPoint(std::make_shared<CUgraphNode>(GraphNode));
   } catch (ur_result_t Err) {
     Result = Err;
   }
@@ -438,9 +431,8 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteRectExp(
         &NodeParams, hCommandBuffer->Device->getContext()));
 
     // Get sync point and register the cuNode with it.
-    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
-    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
-                                      std::make_shared<CUgraphNode>(GraphNode));
+    *pSyncPoint =
+        hCommandBuffer->AddSyncPoint(std::make_shared<CUgraphNode>(GraphNode));
   } catch (ur_result_t Err) {
     Result = Err;
   }
@@ -476,9 +468,8 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferReadRectExp(
         &NodeParams, hCommandBuffer->Device->getContext()));
 
     // Get sync point and register the cuNode with it.
-    *pSyncPoint = hCommandBuffer->GetNextSyncPoint();
-    hCommandBuffer->RegisterSyncPoint(*pSyncPoint,
-                                      std::make_shared<CUgraphNode>(GraphNode));
+    *pSyncPoint =
+        hCommandBuffer->AddSyncPoint(std::make_shared<CUgraphNode>(GraphNode));
   } catch (ur_result_t Err) {
     Result = Err;
   }

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.hpp
@@ -185,6 +185,16 @@ struct ur_exp_command_buffer_handle_t_ {
     return NextSyncPoint;
   }
 
+  // Helper to register next sync point
+  // @param CuNode Node to register as next sycn point
+  // @return Pointer to the sync that registers the Node
+  ur_exp_command_buffer_sync_point_t
+  AddSyncPoint(std::shared_ptr<CUgraphNode> CuNode) {
+    ur_exp_command_buffer_sync_point_t SyncPoint = NextSyncPoint;
+    RegisterSyncPoint(SyncPoint, CuNode);
+    return SyncPoint;
+  }
+
   // UR context associated with this command-buffer
   ur_context_handle_t Context;
   // Device associated with this command buffer

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
@@ -473,23 +473,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
   return Result;
 }
 
-/// General 3D memory copy operation.
-/// This function requires the corresponding CUDA context to be at the top of
-/// the context stack
+/// Set parameter for General 3D memory copy.
 /// If the source and/or destination is on the device, SrcPtr and/or DstPtr
 /// must be a pointer to a CUdeviceptr
-static ur_result_t commonEnqueueMemBufferCopyRect(
-    CUstream cu_stream, ur_rect_region_t region, const void *SrcPtr,
-    const CUmemorytype_enum SrcType, ur_rect_offset_t src_offset,
-    size_t src_row_pitch, size_t src_slice_pitch, void *DstPtr,
-    const CUmemorytype_enum DstType, ur_rect_offset_t dst_offset,
-    size_t dst_row_pitch, size_t dst_slice_pitch) {
-
-  UR_ASSERT(SrcType == CU_MEMORYTYPE_DEVICE || SrcType == CU_MEMORYTYPE_HOST,
-            UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(DstType == CU_MEMORYTYPE_DEVICE || DstType == CU_MEMORYTYPE_HOST,
-            UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-
+void setCopyRectParams(ur_rect_region_t region, const void *SrcPtr,
+                       const CUmemorytype_enum SrcType,
+                       ur_rect_offset_t src_offset, size_t src_row_pitch,
+                       size_t src_slice_pitch, void *DstPtr,
+                       const CUmemorytype_enum DstType,
+                       ur_rect_offset_t dst_offset, size_t dst_row_pitch,
+                       size_t dst_slice_pitch, CUDA_MEMCPY3D &params) {
   src_row_pitch =
       (!src_row_pitch) ? region.width + src_offset.x : src_row_pitch;
   src_slice_pitch = (!src_slice_pitch)
@@ -500,8 +493,6 @@ static ur_result_t commonEnqueueMemBufferCopyRect(
   dst_slice_pitch = (!dst_slice_pitch)
                         ? ((region.height + dst_offset.y) * dst_row_pitch)
                         : dst_slice_pitch;
-
-  CUDA_MEMCPY3D params = {};
 
   params.WidthInBytes = region.width;
   params.Height = region.height;
@@ -527,6 +518,29 @@ static ur_result_t commonEnqueueMemBufferCopyRect(
   params.dstZ = dst_offset.z;
   params.dstPitch = dst_row_pitch;
   params.dstHeight = dst_slice_pitch / dst_row_pitch;
+}
+
+/// General 3D memory copy operation.
+/// This function requires the corresponding CUDA context to be at the top of
+/// the context stack
+/// If the source and/or destination is on the device, SrcPtr and/or DstPtr
+/// must be a pointer to a CUdeviceptr
+static ur_result_t commonEnqueueMemBufferCopyRect(
+    CUstream cu_stream, ur_rect_region_t region, const void *SrcPtr,
+    const CUmemorytype_enum SrcType, ur_rect_offset_t src_offset,
+    size_t src_row_pitch, size_t src_slice_pitch, void *DstPtr,
+    const CUmemorytype_enum DstType, ur_rect_offset_t dst_offset,
+    size_t dst_row_pitch, size_t dst_slice_pitch) {
+  UR_ASSERT(SrcType == CU_MEMORYTYPE_DEVICE || SrcType == CU_MEMORYTYPE_HOST,
+            UR_RESULT_ERROR_INVALID_MEM_OBJECT);
+  UR_ASSERT(DstType == CU_MEMORYTYPE_DEVICE || DstType == CU_MEMORYTYPE_HOST,
+            UR_RESULT_ERROR_INVALID_MEM_OBJECT);
+
+  CUDA_MEMCPY3D params = {};
+
+  setCopyRectParams(region, SrcPtr, SrcType, src_offset, src_row_pitch,
+                    src_slice_pitch, DstPtr, DstType, dst_offset, dst_row_pitch,
+                    dst_slice_pitch, params);
 
   return UR_CHECK_ERROR(cuMemcpy3DAsync(&params, cu_stream));
 }

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
@@ -473,7 +473,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
   return Result;
 }
 
-/// Set parameter for General 3D memory copy.
+/// Set parameters for general 3D memory copy.
 /// If the source and/or destination is on the device, SrcPtr and/or DstPtr
 /// must be a pointer to a CUdeviceptr
 void setCopyRectParams(ur_rect_region_t region, const void *SrcPtr,

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.hpp
@@ -31,3 +31,11 @@ setKernelParams(const ur_context_handle_t Context,
                 const size_t *LocalWorkSize, ur_kernel_handle_t &Kernel,
                 CUfunction &CuFunc, size_t (&ThreadsPerBlock)[3],
                 size_t (&BlocksPerGrid)[3]);
+
+void setCopyRectParams(ur_rect_region_t region, const void *SrcPtr,
+                       const CUmemorytype_enum SrcType,
+                       ur_rect_offset_t src_offset, size_t src_row_pitch,
+                       size_t src_slice_pitch, void *DstPtr,
+                       const CUmemorytype_enum DstType,
+                       ur_rect_offset_t dst_offset, size_t dst_row_pitch,
+                       size_t dst_slice_pitch, CUDA_MEMCPY3D &params);

--- a/sycl/test-e2e/Graph/Explicit/assume_buffer_outlives_graph_property.cpp
+++ b/sycl/test-e2e/Graph/Explicit/assume_buffer_outlives_graph_property.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/assume_data_outlives_buffer_property.cpp
+++ b/sycl/test-e2e/Graph/Explicit/assume_data_outlives_buffer_property.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_2d.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_offsets.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_2d.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_offset.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/cycle_error.cpp
+++ b/sycl/test-e2e/Graph/Explicit/cycle_error.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Graph/Explicit/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_buffer_reduction.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_usm_reduction.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/double_buffer.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/Explicit/event_status_querying.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
 //

--- a/sycl/test-e2e/Graph/Explicit/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/Explicit/executable_graph_update.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/executable_graph_update_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/executable_graph_update_ordering.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/host_task.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/Explicit/queue_shortcuts.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/reduction.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Graph/Explicit/stream.cpp
+++ b/sycl/test-e2e/Graph/Explicit/stream.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out %GPU_CHECK_PLACEHOLDER 2>&1 | FileCheck %s %}

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_reduction.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/subgraph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/Explicit/subgraph_execute_without_parent.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}

--- a/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill_host.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill_shared.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/assume_buffer_outlives_graph_property.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/assume_buffer_outlives_graph_property.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/assume_data_outlives_buffer_property.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/assume_data_outlives_buffer_property.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_2d.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_offsets.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_2d.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_offset.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_buffer_reduction.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_usm_reduction.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/double_buffer.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/event_status_querying.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
 //

--- a/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_contexts.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_contexts.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Graph/RecordReplay/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/executable_graph_update.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/executable_graph_update_ordering.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/executable_graph_update_ordering.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/finalize_while_recording.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/finalize_while_recording.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/host_task.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_shortcuts.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/return_values.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/return_values.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/stream.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/stream.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out %GPU_CHECK_PLACEHOLDER 2>&1 | FileCheck %s %}

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_reduction.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/subgraph_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/subgraph_in_order.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_fill.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_fill_host.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_fill_shared.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/device_query.cpp
+++ b/sycl/test-e2e/Graph/device_query.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -16,7 +15,8 @@ int main() {
       Device.get_info<exp_ext::info::device::graph_support>();
   auto Backend = Device.get_backend();
 
-  if (Backend == backend::ext_oneapi_level_zero) {
+  if ((Backend == backend::ext_oneapi_level_zero) ||
+      (Backend == backend::ext_oneapi_cuda)) {
     assert(SupportsGraphs == exp_ext::info::graph_support_level::native);
   } else {
     assert(SupportsGraphs == exp_ext::info::graph_support_level::unsupported);

--- a/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
+++ b/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Graph/invalid_depends_on.cpp
+++ b/sycl/test-e2e/Graph/invalid_depends_on.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Graph/invalid_event_wait.cpp
+++ b/sycl/test-e2e/Graph/invalid_event_wait.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Graph/invalid_queue_wait.cpp
+++ b/sycl/test-e2e/Graph/invalid_queue_wait.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Graph/queue_state.cpp
+++ b/sycl/test-e2e/Graph/queue_state.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Implements CUDA backend support for:
- memcpyUSM
- memcpy Device to Device (1D and 2D)
- memcpy Host to Device (Write 1D and 2D)
- memcpy Device to Host (Read 1D and 2D) 

Enables all remaining e2e tests