### PR TITLE
[SYCL][Graph] Changes parentheses to braces in e2e tests for Sycl objects

### DIFF
--- a/sycl/test-e2e/Graph/Inputs/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/Inputs/add_nodes_after_finalize.cpp
@@ -40,7 +40,7 @@ int main() {
   Queue.wait_and_throw();
 
   auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(range<1>(Size),
+    CGH.parallel_for(range<1>{Size},
                      [=](item<1> id) { PtrC[id] += PtrA[id] + PtrB[id]; });
   });
 
@@ -50,7 +50,7 @@ int main() {
       Graph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, NodeA);
-        CGH.parallel_for(range<1>(Size),
+        CGH.parallel_for(range<1>{Size},
                          [=](item<1> id) { PtrOut[id] += PtrC[id] + 1; });
       },
       NodeA);

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy.cpp
@@ -51,7 +51,7 @@ int main() {
         Graph, Queue,
         [&](handler &CGH) {
           auto AccA = BufferA.get_access(CGH);
-          CGH.parallel_for(range<1>(Size), [=](item<1> id) {
+          CGH.parallel_for(range<1>{Size}, [=](item<1> id) {
             auto LinID = id.get_linear_id();
             AccA[LinID] += ModValue;
           });
@@ -63,7 +63,7 @@ int main() {
         Graph, Queue,
         [&](handler &CGH) {
           auto AccB = BufferB.get_access(CGH);
-          CGH.parallel_for(range<1>(Size), [=](item<1> id) {
+          CGH.parallel_for(range<1>{Size}, [=](item<1> id) {
             auto LinID = id.get_linear_id();
             AccB[LinID] += ModValue;
           });
@@ -85,7 +85,7 @@ int main() {
         Graph, Queue,
         [&](handler &CGH) {
           auto AccB = BufferB.get_access(CGH);
-          CGH.parallel_for(range<1>(Size), [=](item<1> id) {
+          CGH.parallel_for(range<1>{Size}, [=](item<1> id) {
             auto LinID = id.get_linear_id();
             AccB[LinID] += ModValue;
           });

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_2d.cpp
@@ -28,11 +28,11 @@ int main() {
   }
 
   // Make the buffers 2D so we can test the rect copy path
-  buffer BufferA{DataA.data(), range<2>(Size, Size)};
+  buffer BufferA{DataA.data(), range<2>{Size, Size}};
   BufferA.set_write_back(false);
-  buffer BufferB{DataB.data(), range<2>(Size, Size)};
+  buffer BufferB{DataB.data(), range<2>{Size, Size}};
   BufferB.set_write_back(false);
-  buffer BufferC{DataC.data(), range<2>(Size, Size)};
+  buffer BufferC{DataC.data(), range<2>{Size, Size}};
   BufferC.set_write_back(false);
   {
     exp_ext::command_graph Graph{
@@ -52,7 +52,7 @@ int main() {
         Graph, Queue,
         [&](handler &CGH) {
           auto AccA = BufferA.get_access(CGH);
-          CGH.parallel_for(range<2>(Size, Size),
+          CGH.parallel_for(range<2>{Size, Size},
                            [=](item<2> id) { AccA[id] += ModValue; });
         },
         NodeA);
@@ -62,7 +62,7 @@ int main() {
         Graph, Queue,
         [&](handler &CGH) {
           auto AccB = BufferB.get_access(CGH);
-          CGH.parallel_for(range<2>(Size, Size),
+          CGH.parallel_for(range<2>{Size, Size},
                            [=](item<2> id) { AccB[id] += ModValue; });
         },
         NodeA);
@@ -82,7 +82,7 @@ int main() {
         Graph, Queue,
         [&](handler &CGH) {
           auto AccB = BufferB.get_access(CGH);
-          CGH.parallel_for(range<2>(Size, Size),
+          CGH.parallel_for(range<2>{Size, Size},
                            [=](item<2> id) { AccB[id] += ModValue; });
         },
         NodeC);

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target.cpp
@@ -17,7 +17,7 @@ int main() {
     ReferenceA[i] = DataB[i];
   }
 
-  buffer<T, 1> BufferA(DataA.data(), range<1>(Size));
+  buffer<T, 1> BufferA{DataA.data(), range<1>{Size}};
   BufferA.set_write_back(false);
 
   {

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
@@ -18,7 +18,7 @@ int main() {
   }
 
   // Make the buffers 2D so we can test the rect write path
-  buffer BufferA{DataA.data(), range<2>(Size, Size)};
+  buffer BufferA{DataA.data(), range<2>{Size, Size}};
   BufferA.set_write_back(false);
 
   {

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
@@ -20,7 +20,7 @@ int main() {
       ReferenceA[i] = DataB[i - Offset];
   }
 
-  buffer<T, 1> BufferA(DataA.data(), range<1>(Size + Offset));
+  buffer<T, 1> BufferA{DataA.data(), range<1>{Size + Offset}};
   BufferA.set_write_back(false);
 
   {
@@ -30,8 +30,8 @@ int main() {
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
     auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
-      auto AccA = BufferA.get_access<access::mode::write>(CGH, range<1>(Size),
-                                                          id<1>(Offset));
+      auto AccA = BufferA.get_access<access::mode::write>(CGH, range<1>{Size},
+                                                          id<1>{Offset});
       CGH.copy(DataB.data(), AccA);
     });
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_offsets.cpp
@@ -39,9 +39,9 @@ int main() {
     // Copy from A to B
     auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
       auto AccA = BufferA.get_access<access::mode::read_write>(
-          CGH, range<1>(Size - OffsetSrc), id<1>(OffsetSrc));
+          CGH, range<1>{Size - OffsetSrc}, id<1>{OffsetSrc});
       auto AccB = BufferB.get_access<access::mode::read_write>(
-          CGH, range<1>(Size - OffsetDst), id<1>(OffsetDst));
+          CGH, range<1>{Size - OffsetDst}, id<1>{OffsetDst});
       CGH.copy(AccA, AccB);
     });
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host.cpp
@@ -18,7 +18,7 @@ int main() {
     ReferenceB[i] = DataA[i];
   }
 
-  buffer<T, 1> BufferA(DataA.data(), range<1>(Size));
+  buffer<T, 1> BufferA{DataA.data(), range<1>{Size}};
   BufferA.set_write_back(false);
 
   {

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
@@ -19,7 +19,7 @@ int main() {
   }
 
   // Make the buffers 2D so we can test the rect read path
-  buffer BufferA{DataA.data(), range<2>(Size, Size)};
+  buffer BufferA{DataA.data(), range<2>{Size, Size}};
   BufferA.set_write_back(false);
 
   {

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_offset.cpp
@@ -21,7 +21,7 @@ int main() {
       ReferenceB[i] = DataB[i];
   }
 
-  buffer<T, 1> BufferA(DataA.data(), range<1>(Size));
+  buffer<T, 1> BufferA{DataA.data(), range<1>{Size}};
   BufferA.set_write_back(false);
 
   {
@@ -32,7 +32,7 @@ int main() {
 
     auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
       auto AccA = BufferA.get_access<access::mode::read>(
-          CGH, range<1>(Size - Offset), id<1>(Offset));
+          CGH, range<1>{Size - Offset}, id<1>{Offset});
       CGH.copy(AccA, DataB.data());
     });
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_fill.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_fill.cpp
@@ -8,23 +8,23 @@ int main() {
   const size_t N = 10;
   const float Pattern = 3.14f;
   std::vector<float> Data(N);
-  buffer<float> Buffer(Data);
+  buffer<float> Buffer{Data};
 
   const uint64_t PatternI64 = 0x3333333355555555;
   std::vector<uint64_t> DataI64(N);
-  buffer<uint64_t> BufferI64(DataI64);
+  buffer<uint64_t> BufferI64{DataI64};
 
   const uint32_t PatternI32 = 888;
   std::vector<uint32_t> DataI32(N);
-  buffer<uint32_t> BufferI32(DataI32);
+  buffer<uint32_t> BufferI32{DataI32};
 
   const uint16_t PatternI16 = 777;
   std::vector<uint16_t> DataI16(N);
-  buffer<uint16_t> BufferI16(DataI16);
+  buffer<uint16_t> BufferI16{DataI16};
 
   const uint8_t PatternI8 = 33;
   std::vector<uint8_t> DataI8(N);
-  buffer<uint8_t> BufferI8(DataI8);
+  buffer<uint8_t> BufferI8{DataI8};
 
   Buffer.set_write_back(false);
   BufferI64.set_write_back(false);

--- a/sycl/test-e2e/Graph/Inputs/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/Inputs/dotp_buffer_reduction.cpp
@@ -13,14 +13,14 @@ int main() {
   std::vector<int> YData(N);
   std::vector<int> ZData(N);
 
-  buffer DotpBuf(&DotpData, range<1>(1));
+  buffer DotpBuf(&DotpData, range<1>{1});
   DotpBuf.set_write_back(false);
 
-  buffer XBuf(XData);
+  buffer XBuf{XData};
   XBuf.set_write_back(false);
-  buffer YBuf(YData);
+  buffer YBuf{YData};
   YBuf.set_write_back(false);
-  buffer ZBuf(ZData);
+  buffer ZBuf{ZData};
   ZBuf.set_write_back(false);
   {
     exp_ext::command_graph Graph{

--- a/sycl/test-e2e/Graph/Inputs/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/Inputs/event_status_querying.cpp
@@ -78,7 +78,7 @@ int main() {
     // Read & write A
     auto Node1 = add_node(Graph, Queue, [&](handler &CGH) {
       auto AccA = BufferA.get_access(CGH);
-      CGH.parallel_for(range<1>(Size), [=](item<1> id) {
+      CGH.parallel_for(range<1>{Size}, [=](item<1> id) {
         auto LinID = id.get_linear_id();
         AccA[LinID] += ModValue;
       });
@@ -87,7 +87,7 @@ int main() {
     // Read & write B
     auto Node2 = add_node(Graph, Queue, [&](handler &CGH) {
       auto AccB = BufferB.get_access(CGH);
-      CGH.parallel_for(range<1>(Size), [=](item<1> id) {
+      CGH.parallel_for(range<1>{Size}, [=](item<1> id) {
         auto LinID = id.get_linear_id();
         AccB[LinID] += ModValue;
       });
@@ -103,7 +103,7 @@ int main() {
     // Read and write B
     auto Node4 = add_node(Graph, Queue, [&](handler &CGH) {
       auto AccB = BufferB.get_access(CGH);
-      CGH.parallel_for(range<1>(Size), [=](item<1> id) {
+      CGH.parallel_for(range<1>{Size}, [=](item<1> id) {
         auto LinID = id.get_linear_id();
         AccB[LinID] += ModValue;
       });

--- a/sycl/test-e2e/Graph/Inputs/host_task.cpp
+++ b/sycl/test-e2e/Graph/Inputs/host_task.cpp
@@ -38,7 +38,7 @@ int main() {
 
   // Vector add to output
   auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(range<1>(Size),
+    CGH.parallel_for(range<1>{Size},
                      [=](item<1> id) { PtrC[id] += PtrA[id] + PtrB[id]; });
   });
 
@@ -60,7 +60,7 @@ int main() {
       Graph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, NodeB);
-        CGH.parallel_for(range<1>(Size), [=](item<1> id) { PtrC[id] += 1; });
+        CGH.parallel_for(range<1>{Size}, [=](item<1> id) { PtrC[id] += 1; });
       },
       NodeB);
 

--- a/sycl/test-e2e/Graph/Inputs/stream.cpp
+++ b/sycl/test-e2e/Graph/Inputs/stream.cpp
@@ -20,7 +20,7 @@ int main() {
 
   add_node(Graph, Queue, [&](handler &CGH) {
     sycl::stream Out(WorkItems * 16, 16, CGH);
-    CGH.parallel_for(range<1>(WorkItems), [=](item<1> id) {
+    CGH.parallel_for(range<1>{WorkItems}, [=](item<1> id) {
       Out << "Val: " << PtrIn[id.get_linear_id()] << sycl::endl;
     });
   });

--- a/sycl/test-e2e/Graph/Inputs/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph.cpp
@@ -50,7 +50,7 @@ int main() {
 
   // Vector add two values
   auto NodeSubA = add_node(SubGraph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(range<1>(Size),
+    CGH.parallel_for(range<1>{Size},
                      [=](item<1> id) { PtrC[id] = PtrA[id] + PtrB[id]; });
   });
 
@@ -59,7 +59,7 @@ int main() {
       SubGraph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, NodeSubA);
-        CGH.parallel_for(range<1>(Size),
+        CGH.parallel_for(range<1>{Size},
                          [=](item<1> id) { PtrC[id] -= ModValue; });
       },
       NodeSubA);
@@ -70,7 +70,7 @@ int main() {
 
   // Modify the input values.
   auto NodeMainA = add_node(MainGraph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(range<1>(Size), [=](item<1> id) {
+    CGH.parallel_for(range<1>{Size}, [=](item<1> id) {
       PtrA[id] += ModValue;
       PtrB[id] += ModValue;
     });
@@ -89,7 +89,7 @@ int main() {
       MainGraph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, NodeMainB);
-        CGH.parallel_for(range<1>(Size),
+        CGH.parallel_for(range<1>{Size},
                          [=](item<1> id) { PtrOut[id] = PtrC[id] + ModValue; });
       },
       NodeMainB);

--- a/sycl/test-e2e/Graph/Inputs/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_copy.cpp
@@ -46,7 +46,7 @@ int main() {
       Graph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, NodeA);
-        CGH.parallel_for(range<1>(Size), [=](item<1> id) {
+        CGH.parallel_for(range<1>{Size}, [=](item<1> id) {
           auto LinID = id.get_linear_id();
           PtrA[LinID] += ModValue;
         });
@@ -58,7 +58,7 @@ int main() {
       Graph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, NodeA);
-        CGH.parallel_for(range<1>(Size), [=](item<1> id) {
+        CGH.parallel_for(range<1>{Size}, [=](item<1> id) {
           auto LinID = id.get_linear_id();
           PtrB[LinID] += ModValue;
         });
@@ -79,7 +79,7 @@ int main() {
       Graph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, NodeC);
-        CGH.parallel_for(range<1>(Size), [=](item<1> id) {
+        CGH.parallel_for(range<1>{Size}, [=](item<1> id) {
           auto LinID = id.get_linear_id();
           PtrB[LinID] += ModValue;
         });

--- a/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
@@ -11,7 +11,7 @@ int main() {
   const size_t N = 10;
   int *Arr = malloc_device<int>(N, Queue);
 
-  int Pattern = 3.14f;
+  int Pattern = 314;
   auto NodeA =
       add_node(Graph, Queue, [&](handler &CGH) { CGH.fill(Arr, Pattern, N); });
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
@@ -14,7 +14,7 @@ int main() {
   const size_t N = 10;
   int *Arr = malloc_host<int>(N, Queue);
 
-  int Pattern = 3.14f;
+  int Pattern = 314;
   auto NodeA =
       add_node(Graph, Queue, [&](handler &CGH) { CGH.fill(Arr, Pattern, N); });
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
@@ -15,7 +15,7 @@ int main() {
   const size_t N = 10;
   int *Arr = malloc_shared<int>(N, Queue);
 
-  int Pattern = 3.14f;
+  int Pattern = 314;
   auto NodeA =
       add_node(Graph, Queue, [&](handler &CGH) { CGH.fill(Arr, Pattern, N); });
 

--- a/sycl/test-e2e/Graph/graph_common.hpp
+++ b/sycl/test-e2e/Graph/graph_common.hpp
@@ -83,7 +83,7 @@ event run_kernels(queue Q, const size_t Size, buffer<T> BufferA,
   // Read & write Buffer A.
   Q.submit([&](handler &CGH) {
     auto DataA = BufferA.template get_access<access::mode::read_write>(CGH);
-    CGH.parallel_for(range<1>(Size), [=](item<1> Id) { DataA[Id]++; });
+    CGH.parallel_for(range<1>{Size}, [=](item<1> Id) { DataA[Id]++; });
   });
 
   // Reads Buffer A.
@@ -91,7 +91,7 @@ event run_kernels(queue Q, const size_t Size, buffer<T> BufferA,
   Q.submit([&](handler &CGH) {
     auto DataA = BufferA.template get_access<access::mode::read>(CGH);
     auto DataB = BufferB.template get_access<access::mode::read_write>(CGH);
-    CGH.parallel_for(range<1>(Size),
+    CGH.parallel_for(range<1>{Size},
                      [=](item<1> Id) { DataB[Id] += DataA[Id]; });
   });
 
@@ -100,7 +100,7 @@ event run_kernels(queue Q, const size_t Size, buffer<T> BufferA,
   Q.submit([&](handler &CGH) {
     auto DataA = BufferA.template get_access<access::mode::read>(CGH);
     auto DataC = BufferC.template get_access<access::mode::read_write>(CGH);
-    CGH.parallel_for(range<1>(Size),
+    CGH.parallel_for(range<1>{Size},
                      [=](item<1> Id) { DataC[Id] -= DataA[Id]; });
   });
 
@@ -108,7 +108,7 @@ event run_kernels(queue Q, const size_t Size, buffer<T> BufferA,
   auto ExitEvent = Q.submit([&](handler &CGH) {
     auto DataB = BufferB.template get_access<access::mode::read_write>(CGH);
     auto DataC = BufferC.template get_access<access::mode::read_write>(CGH);
-    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+    CGH.parallel_for(range<1>{Size}, [=](item<1> Id) {
       DataB[Id]--;
       DataC[Id]--;
     });
@@ -134,7 +134,7 @@ add_kernels(exp_ext::command_graph<exp_ext::graph_state::modifiable> Graph,
   // Read & write Buffer A
   Graph.add([&](handler &CGH) {
     auto DataA = BufferA.template get_access<access::mode::read_write>(CGH);
-    CGH.parallel_for(range<1>(Size), [=](item<1> Id) { DataA[Id]++; });
+    CGH.parallel_for(range<1>{Size}, [=](item<1> Id) { DataA[Id]++; });
   });
 
   // Reads Buffer A
@@ -142,7 +142,7 @@ add_kernels(exp_ext::command_graph<exp_ext::graph_state::modifiable> Graph,
   Graph.add([&](handler &CGH) {
     auto DataA = BufferA.template get_access<access::mode::read>(CGH);
     auto DataB = BufferB.template get_access<access::mode::read_write>(CGH);
-    CGH.parallel_for(range<1>(Size),
+    CGH.parallel_for(range<1>{Size},
                      [=](item<1> Id) { DataB[Id] += DataA[Id]; });
   });
 
@@ -151,7 +151,7 @@ add_kernels(exp_ext::command_graph<exp_ext::graph_state::modifiable> Graph,
   Graph.add([&](handler &CGH) {
     auto DataA = BufferA.template get_access<access::mode::read>(CGH);
     auto DataC = BufferC.template get_access<access::mode::read_write>(CGH);
-    CGH.parallel_for(range<1>(Size),
+    CGH.parallel_for(range<1>{Size},
                      [=](item<1> Id) { DataC[Id] -= DataA[Id]; });
   });
 
@@ -159,7 +159,7 @@ add_kernels(exp_ext::command_graph<exp_ext::graph_state::modifiable> Graph,
   auto ExitNode = Graph.add([&](handler &CGH) {
     auto DataB = BufferB.template get_access<access::mode::read_write>(CGH);
     auto DataC = BufferC.template get_access<access::mode::read_write>(CGH);
-    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+    CGH.parallel_for(range<1>{Size}, [=](item<1> Id) {
       DataB[Id]--;
       DataC[Id]--;
     });
@@ -181,7 +181,7 @@ event run_kernels_usm(queue Q, const size_t Size, T *DataA, T *DataB,
                       T *DataC) {
   // Read & write Buffer A
   auto EventA = Q.submit([&](handler &CGH) {
-    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+    CGH.parallel_for(range<1>{Size}, [=](item<1> Id) {
       auto LinID = Id.get_linear_id();
       DataA[LinID]++;
     });
@@ -191,7 +191,7 @@ event run_kernels_usm(queue Q, const size_t Size, T *DataA, T *DataB,
   // Read & Write Buffer B
   auto EventB = Q.submit([&](handler &CGH) {
     CGH.depends_on(EventA);
-    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+    CGH.parallel_for(range<1>{Size}, [=](item<1> Id) {
       auto LinID = Id.get_linear_id();
       DataB[LinID] += DataA[LinID];
     });
@@ -201,7 +201,7 @@ event run_kernels_usm(queue Q, const size_t Size, T *DataA, T *DataB,
   // Read & writes Buffer C
   auto EventC = Q.submit([&](handler &CGH) {
     CGH.depends_on(EventA);
-    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+    CGH.parallel_for(range<1>{Size}, [=](item<1> Id) {
       auto LinID = Id.get_linear_id();
       DataC[LinID] -= DataA[LinID];
     });
@@ -210,7 +210,7 @@ event run_kernels_usm(queue Q, const size_t Size, T *DataA, T *DataB,
   // Read & write Buffers B and C
   auto ExitEvent = Q.submit([&](handler &CGH) {
     CGH.depends_on({EventB, EventC});
-    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+    CGH.parallel_for(range<1>{Size}, [=](item<1> Id) {
       auto LinID = Id.get_linear_id();
       DataB[LinID]--;
       DataC[LinID]--;
@@ -234,7 +234,7 @@ add_kernels_usm(exp_ext::command_graph<exp_ext::graph_state::modifiable> Graph,
                 const size_t Size, T *DataA, T *DataB, T *DataC) {
   // Read & write Buffer A
   auto NodeA = Graph.add([&](handler &CGH) {
-    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+    CGH.parallel_for(range<1>{Size}, [=](item<1> Id) {
       auto LinID = Id.get_linear_id();
       DataA[LinID]++;
     });
@@ -244,7 +244,7 @@ add_kernels_usm(exp_ext::command_graph<exp_ext::graph_state::modifiable> Graph,
   // Read & Write Buffer B
   auto NodeB = Graph.add(
       [&](handler &CGH) {
-        CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+        CGH.parallel_for(range<1>{Size}, [=](item<1> Id) {
           auto LinID = Id.get_linear_id();
           DataB[LinID] += DataA[LinID];
         });
@@ -255,7 +255,7 @@ add_kernels_usm(exp_ext::command_graph<exp_ext::graph_state::modifiable> Graph,
   // Read & writes Buffer C
   auto NodeC = Graph.add(
       [&](handler &CGH) {
-        CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+        CGH.parallel_for(range<1>{Size}, [=](item<1> Id) {
           auto LinID = Id.get_linear_id();
           DataC[LinID] -= DataA[LinID];
         });
@@ -265,7 +265,7 @@ add_kernels_usm(exp_ext::command_graph<exp_ext::graph_state::modifiable> Graph,
   // Read & write data B and C
   auto ExitNode = Graph.add(
       [&](handler &CGH) {
-        CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+        CGH.parallel_for(range<1>{Size}, [=](item<1> Id) {
           auto LinID = Id.get_linear_id();
           DataB[LinID]--;
           DataC[LinID]--;


### PR DESCRIPTION
Makes all Sycl objects use braces instead of parentheses when calling constructor. This is safer for multi-platform software since braces prevent for type narrowing.