### PR TITLE
[SYCL][Graph] Move `graph_support_level` namespace

### DIFF
--- a/sycl/include/sycl/info/ext_oneapi_device_traits.def
+++ b/sycl/include/sycl/info/ext_oneapi_device_traits.def
@@ -11,7 +11,7 @@ __SYCL_PARAM_TRAITS_SPEC(ext::oneapi::experimental, device, architecture,
                          PI_EXT_ONEAPI_DEVICE_INFO_IP_VERSION)
 __SYCL_PARAM_TRAITS_SPEC(
     ext::oneapi::experimental, device, graph_support,
-    ext::oneapi::experimental::info::graph_support_level,
+    ext::oneapi::experimental::graph_support_level,
     0 /* No PI device code needed */)
 
 // Bindless images pitched allocation

--- a/sycl/include/sycl/info/info_desc.hpp
+++ b/sycl/include/sycl/info/info_desc.hpp
@@ -193,7 +193,7 @@ template <typename T, T param> struct compatibility_param_traits {};
 
 namespace ext::oneapi::experimental {
 
-enum class graph_support_level { unsupported = 0, native, emulated };
+enum class graph_support_level { unsupported = 0, native = 1, emulated = 2 };
 
 namespace info::device {
 template <int Dimensions> struct max_work_groups;

--- a/sycl/include/sycl/info/info_desc.hpp
+++ b/sycl/include/sycl/info/info_desc.hpp
@@ -191,14 +191,14 @@ template <typename T, T param> struct compatibility_param_traits {};
   } /*namespace info */                                                        \
   } /*namespace Namespace */
 
-namespace ext::oneapi::experimental::info {
+namespace ext::oneapi::experimental {
 
 enum class graph_support_level { unsupported = 0, native, emulated };
 
-namespace device {
+namespace info::device {
 template <int Dimensions> struct max_work_groups;
-} // namespace device
-} // namespace ext::oneapi::experimental::info
+} // namespace info::device
+} // namespace ext::oneapi::experimental
 #include <sycl/info/ext_codeplay_device_traits.def>
 #include <sycl/info/ext_intel_device_traits.def>
 #include <sycl/info/ext_oneapi_device_traits.def>

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -934,16 +934,16 @@ struct get_device_info_impl<
 // Specialization for graph extension support
 template <>
 struct get_device_info_impl<
-    ext::oneapi::experimental::info::graph_support_level,
+    ext::oneapi::experimental::graph_support_level,
     ext::oneapi::experimental::info::device::graph_support> {
-  static ext::oneapi::experimental::info::graph_support_level
+  static ext::oneapi::experimental::graph_support_level
   get(const DeviceImplPtr &Dev) {
     size_t ResultSize = 0;
     Dev->getPlugin()->call<PiApiKind::piDeviceGetInfo>(
         Dev->getHandleRef(), PI_DEVICE_INFO_EXTENSIONS, 0, nullptr,
         &ResultSize);
     if (ResultSize == 0)
-      return ext::oneapi::experimental::info::graph_support_level::unsupported;
+      return ext::oneapi::experimental::graph_support_level::unsupported;
 
     std::unique_ptr<char[]> Result(new char[ResultSize]);
     Dev->getPlugin()->call<PiApiKind::piDeviceGetInfo>(
@@ -954,9 +954,8 @@ struct get_device_info_impl<
     bool CmdBufferSupport =
         ExtensionsString.find("ur_exp_command_buffer") != std::string::npos;
     return CmdBufferSupport
-               ? ext::oneapi::experimental::info::graph_support_level::native
-               : ext::oneapi::experimental::info::graph_support_level::
-                     unsupported;
+               ? ext::oneapi::experimental::graph_support_level::native
+               : ext::oneapi::experimental::graph_support_level::unsupported;
   }
 };
 
@@ -1862,10 +1861,10 @@ inline uint32_t get_device_info_host<
 }
 
 template <>
-inline ext::oneapi::experimental::info::graph_support_level
+inline ext::oneapi::experimental::graph_support_level
 get_device_info_host<ext::oneapi::experimental::info::device::graph_support>() {
   // No support for graphs on the host device.
-  return ext::oneapi::experimental::info::graph_support_level::unsupported;
+  return ext::oneapi::experimental::graph_support_level::unsupported;
 }
 
 template <>

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -841,7 +841,7 @@ void executable_command_graph::finalizeImpl() {
     bool CmdBufSupport =
         Device.get_info<
             ext::oneapi::experimental::info::device::graph_support>() ==
-        info::graph_support_level::native;
+        graph_support_level::native;
 
 #if FORCE_EMULATION_MODE
     // Above query should still succeed in emulation mode, but ignore the

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -315,7 +315,7 @@ public:
 
     if (SyclDevice.get_info<
             ext::oneapi::experimental::info::device::graph_support>() ==
-        info::graph_support_level::unsupported) {
+        graph_support_level::unsupported) {
       std::stringstream Stream;
       Stream << SyclDevice.get_backend();
       std::string BackendString = Stream.str();

--- a/sycl/test-e2e/Graph/device_query.cpp
+++ b/sycl/test-e2e/Graph/device_query.cpp
@@ -11,13 +11,13 @@ int main() {
 
   auto Device = Queue.get_device();
 
-  exp_ext::info::graph_support_level SupportsGraphs =
+  exp_ext::graph_support_level SupportsGraphs =
       Device.get_info<exp_ext::info::device::graph_support>();
   auto Backend = Device.get_backend();
 
   if (Backend == backend::ext_oneapi_level_zero) {
-    assert(SupportsGraphs == exp_ext::info::graph_support_level::native);
+    assert(SupportsGraphs == exp_ext::graph_support_level::native);
   } else {
-    assert(SupportsGraphs == exp_ext::info::graph_support_level::unsupported);
+    assert(SupportsGraphs == exp_ext::graph_support_level::unsupported);
   }
 }

--- a/sycl/test-e2e/Graph/exception_unsupported_backend.cpp
+++ b/sycl/test-e2e/Graph/exception_unsupported_backend.cpp
@@ -12,7 +12,7 @@ int GetUnsupportedBackend(const sycl::device &Dev) {
   // 0 does not prevent another device to be picked as a second choice
   return Dev.get_info<
              ext::oneapi::experimental::info::device::graph_support>() ==
-         ext::oneapi::experimental::info::graph_support_level::unsupported;
+         ext::oneapi::experimental::graph_support_level::unsupported;
 }
 
 int main() {
@@ -20,7 +20,7 @@ int main() {
   queue Queue{Dev};
 
   if (Dev.get_info<ext::oneapi::experimental::info::device::graph_support>() !=
-      ext::oneapi::experimental::info::graph_support_level::unsupported)
+      ext::oneapi::experimental::graph_support_level::unsupported)
     return 0;
 
   std::error_code ExceptionCode = make_error_code(sycl::errc::success);


### PR DESCRIPTION
Move the `graph_support_level` enum from `sycl::ext::oneapi::experimental::info` to `sycl::ext::oneapi::experimental`

Reflects changes from specification PR https://github.com/reble/llvm/pull/311