### PR TITLE
[SYCL][Graph] Fixes multithread finalize unitest bug

### DIFF
--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1931,18 +1931,21 @@ TEST_F(MultiThreadGraphTest, RecordAddNodesInOrderQueue) {
 TEST_F(MultiThreadGraphTest, Finalize) {
   addKernels(Graph);
 
+  std::mutex MutexMap;
+
   std::map<int,
            experimental::command_graph<experimental::graph_state::executable>>
       GraphsExecMap;
   auto FinalizeGraph = [&](int ThreadNum) {
     SyncPoint.wait();
     auto GraphExec = Graph.finalize();
+    Queue.submit([&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
 
+    std::lock_guard<std::mutex> guard(MutexMap);
     GraphsExecMap.insert(
         std::map<int, experimental::command_graph<
                           experimental::graph_state::executable>>::
             value_type(ThreadNum, GraphExec));
-    Queue.submit([&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   };
 
   for (unsigned i = 0; i < NumThreads; ++i) {

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1941,7 +1941,7 @@ TEST_F(MultiThreadGraphTest, Finalize) {
     auto GraphExec = Graph.finalize();
     Queue.submit([&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
 
-    std::lock_guard<std::mutex> guard(MutexMap);
+    std::lock_guard<std::mutex> Guard(MutexMap);
     GraphsExecMap.insert(
         std::map<int, experimental::command_graph<
                           experimental::graph_state::executable>>::


### PR DESCRIPTION
std::map insertions are not thread-safe causing an issue in the multithread finalize test. This commit adds a mutex to prevent races when inserting data in the map.