### PR TITLE
[SYCL][Graph] Update spec supported features

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -486,10 +486,10 @@ class depends_on {
 }
 ----
 
-==== Depends-On-All-Leaves Property 
+==== Depends-On-All-Leaves Property
 The API for explicitly adding nodes to a `command_graph` includes a
-`property_list` parameter. This extension defines the `depends_on_all_leaves` 
-property to be passed here. `depends_on_all_leaves` provides a shortcut for 
+`property_list` parameter. This extension defines the `depends_on_all_leaves`
+property to be passed here. `depends_on_all_leaves` provides a shortcut for
 adding all the current leaves of a graph as dependencies.
 [source,c++]
 ----
@@ -757,11 +757,11 @@ print_graph(std::string path, bool verbose = false) const;
 ----
 
 |Synchronous operation that writes a DOT formatted description of the graph to the
-provided path. By default, this includes the graph topology, node types, node id, 
-and kernel names. 
-Verbose can be set to true to write more detailed information about each node type 
+provided path. By default, this includes the graph topology, node types, node id,
+and kernel names.
+Verbose can be set to true to write more detailed information about each node type
 such as kernel arguments, copy source, and destination addresses.
-At the moment DOT format is the only supported format. The name of hte output file 
+At the moment DOT format is the only supported format. The name of the output file
 must therefore match this extension, i.e. "<filename>.dot".
 
 Parameters:
@@ -772,7 +772,7 @@ or memory access where applicable.
 
 Exceptions:
 
-* Throws synchronously with error code `invalid` if the path is invalid or 
+* Throws synchronously with error code `invalid` if the path is invalid or
 the file extension is not supported or if the write operation failed.
 
 |===
@@ -1220,11 +1220,12 @@ passed an invalid event.
 
 The new handler methods, and queue shortcuts, defined by
 link:../supported/sycl_ext_oneapi_enqueue_barrier.asciidoc[sycl_ext_oneapi_enqueue_barrier]
-cannot be used in graph nodes. A synchronous exception will be thrown with
-error code `invalid` if a user tries to add them to a graph.
-
-Removing this restriction is something we may look at for future revisions of
-`sycl_ext_oneapi_graph`.
+can only be used in graph nodes created using the Record & Replay API, as
+barriers rely on events to enforce dependencies. A synchronous exception will be
+thrown with error code `invalid` if a user tries to add them to a graph using
+the Explicit API. Empty nodes created with the `node::depends_on_all_leaves`
+property can be used instead of barriers when a user is building a graph with
+the explicit API.
 
 ==== sycl_ext_oneapi_memcpy2d
 
@@ -1793,12 +1794,14 @@ if used in application code.
 . Using `handler::memset` in a graph node.
 . Using `handler::prefetch` in a graph node.
 . Using `handler::memadvise` in a graph node.
-. Using specialization constants in a graph node.
 . Using reductions in a graph node.
 . Using sycl streams in a graph node.
-. Using a kernel bundle in a graph node.
 . Profiling an event returned from graph submission with
   `event::get_profiling_info()`.
+. Level Zero immediate command-lists are not supported, and
+  `sycl::ext::intel::property::queue::no_immediate_command_list`
+  should be set on construction to any queues an executable
+  graph is submitted to.
 
 == Revision History
 


### PR DESCRIPTION
The following features defined in the specification as unsupported, have working implementations upstream.

* https://github.com/intel/llvm/pull/11418
* https://github.com/intel/llvm/pull/11505
* https://github.com/intel/llvm/pull/11556
* https://github.com/intel/llvm/pull/11855

Duplicate PR to https://github.com/reble/llvm/pull/338 but without accidentally adding lots of participants from a messed up rebase