### PR TITLE
[SYCL][Graph] Enable specification constants with graph

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1623,10 +1623,6 @@ public:
   void set_specialization_constant(
       typename std::remove_reference_t<decltype(SpecName)>::value_type Value) {
 
-    throwIfGraphAssociated<
-        ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
-            sycl_specialization_constants>();
-
     setStateSpecConstSet();
 
     std::shared_ptr<detail::kernel_bundle_impl> KernelBundleImplPtr =
@@ -1640,10 +1636,6 @@ public:
   template <auto &SpecName>
   typename std::remove_reference_t<decltype(SpecName)>::value_type
   get_specialization_constant() const {
-
-    throwIfGraphAssociated<
-        ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
-            sycl_specialization_constants>();
 
     if (isStateExplicitKernelBundle())
       throw sycl::exception(make_error_code(errc::invalid),

--- a/sycl/test-e2e/Graph/Explicit/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/Explicit/spec_constants_handler_api.cpp
@@ -1,0 +1,16 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using ZE_DEBUG
+// RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// CHECK-NOT: LEAK
+
+// The following limitation is not restricted to Sycl-Graph
+// but comes from the orignal test : `SpecConstants/2020/handler-api.cpp`
+// FIXME: ACC devices use emulation path, which is not yet supported
+// UNSUPPORTED: accelerator
+
+#define GRAPH_E2E_EXPLICIT
+
+#include "../Inputs/spec_constants_handler_api.cpp"

--- a/sycl/test-e2e/Graph/Explicit/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/Explicit/spec_constants_kernel_bundle_api.cpp
@@ -7,7 +7,7 @@
 // CHECK-NOT: LEAK
 
 // The following limitation is not restricted to Sycl-Graph
-// but comes from the orignal test : `SpecConstants/2020/handler-api.cpp`
+// but comes from the orignal test : `SpecConstants/2020/kernel-bundle-api.cpp`
 // FIXME: ACC devices use emulation path, which is not yet supported
 // UNSUPPORTED: accelerator
 // UNSUPPORTED: hip

--- a/sycl/test-e2e/Graph/Explicit/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/Explicit/spec_constants_kernel_bundle_api.cpp
@@ -1,0 +1,17 @@
+// REQUIRES: cuda || level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using ZE_DEBUG
+// RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// CHECK-NOT: LEAK
+
+// The following limitation is not restricted to Sycl-Graph
+// but comes from the orignal test : `SpecConstants/2020/handler-api.cpp`
+// FIXME: ACC devices use emulation path, which is not yet supported
+// UNSUPPORTED: accelerator
+// UNSUPPORTED: hip
+
+#define GRAPH_E2E_EXPLICIT
+
+#include "../Inputs/spec_constants_kernel_bundle_api.cpp"

--- a/sycl/test-e2e/Graph/Inputs/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/Inputs/spec_constants_handler_api.cpp
@@ -1,5 +1,8 @@
 // This test is intended to check basic operations with SYCL 2020 specialization
 // constants using Graph and sycl::handler and sycl::kernel_handler APIs
+// This test was taken from `SpecConstants/2020/handler-api.cpp`.
+// Variable names have been changed to meet PascalCase naming convention
+// requirements.
 
 #include "../graph_common.hpp"
 

--- a/sycl/test-e2e/Graph/Inputs/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/Inputs/spec_constants_handler_api.cpp
@@ -1,0 +1,203 @@
+// This test is intended to check basic operations with SYCL 2020 specialization
+// constants using Graph and sycl::handler and sycl::kernel_handler APIs
+
+#include "../graph_common.hpp"
+
+constexpr sycl::specialization_id<int> IntId;
+constexpr sycl::specialization_id<int> IntId2(2);
+constexpr sycl::specialization_id<float> FloatId(3.14);
+
+class TestDefaultValuesKernel;
+class EmptyKernel;
+class TestSetAndGetOnDevice;
+
+bool test_default_values(sycl::queue Queue);
+bool test_set_and_get_on_host(sycl::queue Queue);
+bool test_set_and_get_on_device(sycl::queue Queue);
+
+bool test_set_and_get_on_device(sycl::queue Queue);
+
+int main() {
+  auto ExceptionHandler = [&](sycl::exception_list Exceptions) {
+    for (std::exception_ptr const &E : Exceptions) {
+      try {
+        std::rethrow_exception(E);
+      } catch (sycl::exception const &E) {
+        std::cout << "An async SYCL exception was caught: " << E.what()
+                  << std::endl;
+        std::exit(1);
+      }
+    }
+  };
+
+  queue Queue{ExceptionHandler,
+              {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!test_default_values(Queue)) {
+    std::cout << "Test for default values of specialization constants failed!"
+              << std::endl;
+    return 1;
+  }
+
+  if (!test_set_and_get_on_host(Queue)) {
+    std::cout << "Test for set and get API on host failed!" << std::endl;
+    return 1;
+  }
+
+  if (!test_set_and_get_on_device(Queue)) {
+    std::cout << "Test for set and get API on device failed!" << std::endl;
+    return 1;
+  }
+
+  return 0;
+};
+
+bool test_default_values(sycl::queue Queue) {
+  sycl::buffer<int> IntBuffer(1);
+  IntBuffer.set_write_back(false);
+  sycl::buffer<int> IntBuffer2(1);
+  IntBuffer2.set_write_back(false);
+  sycl::buffer<float> FloatBuffer(1);
+  FloatBuffer.set_write_back(false);
+
+  {
+    exp_ext::command_graph Graph{
+        Queue.get_context(),
+        Queue.get_device(),
+        {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+    add_node(Graph, Queue, ([&](sycl::handler &CGH) {
+               auto IntAcc =
+                   IntBuffer.get_access<sycl::access::mode::write>(CGH);
+               auto IntAcc2 =
+                   IntBuffer2.get_access<sycl::access::mode::write>(CGH);
+               auto FloatAcc =
+                   FloatBuffer.get_access<sycl::access::mode::write>(CGH);
+
+               CGH.single_task<TestDefaultValuesKernel>(
+                   [=](sycl::kernel_handler KH) {
+                     IntAcc[0] = KH.get_specialization_constant<IntId>();
+                     IntAcc2[0] = KH.get_specialization_constant<IntId2>();
+                     FloatAcc[0] = KH.get_specialization_constant<FloatId>();
+                   });
+             }));
+
+    auto GraphExec = Graph.finalize();
+
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.wait_and_throw();
+  }
+
+  sycl::host_accessor IntAcc(IntBuffer, sycl::read_only);
+  if (!check_value(
+          0, IntAcc[0],
+          "integer specialization constant (defined without default value)"))
+    return false;
+
+  sycl::host_accessor IntAcc2(IntBuffer2, sycl::read_only);
+  if (!check_value(2, IntAcc2[0], "integer specialization constant"))
+    return false;
+
+  sycl::host_accessor FloatAcc(FloatBuffer, sycl::read_only);
+  if (!check_value(3.14f, FloatAcc[0], "float specialization constant"))
+    return false;
+
+  return true;
+}
+
+bool test_set_and_get_on_host(sycl::queue Queue) {
+  unsigned Errors = 0;
+
+  exp_ext::command_graph Graph{
+      Queue.get_context(),
+      Queue.get_device(),
+      {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+  add_node(
+      Graph, Queue, ([&](sycl::handler &CGH) {
+        if (!check_value(
+                0, CGH.get_specialization_constant<IntId>(),
+                "integer specializaiton constant before setting any value"))
+          ++Errors;
+
+        if (!check_value(
+                3.14f, CGH.get_specialization_constant<FloatId>(),
+                "float specializaiton constant before setting any value"))
+          ++Errors;
+
+        int NewIntValue = 8;
+        float NewFloatValue = 3.0f;
+        CGH.set_specialization_constant<IntId>(NewIntValue);
+        CGH.set_specialization_constant<FloatId>(NewFloatValue);
+
+        if (!check_value(
+                NewIntValue, CGH.get_specialization_constant<IntId>(),
+                "integer specializaiton constant after setting a new value"))
+          ++Errors;
+
+        if (!check_value(
+                NewFloatValue, CGH.get_specialization_constant<FloatId>(),
+                "float specializaiton constant after setting a new value"))
+          ++Errors;
+
+        CGH.single_task<EmptyKernel>([=]() {});
+      }));
+
+  return Errors == 0;
+}
+
+bool test_set_and_get_on_device(sycl::queue Queue) {
+  sycl::buffer<int> IntBuffer(1);
+  IntBuffer.set_write_back(false);
+  sycl::buffer<int> IntBuffer2(1);
+  IntBuffer2.set_write_back(false);
+  sycl::buffer<float> FloatBuffer(1);
+  FloatBuffer.set_write_back(false);
+
+  int NewIntValue = 8;
+  int NewIntValue2 = 0;
+  float NewFloatValue = 3.0f;
+
+  {
+    exp_ext::command_graph Graph{
+        Queue.get_context(),
+        Queue.get_device(),
+        {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+    add_node(
+        Graph, Queue, ([&](sycl::handler &CGH) {
+          auto IntAcc = IntBuffer.get_access<sycl::access::mode::write>(CGH);
+          auto IntAcc2 = IntBuffer2.get_access<sycl::access::mode::write>(CGH);
+          auto FloatAcc =
+              FloatBuffer.get_access<sycl::access::mode::write>(CGH);
+
+          CGH.set_specialization_constant<IntId>(NewIntValue);
+          CGH.set_specialization_constant<IntId2>(NewIntValue2);
+          CGH.set_specialization_constant<FloatId>(NewFloatValue);
+
+          CGH.single_task<TestSetAndGetOnDevice>([=](sycl::kernel_handler KH) {
+            IntAcc[0] = KH.get_specialization_constant<IntId>();
+            IntAcc2[0] = KH.get_specialization_constant<IntId2>();
+            FloatAcc[0] = KH.get_specialization_constant<FloatId>();
+          });
+        }));
+
+    auto GraphExec = Graph.finalize();
+
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.wait_and_throw();
+  }
+  sycl::host_accessor IntAcc(IntBuffer, sycl::read_only);
+  if (!check_value(NewIntValue, IntAcc[0], "integer specialization constant"))
+    return false;
+
+  sycl::host_accessor IntAcc2(IntBuffer2, sycl::read_only);
+  if (!check_value(NewIntValue2, IntAcc2[0], "integer specialization constant"))
+    return false;
+
+  sycl::host_accessor FloatAcc(FloatBuffer, sycl::read_only);
+  if (!check_value(NewFloatValue, FloatAcc[0], "float specialization constant"))
+    return false;
+
+  return true;
+}

--- a/sycl/test-e2e/Graph/Inputs/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/Inputs/spec_constants_kernel_bundle_api.cpp
@@ -1,5 +1,8 @@
 // This test is intended to check basic operations with SYCL 2020 specialization
 // constants using Graph and sycl::kernel_bundle and sycl::kernel_handler APIs
+// This test was taken from `SpecConstants/2020/kernel-bundle-api.cpp`.
+// Variable names have been changed to meet PascalCase naming convention
+// requirements and native constants test was removed.
 
 #include "../graph_common.hpp"
 

--- a/sycl/test-e2e/Graph/Inputs/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/Inputs/spec_constants_kernel_bundle_api.cpp
@@ -1,0 +1,226 @@
+// This test is intended to check basic operations with SYCL 2020 specialization
+// constants using Graph and sycl::kernel_bundle and sycl::kernel_handler APIs
+
+#include "../graph_common.hpp"
+
+constexpr sycl::specialization_id<int> IntId(2);
+constexpr sycl::specialization_id<float> FloatId(3.14f);
+
+class TestDefaultValuesKernel;
+class EmptyKernel;
+class TestSetAndGetOnDevice;
+
+bool test_default_values(sycl::queue Queue);
+bool test_set_and_get_on_host(sycl::queue Queue);
+bool test_set_and_get_on_device(sycl::queue Queue);
+
+int main() {
+  auto ExceptionHandler = [&](sycl::exception_list Exceptions) {
+    for (std::exception_ptr const &E : Exceptions) {
+      try {
+        std::rethrow_exception(E);
+      } catch (sycl::exception const &E) {
+        std::cout << "An async SYCL exception was caught: " << E.what()
+                  << std::endl;
+        std::exit(1);
+      }
+    }
+  };
+
+  queue Queue{ExceptionHandler,
+              {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!test_default_values(Queue)) {
+    std::cout << "Test for default values of specialization constants failed!"
+              << std::endl;
+    return 1;
+  }
+
+  if (!test_set_and_get_on_host(Queue)) {
+    std::cout << "Test for set and get API on host failed!" << std::endl;
+    return 1;
+  }
+
+  if (!test_set_and_get_on_device(Queue)) {
+    std::cout << "Test for set and get API on device failed!" << std::endl;
+    return 1;
+  }
+
+  return 0;
+};
+
+bool test_default_values(sycl::queue Queue) {
+  if (!sycl::has_kernel_bundle<sycl::bundle_state::input>(
+          Queue.get_context())) {
+    std::cout << "Cannot obtain kernel_bundle in input state, skipping default "
+                 "values test"
+              << std::endl;
+    return true;
+  }
+
+  sycl::buffer<int> IntBuffer(1);
+  IntBuffer.set_write_back(false);
+  sycl::buffer<float> FloatBuffer(1);
+  FloatBuffer.set_write_back(false);
+
+  auto InputBundle =
+      sycl::get_kernel_bundle<sycl::bundle_state::input>(Queue.get_context());
+  auto ExecBundle = sycl::build(InputBundle);
+
+  {
+    exp_ext::command_graph Graph{
+        Queue.get_context(),
+        Queue.get_device(),
+        {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+    add_node(Graph, Queue, ([&](sycl::handler &CGH) {
+               CGH.use_kernel_bundle(ExecBundle);
+               auto IntAcc =
+                   IntBuffer.get_access<sycl::access::mode::write>(CGH);
+               auto FloatAcc =
+                   FloatBuffer.get_access<sycl::access::mode::write>(CGH);
+
+               CGH.single_task<TestDefaultValuesKernel>(
+                   [=](sycl::kernel_handler KH) {
+                     IntAcc[0] = KH.get_specialization_constant<IntId>();
+                     FloatAcc[0] = KH.get_specialization_constant<FloatId>();
+                   });
+             }));
+
+    auto GraphExec = Graph.finalize();
+
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.wait_and_throw();
+  }
+
+  sycl::host_accessor IntAcc(IntBuffer, sycl::read_only);
+  if (!check_value(2, IntAcc[0], "integer specialization constant"))
+    return false;
+
+  sycl::host_accessor FloatAcc(FloatBuffer, sycl::read_only);
+  if (!check_value(3.14f, FloatAcc[0], "float specialization constant"))
+    return false;
+
+  return true;
+}
+
+bool test_set_and_get_on_host(sycl::queue Queue) {
+  if (!sycl::has_kernel_bundle<sycl::bundle_state::input>(
+          Queue.get_context())) {
+    std::cout << "Cannot obtain kernel_bundle in input state, skipping default "
+                 "values test"
+              << std::endl;
+    return true;
+  }
+
+  unsigned Errors = 0;
+
+  try {
+    auto InputBundle =
+        sycl::get_kernel_bundle<sycl::bundle_state::input>(Queue.get_context());
+
+    if (!InputBundle.contains_specialization_constants()) {
+      std::cout
+          << "Obtained kernel_bundle is expected to contain specialization "
+             "constants, but it doesn't!"
+          << std::endl;
+      return false;
+    }
+
+    // Check default values
+    if (!check_value(
+            2, InputBundle.get_specialization_constant<IntId>(),
+            "integer specialization constant before setting any value"))
+      ++Errors;
+
+    if (!check_value(3.14f, InputBundle.get_specialization_constant<FloatId>(),
+                     "float specialization constant before setting any value"))
+      ++Errors;
+
+    // Update values
+    int NewIntValue = 42;
+    float NewFloatValue = 3.0f;
+
+    InputBundle.set_specialization_constant<IntId>(NewIntValue);
+    InputBundle.set_specialization_constant<FloatId>(NewFloatValue);
+
+    // And re-check them again
+    if (!check_value(
+            NewIntValue, InputBundle.get_specialization_constant<IntId>(),
+            "integer specialization constant after setting a new value"))
+      ++Errors;
+
+    if (!check_value(NewFloatValue,
+                     InputBundle.get_specialization_constant<FloatId>(),
+                     "float specialization constant after setting a value"))
+      ++Errors;
+
+    // Let's try to build the bundle
+    auto ExecBundle = sycl::build(InputBundle);
+
+    // And ensure that updated spec constant values are still there
+    if (!check_value(NewIntValue,
+                     ExecBundle.get_specialization_constant<IntId>(),
+                     "integer specialization constant after build"))
+      ++Errors;
+
+    if (!check_value(NewFloatValue,
+                     ExecBundle.get_specialization_constant<FloatId>(),
+                     "float specialization constant after build"))
+      ++Errors;
+  } catch (sycl::exception &e) {
+  }
+
+  return 0 == Errors;
+}
+
+bool test_set_and_get_on_device(sycl::queue Queue) {
+  sycl::buffer<int> IntBuffer(1);
+  IntBuffer.set_write_back(false);
+  sycl::buffer<float> FloatBuffer(1);
+  FloatBuffer.set_write_back(false);
+
+  int NewIntValue = 42;
+  float NewFloatValue = 2.0f;
+
+  auto InputBundle =
+      sycl::get_kernel_bundle<sycl::bundle_state::input>(Queue.get_context());
+  InputBundle.set_specialization_constant<IntId>(NewIntValue);
+  InputBundle.set_specialization_constant<FloatId>(NewFloatValue);
+  auto ExecBundle = sycl::build(InputBundle);
+
+  {
+    exp_ext::command_graph Graph{
+        Queue.get_context(),
+        Queue.get_device(),
+        {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+    add_node(
+        Graph, Queue, ([&](sycl::handler &CGH) {
+          CGH.use_kernel_bundle(ExecBundle);
+          auto IntAcc = IntBuffer.get_access<sycl::access::mode::write>(CGH);
+          auto FloatAcc =
+              FloatBuffer.get_access<sycl::access::mode::write>(CGH);
+
+          CGH.single_task<TestSetAndGetOnDevice>([=](sycl::kernel_handler KH) {
+            IntAcc[0] = KH.get_specialization_constant<IntId>();
+            FloatAcc[0] = KH.get_specialization_constant<FloatId>();
+          });
+        }));
+
+    auto GraphExec = Graph.finalize();
+
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.wait_and_throw();
+  }
+
+  sycl::host_accessor IntAcc(IntBuffer, sycl::read_only);
+  if (!check_value(NewIntValue, IntAcc[0], "integer specialization constant"))
+    return false;
+
+  sycl::host_accessor FloatAcc(FloatBuffer, sycl::read_only);
+  if (!check_value(NewFloatValue, FloatAcc[0], "float specialization constant"))
+    return false;
+
+  return true;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/spec_constants_handler_api.cpp
@@ -1,0 +1,16 @@
+// REQUIRES: cuda || level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using ZE_DEBUG
+// RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// CHECK-NOT: LEAK
+
+// The following limitation is not restricted to Sycl-Graph
+// but comes from the orignal test : `SpecConstants/2020/handler-api.cpp`
+// FIXME: ACC devices use emulation path, which is not yet supported
+// UNSUPPORTED: accelerator
+
+#define GRAPH_E2E_RECORD_REPLAY
+
+#include "../Inputs/spec_constants_handler_api.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/spec_constants_kernel_bundle_api.cpp
@@ -7,7 +7,7 @@
 // CHECK-NOT: LEAK
 
 // The following limitation is not restricted to Sycl-Graph
-// but comes from the orignal test : `SpecConstants/2020/handler-api.cpp`
+// but comes from the orignal test : `SpecConstants/2020/kernel-bundle-api.cpp`
 // FIXME: ACC devices use emulation path, which is not yet supported
 // UNSUPPORTED: accelerator
 // UNSUPPORTED: hip

--- a/sycl/test-e2e/Graph/RecordReplay/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/spec_constants_kernel_bundle_api.cpp
@@ -1,0 +1,17 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using ZE_DEBUG
+// RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// CHECK-NOT: LEAK
+
+// The following limitation is not restricted to Sycl-Graph
+// but comes from the orignal test : `SpecConstants/2020/handler-api.cpp`
+// FIXME: ACC devices use emulation path, which is not yet supported
+// UNSUPPORTED: accelerator
+// UNSUPPORTED: hip
+
+#define GRAPH_E2E_RECORD_REPLAY
+
+#include "../Inputs/spec_constants_kernel_bundle_api.cpp"

--- a/sycl/test-e2e/Graph/graph_common.hpp
+++ b/sycl/test-e2e/Graph/graph_common.hpp
@@ -434,10 +434,10 @@ private:
 };
 
 template <typename T>
-bool check_value(const T &ref, const T &got, const std::string &variable_name) {
-  if (got != ref) {
-    std::cout << "Unexpected value of " << variable_name << ": " << got
-              << " (got) vs " << ref << " (expected)" << std::endl;
+bool check_value(const T &Ref, const T &Got, const std::string &VariableName) {
+  if (Got != Ref) {
+    std::cout << "Unexpected value of " << VariableName << ": " << Got
+              << " (got) vs " << Ref << " (expected)" << std::endl;
     return false;
   }
 

--- a/sycl/test-e2e/Graph/graph_common.hpp
+++ b/sycl/test-e2e/Graph/graph_common.hpp
@@ -432,3 +432,14 @@ private:
   std::condition_variable cv;
   std::size_t threadNum;
 };
+
+template <typename T>
+bool check_value(const T &ref, const T &got, const std::string &variable_name) {
+  if (got != ref) {
+    std::cout << "Unexpected value of " << variable_name << ": " << got
+              << " (got) vs " << ref << " (expected)" << std::endl;
+    return false;
+  }
+
+  return true;
+}

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -22,21 +22,6 @@
 using namespace sycl;
 using namespace sycl::ext::oneapi;
 
-// Spec constant for testing.
-constexpr specialization_id<int> SpecConst1{7};
-
-namespace sycl {
-inline namespace _V1 {
-namespace detail {
-
-// Necessary for get_specialization_constant() to work in unit tests.
-template <> const char *get_spec_constant_symbolic_ID<SpecConst1>() {
-  return "SC1";
-}
-} // namespace detail
-} // namespace _V1
-} // namespace sycl
-
 // anonymous namespace used to avoid code redundancy by defining functions
 // used by multiple times by unitests.
 // Defining anonymous namespace prevents from function naming conflits
@@ -1857,36 +1842,6 @@ TEST_F(CommandGraphTest, Memcpy2DExceptionCheck) {
 
   sycl::free(USMMemSrc, Queue);
   sycl::free(USMMemDst, Queue);
-}
-
-// Tests that using specialization constants in a graph will throw.
-TEST_F(CommandGraphTest, SpecializationConstant) {
-
-  ASSERT_THROW(
-      {
-        try {
-          Graph.add([&](handler &CGH) {
-            CGH.set_specialization_constant<SpecConst1>(8);
-          });
-        } catch (const sycl::exception &e) {
-          ASSERT_EQ(e.code(), make_error_code(sycl::errc::invalid));
-          throw;
-        }
-      },
-      sycl::exception);
-  ASSERT_THROW(
-      {
-        try {
-          Graph.add([&](handler &CGH) {
-            int Value = CGH.get_specialization_constant<SpecConst1>();
-            (void)Value;
-          });
-        } catch (const sycl::exception &e) {
-          ASSERT_EQ(e.code(), make_error_code(sycl::errc::invalid));
-          throw;
-        }
-      },
-      sycl::exception);
 }
 
 // Tests that using reductions in a graph will throw.


### PR DESCRIPTION
Enables specification constants handling in Graph. 
Adds tests that verify this behaviour.
Removes tests that checked for unsupported feature exception throwing.

Closes Issue: #99