### PR TITLE
[SYCL][Graph] Add support for fill and memset memop for CUDA backend

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
@@ -119,7 +119,7 @@ static ur_result_t enqueueCommandBufferFillHelper(
                                  SyncPointWaitList, DepsList));
 
   try {
-    auto N = Size / PatternSize;
+    size_t N = Size / PatternSize;
     auto Value = *static_cast<const uint32_t *>(Pattern);
     auto DstPtr = DstType == CU_MEMORYTYPE_DEVICE
                       ? *static_cast<CUdeviceptr *>(DstDevice)
@@ -152,7 +152,7 @@ static ur_result_t enqueueCommandBufferFillHelper(
       // This means that one cuGraphAddMemsetNode call is made for every 4 bytes
       // in the pattern.
 
-      auto NumberOfSteps = PatternSize / sizeof(uint32_t);
+      size_t NumberOfSteps = PatternSize / sizeof(uint32_t);
 
       // we walk up the pattern in 4-byte steps, and call cuMemset for each
       // 4-byte chunk of the pattern.

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
@@ -143,10 +143,10 @@ static ur_result_t enqueueCommandBufferFillHelper(
       // Get sync point and register the cuNode with it.
       *SyncPoint =
           CommandBuffer->AddSyncPoint(std::make_shared<CUgraphNode>(GraphNode));
-      // pattern size in bytes
+
     } else {
       // CUDA has no memset functions that allow setting values more than 4
-      // bytes. PI API lets you pass an arbitrary "pattern" to the buffer
+      // bytes. UR API lets you pass an arbitrary "pattern" to the buffer
       // fill, which can be more than 4 bytes. We must break up the pattern
       // into 4 byte values, and set the buffer using multiple strided calls.
       // This means that one cuGraphAddMemsetNode call is made for every 4 bytes
@@ -571,9 +571,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
 
   auto PatternIsValid = (pPattern != nullptr);
 
-  auto PatternSizeIsValid =
-      ((patternSize & (patternSize - 1)) == 0) && // is power of two
-      (patternSize > 0) && (patternSize <= 128);  // falls within valid range
+  auto PatternSizeIsValid = ((patternSize & (patternSize - 1)) == 0) &&
+                            (patternSize > 0); // is a positive power of two
   UR_ASSERT(ArgsAreMultiplesOfPatternSize && PatternIsValid &&
                 PatternSizeIsValid,
             UR_RESULT_ERROR_INVALID_SIZE);
@@ -594,9 +593,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
 
   auto PatternIsValid = (pPattern != nullptr);
 
-  auto PatternSizeIsValid =
-      ((patternSize & (patternSize - 1)) == 0) && // is power of two
-      (patternSize > 0) && (patternSize <= 128);  // falls within valid range
+  auto PatternSizeIsValid = ((patternSize & (patternSize - 1)) == 0) &&
+                            (patternSize > 0); // is a positive power of two
 
   UR_ASSERT(PatternIsValid && PatternSizeIsValid, UR_RESULT_ERROR_INVALID_SIZE);
   return enqueueCommandBufferFillHelper(

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
@@ -106,6 +106,90 @@ static void setCopyParams(const void *SrcPtr, const CUmemorytype_enum SrcType,
   Params.Depth = 1;
 }
 
+// Helper function for enqueuing memory fills
+static ur_result_t enqueueCommandBufferFillHelper(
+    ur_exp_command_buffer_handle_t CommandBuffer, void *DstDevice,
+    const CUmemorytype_enum DstType, const void *Pattern, size_t PatternSize,
+    size_t Size, uint32_t NumSyncPointsInWaitList,
+    const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
+    ur_exp_command_buffer_sync_point_t *SyncPoint) {
+  ur_result_t Result;
+  std::vector<CUgraphNode> DepsList;
+  UR_CALL(getNodesFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
+                                 SyncPointWaitList, DepsList));
+
+  try {
+    auto N = Size / PatternSize;
+    auto Value = *static_cast<const uint32_t *>(Pattern);
+    auto DstPtr = DstType == CU_MEMORYTYPE_DEVICE
+                      ? *static_cast<CUdeviceptr *>(DstDevice)
+                      : (CUdeviceptr)DstDevice;
+
+    if ((PatternSize == 1) || (PatternSize == 2) || (PatternSize == 4)) {
+      // Create a new node
+      CUgraphNode GraphNode;
+      CUDA_MEMSET_NODE_PARAMS NodeParams = {};
+      NodeParams.dst = DstPtr;
+      NodeParams.elementSize = PatternSize;
+      NodeParams.height = N;
+      NodeParams.pitch = PatternSize;
+      NodeParams.value = Value;
+      NodeParams.width = 1;
+
+      Result = UR_CHECK_ERROR(cuGraphAddMemsetNode(
+          &GraphNode, CommandBuffer->CudaGraph, DepsList.data(),
+          DepsList.size(), &NodeParams, CommandBuffer->Device->getContext()));
+
+      // Get sync point and register the cuNode with it.
+      *SyncPoint =
+          CommandBuffer->AddSyncPoint(std::make_shared<CUgraphNode>(GraphNode));
+      // pattern size in bytes
+    } else {
+      // CUDA has no memset functions that allow setting values more than 4
+      // bytes. PI API lets you pass an arbitrary "pattern" to the buffer
+      // fill, which can be more than 4 bytes. We must break up the pattern
+      // into 4 byte values, and set the buffer using multiple strided calls.
+      // This means that one cuGraphAddMemsetNode call is made for every 4 bytes
+      // in the pattern.
+
+      auto NumberOfSteps = PatternSize / sizeof(uint32_t);
+
+      // we walk up the pattern in 4-byte steps, and call cuMemset for each
+      // 4-byte chunk of the pattern.
+      for (auto Step = 0u; Step < NumberOfSteps; ++Step) {
+        // take 4 bytes of the pattern
+        auto Value = *(static_cast<const uint32_t *>(Pattern) + Step);
+
+        // offset the pointer to the part of the buffer we want to write to
+        auto OffsetPtr = DstPtr + (Step * sizeof(uint32_t));
+
+        // Create a new node
+        CUgraphNode GraphNode;
+        // Update NodeParam
+        CUDA_MEMSET_NODE_PARAMS NodeParamsStep = {};
+        NodeParamsStep.dst = (CUdeviceptr)OffsetPtr;
+        NodeParamsStep.elementSize = 4;
+        NodeParamsStep.height = N;
+        NodeParamsStep.pitch = PatternSize;
+        NodeParamsStep.value = Value;
+        NodeParamsStep.width = 1;
+
+        Result = UR_CHECK_ERROR(cuGraphAddMemsetNode(
+            &GraphNode, CommandBuffer->CudaGraph, DepsList.data(),
+            DepsList.size(), &NodeParamsStep,
+            CommandBuffer->Device->getContext()));
+
+        // Get sync point and register the cuNode with it.
+        *SyncPoint = CommandBuffer->AddSyncPoint(
+            std::make_shared<CUgraphNode>(GraphNode));
+      }
+    }
+  } catch (ur_result_t Err) {
+    Result = Err;
+  }
+  return Result;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     const ur_exp_command_buffer_desc_t *hCommandBufferDesc,
@@ -482,20 +566,23 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint) {
-  (void)hCommandBuffer;
-  (void)hBuffer;
-  (void)pPattern;
-  (void)patternSize;
-  (void)offset;
-  (void)size;
+  auto ArgsAreMultiplesOfPatternSize =
+      (offset % patternSize == 0) || (size % patternSize == 0);
 
-  (void)numSyncPointsInWaitList;
-  (void)pSyncPointWaitList;
-  (void)pSyncPoint;
+  auto PatternIsValid = (pPattern != nullptr);
 
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for CUDA adapter.");
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  auto PatternSizeIsValid =
+      ((patternSize & (patternSize - 1)) == 0) && // is power of two
+      (patternSize > 0) && (patternSize <= 128);  // falls within valid range
+  UR_ASSERT(ArgsAreMultiplesOfPatternSize && PatternIsValid &&
+                PatternSizeIsValid,
+            UR_RESULT_ERROR_INVALID_SIZE);
+
+  auto DstDevice = hBuffer->Mem.BufferMem.get() + offset;
+
+  return enqueueCommandBufferFillHelper(
+      hCommandBuffer, &DstDevice, CU_MEMORYTYPE_DEVICE, pPattern, patternSize,
+      size, numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
@@ -504,19 +591,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint) {
-  (void)hCommandBuffer;
-  (void)pPtr;
-  (void)pPattern;
-  (void)patternSize;
-  (void)size;
 
-  (void)numSyncPointsInWaitList;
-  (void)pSyncPointWaitList;
-  (void)pSyncPoint;
+  auto PatternIsValid = (pPattern != nullptr);
 
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for CUDA adapter.");
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  auto PatternSizeIsValid =
+      ((patternSize & (patternSize - 1)) == 0) && // is power of two
+      (patternSize > 0) && (patternSize <= 128);  // falls within valid range
+
+  UR_ASSERT(PatternIsValid && PatternSizeIsValid, UR_RESULT_ERROR_INVALID_SIZE);
+  return enqueueCommandBufferFillHelper(
+      hCommandBuffer, pPtr, CU_MEMORYTYPE_UNIFIED, pPattern, patternSize, size,
+      numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(

--- a/sycl/test-e2e/Graph/Explicit/buffer_fill.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_fill.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/usm_memset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_memset.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Inputs/buffer_fill.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_fill.cpp
@@ -9,16 +9,57 @@ int main() {
   const float Pattern = 3.14f;
   std::vector<float> Data(N);
   buffer<float> Buffer(Data);
+
+  const uint64_t PatternI64 = 0x3333333355555555;
+  std::vector<uint64_t> DataI64(N);
+  buffer<uint64_t> BufferI64(DataI64);
+
+  const uint32_t PatternI32 = 888;
+  std::vector<uint32_t> DataI32(N);
+  buffer<uint32_t> BufferI32(DataI32);
+
+  const uint16_t PatternI16 = 777;
+  std::vector<uint16_t> DataI16(N);
+  buffer<uint16_t> BufferI16(DataI16);
+
+  const uint8_t PatternI8 = 33;
+  std::vector<uint8_t> DataI8(N);
+  buffer<uint8_t> BufferI8(DataI8);
+
   Buffer.set_write_back(false);
+  BufferI64.set_write_back(false);
+  BufferI32.set_write_back(false);
+  BufferI16.set_write_back(false);
+  BufferI8.set_write_back(false);
   {
     exp_ext::command_graph Graph{
         Queue.get_context(),
         Queue.get_device(),
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
-    auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
+    add_node(Graph, Queue, [&](handler &CGH) {
       auto Acc = Buffer.get_access(CGH);
       CGH.fill(Acc, Pattern);
+    });
+
+    add_node(Graph, Queue, [&](handler &CGH) {
+      auto Acc = BufferI64.get_access(CGH);
+      CGH.fill(Acc, PatternI64);
+    });
+
+    add_node(Graph, Queue, [&](handler &CGH) {
+      auto Acc = BufferI32.get_access(CGH);
+      CGH.fill(Acc, PatternI32);
+    });
+
+    add_node(Graph, Queue, [&](handler &CGH) {
+      auto Acc = BufferI16.get_access(CGH);
+      CGH.fill(Acc, PatternI16);
+    });
+
+    add_node(Graph, Queue, [&](handler &CGH) {
+      auto Acc = BufferI8.get_access(CGH);
+      CGH.fill(Acc, PatternI8);
     });
 
     auto ExecGraph = Graph.finalize();
@@ -26,8 +67,17 @@ int main() {
     Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
   }
   host_accessor HostData(Buffer);
-  for (int i = 0; i < N; i++)
+  host_accessor HostDataI64(BufferI64);
+  host_accessor HostDataI32(BufferI32);
+  host_accessor HostDataI16(BufferI16);
+  host_accessor HostDataI8(BufferI8);
+  for (int i = 0; i < N; i++) {
     assert(HostData[i] == Pattern);
+    assert(HostDataI64[i] == PatternI64);
+    assert(HostDataI32[i] == PatternI32);
+    assert(HostDataI16[i] == PatternI16);
+    assert(HostDataI8[i] == PatternI8);
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_fill.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_fill.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/usm_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_memset.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG


### PR DESCRIPTION
Implements CUDA backend support for:
    - BufferFill
    - USMFill
 
Improves buffer_fill e2e test to test different pattern sizes.