### PR TITLE
[SYCL][Graph] Refactor node storage inside graphs

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -29,50 +29,6 @@ namespace experimental {
 namespace detail {
 
 namespace {
-
-/// Recursively check if a given node is an exit node, and add the new nodes as
-/// successors if so.
-/// @param[in] CurrentNode Node to check as exit node.
-/// @param[in] NewInputs Noes to add as successors.
-void connectToExitNodes(
-    std::shared_ptr<node_impl> CurrentNode,
-    const std::vector<std::shared_ptr<node_impl>> &NewInputs) {
-  if (CurrentNode->MSuccessors.size() > 0) {
-    for (auto &Successor : CurrentNode->MSuccessors) {
-      connectToExitNodes(Successor, NewInputs);
-    }
-
-  } else {
-    for (auto &Input : NewInputs) {
-      CurrentNode->registerSuccessor(Input, CurrentNode);
-    }
-  }
-}
-
-/// Recursive check if a graph node or its successors contains a given
-/// requirement.
-/// @param[in] Req The requirement to check for.
-/// @param[in] CurrentNode The current graph node being checked.
-/// @param[in,out] Deps The unique list of dependencies which have been
-/// identified for this requirement.
-/// @return True if a dependency was added in this node or any of its
-/// successors.
-bool checkForRequirement(sycl::detail::AccessorImplHost *Req,
-                         const std::shared_ptr<node_impl> &CurrentNode,
-                         std::set<std::shared_ptr<node_impl>> &Deps) {
-  bool SuccessorAddedDep = false;
-  for (auto &Successor : CurrentNode->MSuccessors) {
-    SuccessorAddedDep |= checkForRequirement(Req, Successor, Deps);
-  }
-
-  if (!CurrentNode->isEmpty() && Deps.find(CurrentNode) == Deps.end() &&
-      CurrentNode->hasRequirement(Req) && !SuccessorAddedDep) {
-    Deps.insert(CurrentNode);
-    return true;
-  }
-  return SuccessorAddedDep;
-}
-
 /// Visits a node on the graph and it's successors recursively in a depth-first
 /// approach.
 /// @param[in] Node The current node being visited.
@@ -99,7 +55,8 @@ bool visitNodeDepthFirst(
   Node->MVisited = true;
   VisitedNodes.emplace(Node);
   for (auto &Successor : Node->MSuccessors) {
-    if (visitNodeDepthFirst(Successor, VisitedNodes, NodeStack, NodeFunc)) {
+    if (visitNodeDepthFirst(Successor.lock(), VisitedNodes, NodeStack,
+                            NodeFunc)) {
       return true;
     }
   }
@@ -119,10 +76,25 @@ void duplicateNode(const std::shared_ptr<node_impl> Node,
 
 } // anonymous namespace
 
+/// Recursively add nodes to execution stack.
+/// @param NodeImpl Node to schedule.
+/// @param Schedule Execution ordering to add node to.
+void sortTopological(std::shared_ptr<node_impl> NodeImpl,
+                     std::list<std::shared_ptr<node_impl>> &Schedule) {
+  for (auto &Succ : NodeImpl->MSuccessors) {
+    // Check if we've already scheduled this node
+    auto NextNode = Succ.lock();
+    if (std::find(Schedule.begin(), Schedule.end(), NextNode) == Schedule.end())
+      sortTopological(NextNode, Schedule);
+  }
+
+  Schedule.push_front(NodeImpl);
+}
+
 void exec_graph_impl::schedule() {
   if (MSchedule.empty()) {
     for (auto &Node : MGraphImpl->MRoots) {
-      Node->sortTopological(Node, MSchedule);
+      sortTopological(Node, MSchedule);
     }
   }
 }
@@ -148,10 +120,20 @@ std::shared_ptr<node_impl> graph_impl::addNodesToExits(
     }
   }
 
-  // Recursively walk the graph to find exit nodes and connect up the inputs
-  // TODO: Consider caching exit nodes so we don't have to do this
-  for (auto &NodeImpl : MRoots) {
-    connectToExitNodes(NodeImpl, Inputs);
+  // Find all exit nodes in the current graph and register the Inputs as
+  // successors
+  for (size_t i = 0; i < MNodeStorage.size(); i++) {
+    auto NodeImpl = MNodeStorage[i];
+    if (NodeImpl->MSuccessors.size() == 0) {
+      for (auto &Input : Inputs) {
+        NodeImpl->registerSuccessor(Input, NodeImpl);
+      }
+    }
+  }
+
+  // Add all the new nodes to the node storage
+  for (auto &Node : NodeList) {
+    MNodeStorage.push_back(Node);
   }
 
   return this->add(Outputs);
@@ -175,7 +157,7 @@ std::shared_ptr<node_impl> graph_impl::addSubgraphNodes(
     *NewNodesIt = NodeCopy;
     NodesMap.insert({Node, NodeCopy});
     for (auto &NextNode : Node->MSuccessors) {
-      auto Successor = NodesMap.at(NextNode);
+      auto Successor = NodesMap.at(NextNode.lock());
       NodeCopy->registerSuccessor(Successor, NodeCopy);
     }
   }
@@ -201,6 +183,7 @@ graph_impl::add(const std::vector<std::shared_ptr<node_impl>> &Dep) {
   // Add any deps from the vector of extra dependencies
   Deps.insert(Deps.end(), MExtraDependencies.begin(), MExtraDependencies.end());
 
+  MNodeStorage.push_back(NodeImpl);
   // TODO: Encapsulate in separate function to avoid duplication
   if (!Deps.empty()) {
     for (auto &N : Deps) {
@@ -285,17 +268,25 @@ graph_impl::add(sycl::detail::CG::CGTYPE CGType,
       MemObj->markBeingUsedInGraph();
     }
     // Look through the graph for nodes which share this requirement
-    for (auto &NodePtr : MRoots) {
-      checkForRequirement(Req, NodePtr, UniqueDeps);
+    for (auto Node : MNodeStorage) {
+      if (Node->hasRequirement(Req)) {
+        bool ShouldAddDep = true;
+        // If any of this node's successors have this requirement then we skip
+        // adding the current node as a dependency.
+        for (auto &Succ : Node->MSuccessors) {
+          if (Succ.lock()->hasRequirement(Req))
+            ShouldAddDep = false;
+        }
+        if (ShouldAddDep)
+          UniqueDeps.insert(Node);
+      }
     }
   }
 
   // Add any nodes specified by event dependencies into the dependency list
   for (auto &Dep : CommandGroup->getEvents()) {
     if (auto NodeImpl = MEventsMap.find(Dep); NodeImpl != MEventsMap.end()) {
-      if (UniqueDeps.find(NodeImpl->second) == UniqueDeps.end()) {
-        UniqueDeps.insert(NodeImpl->second);
-      }
+      UniqueDeps.insert(NodeImpl->second);
     } else {
       throw sycl::exception(sycl::make_error_code(errc::invalid),
                             "Event dependency from handler::depends_on does "
@@ -311,6 +302,8 @@ graph_impl::add(sycl::detail::CG::CGTYPE CGType,
 
   const std::shared_ptr<node_impl> &NodeImpl =
       std::make_shared<node_impl>(CGType, std::move(CommandGroup));
+  MNodeStorage.push_back(NodeImpl);
+
   if (!Deps.empty()) {
     for (auto &N : Deps) {
       N->registerSuccessor(NodeImpl, N); // register successor
@@ -394,18 +387,14 @@ void graph_impl::makeEdge(std::shared_ptr<node_impl> Src,
 
   bool SrcFound = false;
   bool DestFound = false;
-  auto CheckForNodes = [&](std::shared_ptr<node_impl> &Node,
-                           std::deque<std::shared_ptr<node_impl>> &) {
-    if (Node == Src) {
-      SrcFound = true;
-    }
-    if (Node == Dest) {
-      DestFound = true;
-    }
-    return SrcFound && DestFound;
-  };
+  for (auto Node : MNodeStorage) {
 
-  searchDepthFirst(CheckForNodes);
+    SrcFound |= Node == Src;
+    DestFound |= Node == Dest;
+
+    if (SrcFound && DestFound)
+      break;
+  }
 
   if (!SrcFound) {
     throw sycl::exception(make_error_code(sycl::errc::invalid),

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -40,7 +40,7 @@ namespace detail {
 class node_impl {
 public:
   /// List of successors to this node.
-  std::vector<std::shared_ptr<node_impl>> MSuccessors;
+  std::vector<std::weak_ptr<node_impl>> MSuccessors;
   /// List of predecessors to this node.
   ///
   /// Using weak_ptr here to prevent circular references between nodes.
@@ -61,8 +61,10 @@ public:
   /// use a raw \p this pointer, so the extra \Prev parameter is passed.
   void registerSuccessor(const std::shared_ptr<node_impl> &Node,
                          const std::shared_ptr<node_impl> &Prev) {
-    if (std::find(MSuccessors.begin(), MSuccessors.end(), Node) !=
-        MSuccessors.end()) {
+    if (std::find_if(MSuccessors.begin(), MSuccessors.end(),
+                     [Node](const std::weak_ptr<node_impl> &Ptr) {
+                       return Ptr.lock() == Node;
+                     }) != MSuccessors.end()) {
       return;
     }
     MSuccessors.push_back(Node);
@@ -91,65 +93,6 @@ public:
   node_impl(sycl::detail::CG::CGTYPE CGType,
             std::unique_ptr<sycl::detail::CG> &&CommandGroup)
       : MCGType(CGType), MCommandGroup(std::move(CommandGroup)) {}
-
-  /// Tests if two nodes have the same content,
-  /// i.e. same command group
-  /// This function should only be used for internal purposes.
-  /// A true return from this operator is not a guarantee that the nodes are
-  /// equals according to the Common reference semantics. But this function is
-  /// an helper to verify that two nodes contain equivalent Command Groups.
-  /// @param Node node to compare with
-  /// @return true if two nodes have equivament command groups. false otherwise.
-  bool operator==(const node_impl &Node) {
-    if (MCGType != Node.MCGType)
-      return false;
-
-    switch (MCGType) {
-    case sycl::detail::CG::CGTYPE::Kernel: {
-      sycl::detail::CGExecKernel *ExecKernelA =
-          static_cast<sycl::detail::CGExecKernel *>(MCommandGroup.get());
-      sycl::detail::CGExecKernel *ExecKernelB =
-          static_cast<sycl::detail::CGExecKernel *>(Node.MCommandGroup.get());
-      return ExecKernelA->MKernelName.compare(ExecKernelB->MKernelName) == 0;
-    }
-    case sycl::detail::CG::CGTYPE::CopyUSM: {
-      sycl::detail::CGCopyUSM *CopyA =
-          static_cast<sycl::detail::CGCopyUSM *>(MCommandGroup.get());
-      sycl::detail::CGCopyUSM *CopyB =
-          static_cast<sycl::detail::CGCopyUSM *>(MCommandGroup.get());
-      return (CopyA->getSrc() == CopyB->getSrc()) &&
-             (CopyA->getDst() == CopyB->getDst()) &&
-             (CopyA->getLength() == CopyB->getLength());
-    }
-    case sycl::detail::CG::CGTYPE::CopyAccToAcc:
-    case sycl::detail::CG::CGTYPE::CopyAccToPtr:
-    case sycl::detail::CG::CGTYPE::CopyPtrToAcc: {
-      sycl::detail::CGCopy *CopyA =
-          static_cast<sycl::detail::CGCopy *>(MCommandGroup.get());
-      sycl::detail::CGCopy *CopyB =
-          static_cast<sycl::detail::CGCopy *>(MCommandGroup.get());
-      return (CopyA->getSrc() == CopyB->getSrc()) &&
-             (CopyA->getDst() == CopyB->getDst());
-    }
-    default:
-      assert(false && "Unexpected command group type!");
-      return false;
-    }
-  }
-
-  /// Recursively add nodes to execution stack.
-  /// @param NodeImpl Node to schedule.
-  /// @param Schedule Execution ordering to add node to.
-  void sortTopological(std::shared_ptr<node_impl> NodeImpl,
-                       std::list<std::shared_ptr<node_impl>> &Schedule) {
-    for (auto &Next : MSuccessors) {
-      // Check if we've already scheduled this node
-      if (std::find(Schedule.begin(), Schedule.end(), Next) == Schedule.end())
-        Next->sortTopological(Next, Schedule);
-    }
-
-    Schedule.push_front(NodeImpl);
-  }
 
   /// Checks if this node has a given requirement.
   /// @param Requirement Requirement to lookup.
@@ -235,50 +178,54 @@ public:
     return nullptr;
   }
 
-  /// Tests is the caller is similar to Node
+  /// Tests is the caller is similar to Node, this is only used for testing.
+  /// @param Node The node to check for similarity.
+  /// @param CompareContentOnly Skip comparisons related to graph structure,
+  /// compare only the type and command groups of the nodes
   /// @return True if the two nodes are similar
-  bool isSimilar(std::shared_ptr<node_impl> Node) {
-    if (MSuccessors.size() != Node->MSuccessors.size())
+  bool isSimilar(std::shared_ptr<node_impl> Node,
+                 bool CompareContentOnly = false) {
+    if (!CompareContentOnly) {
+      if (MSuccessors.size() != Node->MSuccessors.size())
+        return false;
+
+      if (MPredecessors.size() != Node->MPredecessors.size())
+        return false;
+    }
+    if (MCGType != Node->MCGType)
       return false;
 
-    if (MPredecessors.size() != Node->MPredecessors.size())
+    switch (MCGType) {
+    case sycl::detail::CG::CGTYPE::Kernel: {
+      sycl::detail::CGExecKernel *ExecKernelA =
+          static_cast<sycl::detail::CGExecKernel *>(MCommandGroup.get());
+      sycl::detail::CGExecKernel *ExecKernelB =
+          static_cast<sycl::detail::CGExecKernel *>(Node->MCommandGroup.get());
+      return ExecKernelA->MKernelName.compare(ExecKernelB->MKernelName) == 0;
+    }
+    case sycl::detail::CG::CGTYPE::CopyUSM: {
+      sycl::detail::CGCopyUSM *CopyA =
+          static_cast<sycl::detail::CGCopyUSM *>(MCommandGroup.get());
+      sycl::detail::CGCopyUSM *CopyB =
+          static_cast<sycl::detail::CGCopyUSM *>(Node->MCommandGroup.get());
+      return (CopyA->getSrc() == CopyB->getSrc()) &&
+             (CopyA->getDst() == CopyB->getDst()) &&
+             (CopyA->getLength() == CopyB->getLength());
+    }
+    case sycl::detail::CG::CGTYPE::CopyAccToAcc:
+    case sycl::detail::CG::CGTYPE::CopyAccToPtr:
+    case sycl::detail::CG::CGTYPE::CopyPtrToAcc: {
+      sycl::detail::CGCopy *CopyA =
+          static_cast<sycl::detail::CGCopy *>(MCommandGroup.get());
+      sycl::detail::CGCopy *CopyB =
+          static_cast<sycl::detail::CGCopy *>(Node->MCommandGroup.get());
+      return (CopyA->getSrc() == CopyB->getSrc()) &&
+             (CopyA->getDst() == CopyB->getDst());
+    }
+    default:
+      assert(false && "Unexpected command group type!");
       return false;
-
-    if (*this == *Node.get())
-      return true;
-
-    return false;
-  }
-
-  /// Recursive traversal of successor nodes checking for
-  /// equivalent node successions in Node
-  /// @param Node pointer to the starting node for structure comparison
-  /// @return true is same structure found, false otherwise
-  bool checkNodeRecursive(std::shared_ptr<node_impl> Node) {
-    size_t FoundCnt = 0;
-    for (std::shared_ptr<node_impl> SuccA : MSuccessors) {
-      for (std::shared_ptr<node_impl> SuccB : Node->MSuccessors) {
-        if (isSimilar(Node) && SuccA->checkNodeRecursive(SuccB)) {
-          FoundCnt++;
-          break;
-        }
-      }
     }
-    if (FoundCnt != MSuccessors.size()) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /// Recusively computes the number of successor nodes
-  /// @return number of successor nodes
-  size_t depthSearchCount() const {
-    size_t NumberOfNodes = 1;
-    for (const auto &Succ : MSuccessors) {
-      NumberOfNodes += Succ->depthSearchCount();
-    }
-    return NumberOfNodes;
   }
 
 private:
@@ -434,6 +381,9 @@ public:
   /// List of root nodes.
   std::set<std::shared_ptr<node_impl>> MRoots;
 
+  /// Storage for all nodes contained within a graph
+  std::vector<std::shared_ptr<node_impl>> MNodeStorage;
+
   /// Find the last node added to this graph from an in-order queue.
   /// @param Queue In-order queue to find the last node added to the graph from.
   /// @return Last node in this graph added from \p Queue recording, or empty
@@ -474,6 +424,29 @@ public:
                                 " cannot be called when a queue "
                                 "is currently recording commands to a graph.");
     }
+  }
+
+  /// Recursively check successors of NodeA and NodeB to check they are similar.
+  /// @param NodeA pointer to the first node for comparison
+  /// @param NodeB pointer to the second node for comparison
+  /// @return true is same structure found, false otherwise
+  bool checkNodeRecursive(std::shared_ptr<node_impl> NodeA,
+                          std::shared_ptr<node_impl> NodeB) const {
+    size_t FoundCnt = 0;
+    for (std::weak_ptr<node_impl> &SuccA : NodeA->MSuccessors) {
+      for (std::weak_ptr<node_impl> &SuccB : NodeB->MSuccessors) {
+        if (NodeA->isSimilar(NodeB) &&
+            checkNodeRecursive(SuccA.lock(), SuccB.lock())) {
+          FoundCnt++;
+          break;
+        }
+      }
+    }
+    if (FoundCnt != NodeA->MSuccessors.size()) {
+      return false;
+    }
+
+    return true;
   }
 
   /// Checks if the graph_impl of Graph has a similar structure to
@@ -536,7 +509,7 @@ public:
     for (std::shared_ptr<node_impl> NodeA : MRoots) {
       for (std::shared_ptr<node_impl> NodeB : Graph->MRoots) {
         if (NodeA->isSimilar(NodeB)) {
-          if (NodeA->checkNodeRecursive(NodeB)) {
+          if (checkNodeRecursive(NodeA, NodeB)) {
             RootsFound++;
             break;
           }
@@ -555,15 +528,9 @@ public:
     return true;
   }
 
-  // Returns the number of nodes in the Graph
-  // @return Number of nodes in the Graph
-  size_t getNumberOfNodes() const {
-    size_t NumberOfNodes = 0;
-    for (const auto &Node : MRoots) {
-      NumberOfNodes += Node->depthSearchCount();
-    }
-    return NumberOfNodes;
-  }
+  /// Returns the number of nodes in the Graph
+  /// @return Number of nodes in the Graph
+  size_t getNumberOfNodes() const { return MNodeStorage.size(); }
 
   /// Traverse the graph recursively to get the events associated with the
   /// output nodes of this graph.


### PR DESCRIPTION
- Store graph nodes inside a vector instead for more optimal searches
- Replace several depth first search operations with iterations over node storage
- Node successors are now weak_ptrs
- Remove node_impl::operator== and move functionality to isSimilar()
- Unit tests updated to reflect changes