### PR TITLE
[SYCL][Graph] Improve multithread e2e tests

### DIFF
--- a/sycl/test-e2e/Graph/Threading/submit.cpp
+++ b/sycl/test-e2e/Graph/Threading/submit.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, gpu
+// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build_pthread_inc} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
@@ -57,7 +57,7 @@ int main() {
 
   Barrier SyncPoint{NumThreads};
 
-  auto FinalizeGraph = [&](int ThreadNum) {
+  auto SubmitGraph = [&](int ThreadNum) {
     SyncPoint.wait();
     Queue.submit([&](sycl::handler &CGH) {
       CGH.ext_oneapi_graph(GraphExecs[ThreadNum]);
@@ -68,7 +68,7 @@ int main() {
   Threads.reserve(NumThreads);
 
   for (unsigned i = 0; i < NumThreads; ++i) {
-    Threads.emplace_back(FinalizeGraph, i);
+    Threads.emplace_back(SubmitGraph, i);
   }
 
   for (unsigned i = 0; i < NumThreads; ++i) {


### PR DESCRIPTION
Multithread finalize.cpp e2e was written to test both finalize and submit processes. 
This test was based on strong assumptions on the backend's kernel execution order, and was unstable. 
Since the behaviour of the finalization process in multi-threading environment is already tested by a unitest, we (re)focused this test to verify concurrent submissions. 
The test is therefore renamed submit.cpp.