### PR TITLE
[SYCL][Graph] Enable use of kernel properties

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -1282,11 +1282,8 @@ which is layered ontop of `sycl_ext_oneapi_graph`.
 
 The new handler methods, and queue shortcuts, defined by
 link:../experimental/sycl_ext_oneapi_kernel_properties.asciidoc[sycl_ext_oneapi_kernel_properties]
-cannot be used in graph nodes. A synchronous exception will be thrown with error
-code `invalid` if a user tries to add them to a graph.
-
-Removing this restriction is something we may look at for future revisions of
-`sycl_ext_oneapi_graph`.
+can be used in graph nodes in the same way as they are used in normal queue
+submission. 
 
 ==== sycl_ext_oneapi_prod
 

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2317,7 +2317,6 @@ public:
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
   single_task(PropertiesT Props, _KERNELFUNCPARAM(KernelFunc)) {
-    throwIfGraphAssociatedAndKernelProperties<PropertiesT>();
     single_task_lambda_impl<KernelName, KernelType, PropertiesT>(Props,
                                                                  KernelFunc);
   }
@@ -2328,7 +2327,6 @@ public:
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
   parallel_for(range<1> NumWorkItems, PropertiesT Props,
                _KERNELFUNCPARAM(KernelFunc)) {
-    throwIfGraphAssociatedAndKernelProperties<PropertiesT>();
     parallel_for_lambda_impl<KernelName, KernelType, 1, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
@@ -2339,7 +2337,6 @@ public:
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
   parallel_for(range<2> NumWorkItems, PropertiesT Props,
                _KERNELFUNCPARAM(KernelFunc)) {
-    throwIfGraphAssociatedAndKernelProperties<PropertiesT>();
     parallel_for_lambda_impl<KernelName, KernelType, 2, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
@@ -2350,7 +2347,6 @@ public:
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
   parallel_for(range<3> NumWorkItems, PropertiesT Props,
                _KERNELFUNCPARAM(KernelFunc)) {
-    throwIfGraphAssociatedAndKernelProperties<PropertiesT>();
     parallel_for_lambda_impl<KernelName, KernelType, 3, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
@@ -2361,7 +2357,6 @@ public:
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
   parallel_for(nd_range<Dims> Range, PropertiesT Properties,
                _KERNELFUNCPARAM(KernelFunc)) {
-    throwIfGraphAssociatedAndKernelProperties<PropertiesT>();
     parallel_for_impl<KernelName>(Range, Properties, std::move(KernelFunc));
   }
 
@@ -2376,7 +2371,6 @@ public:
   parallel_for(range<1> Range, PropertiesT Properties, RestT &&...Rest) {
     throwIfGraphAssociated<ext::oneapi::experimental::detail::
                                UnsupportedGraphFeatures::sycl_reductions>();
-    throwIfGraphAssociatedAndKernelProperties<PropertiesT>();
     detail::reduction_parallel_for<KernelName>(*this, Range, Properties,
                                                std::forward<RestT>(Rest)...);
   }
@@ -2390,7 +2384,6 @@ public:
   parallel_for(range<2> Range, PropertiesT Properties, RestT &&...Rest) {
     throwIfGraphAssociated<ext::oneapi::experimental::detail::
                                UnsupportedGraphFeatures::sycl_reductions>();
-    throwIfGraphAssociatedAndKernelProperties<PropertiesT>();
     detail::reduction_parallel_for<KernelName>(*this, Range, Properties,
                                                std::forward<RestT>(Rest)...);
   }
@@ -2404,7 +2397,6 @@ public:
   parallel_for(range<3> Range, PropertiesT Properties, RestT &&...Rest) {
     throwIfGraphAssociated<ext::oneapi::experimental::detail::
                                UnsupportedGraphFeatures::sycl_reductions>();
-    throwIfGraphAssociatedAndKernelProperties<PropertiesT>();
     detail::reduction_parallel_for<KernelName>(*this, Range, Properties,
                                                std::forward<RestT>(Rest)...);
   }
@@ -2461,7 +2453,6 @@ public:
             int Dims, typename PropertiesT>
   void parallel_for_work_group(range<Dims> NumWorkGroups, PropertiesT Props,
                                _KERNELFUNCPARAM(KernelFunc)) {
-    throwIfGraphAssociatedAndKernelProperties<PropertiesT>();
     parallel_for_work_group_lambda_impl<KernelName, KernelType, Dims,
                                         PropertiesT>(NumWorkGroups, Props,
                                                      KernelFunc);
@@ -2472,7 +2463,6 @@ public:
   void parallel_for_work_group(range<Dims> NumWorkGroups,
                                range<Dims> WorkGroupSize, PropertiesT Props,
                                _KERNELFUNCPARAM(KernelFunc)) {
-    throwIfGraphAssociatedAndKernelProperties<PropertiesT>();
     parallel_for_work_group_lambda_impl<KernelName, KernelType, Dims,
                                         PropertiesT>(
         NumWorkGroups, WorkGroupSize, Props, KernelFunc);
@@ -3619,17 +3609,6 @@ private:
       throw sycl::exception(make_error_code(errc::kernel_argument),
                             "placeholder accessor must be bound by calling "
                             "handler::require() before it can be used.");
-  }
-
-  template <typename PropertiesT>
-  std::enable_if_t<
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  throwIfGraphAssociatedAndKernelProperties() const {
-    if (!std::is_same_v<PropertiesT,
-                        ext::oneapi::experimental::empty_properties_t>)
-      throwIfGraphAssociated<
-          ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
-              sycl_ext_oneapi_kernel_properties>();
   }
 
   // Set value of the gpu cache configuration for the kernel.

--- a/sycl/test-e2e/Graph/Explicit/sub_group_prop.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_group_prop.cpp
@@ -1,0 +1,10 @@
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if ext_oneapi_level_zero %{env UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// CHECK-NOT: LEAK
+
+#define GRAPH_E2E_EXPLICIT
+
+#include "../Inputs/sub_group_prop.cpp"

--- a/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
@@ -1,0 +1,13 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if ext_oneapi_level_zero %{env UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// CHECK-NOT: LEAK
+
+// Failing negative test with HIP. Temporarily disabled for CUDA.
+// XFAIL: hip, cuda
+
+#define GRAPH_E2E_EXPLICIT
+
+#include "../Inputs/work_group_size_prop.cpp"

--- a/sycl/test-e2e/Graph/Inputs/sub_group_prop.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_group_prop.cpp
@@ -1,0 +1,155 @@
+// This test is adapted from "test-e2e/Basic/sub_group_size_prop.cpp"
+
+#include "../graph_common.hpp"
+
+enum class Variant { Function, Functor, FunctorAndProperty };
+
+template <Variant KernelVariant, size_t SGSize> class SubGroupKernel;
+
+template <size_t SGSize> struct KernelFunctorWithSGSizeProp {
+  accessor<size_t, 1, access_mode::write> Acc;
+
+  KernelFunctorWithSGSizeProp(accessor<size_t, 1, access_mode::write> Acc)
+      : Acc(Acc) {}
+
+  void operator()(nd_item<1> NdItem) const {
+    auto SG = NdItem.get_sub_group();
+    if (NdItem.get_global_linear_id() == 0)
+      Acc[0] = SG.get_local_linear_range();
+  }
+
+  auto get(sycl::ext::oneapi::experimental::properties_tag) {
+    return sycl::ext::oneapi::experimental::properties{
+        sycl::ext::oneapi::experimental::sub_group_size<SGSize>};
+  }
+};
+
+template <size_t SGSize>
+void test(queue &Queue, const std::vector<size_t> SupportedSGSizes) {
+  std::cout << "Testing sub_group_size property for sub-group size=" << SGSize
+            << std::endl;
+
+  auto SGSizeSupported =
+      std::find(SupportedSGSizes.begin(), SupportedSGSizes.end(), SGSize) !=
+      SupportedSGSizes.end();
+  if (!SGSizeSupported) {
+    std::cout << "Sub-group size " << SGSize
+              << " is not supported on the device." << std::endl;
+    return;
+  }
+
+  auto Props = ext::oneapi::experimental::properties{
+      ext::oneapi::experimental::sub_group_size<SGSize>};
+
+  nd_range<1> NdRange(SGSize * 4, SGSize * 2);
+
+  size_t ReadSubGroupSize = 0;
+  {
+    buffer ReadSubGroupSizeBuf(&ReadSubGroupSize, range(1));
+    ReadSubGroupSizeBuf.set_write_back(false);
+
+    {
+      exp_ext::command_graph Graph{
+          Queue.get_context(),
+          Queue.get_device(),
+          {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+      add_node(Graph, Queue, [&](handler &CGH) {
+        accessor ReadSubGroupSizeBufAcc{ReadSubGroupSizeBuf, CGH,
+                                        sycl::write_only, sycl::no_init};
+
+        CGH.parallel_for<SubGroupKernel<Variant::Function, SGSize>>(
+            NdRange, Props, [=](nd_item<1> NdItem) {
+              auto SG = NdItem.get_sub_group();
+              if (NdItem.get_global_linear_id() == 0)
+                ReadSubGroupSizeBufAcc[0] = SG.get_local_linear_range();
+            });
+      });
+
+      auto ExecGraph = Graph.finalize();
+      Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+      Queue.wait_and_throw();
+    }
+
+    host_accessor HostAcc(ReadSubGroupSizeBuf);
+    ReadSubGroupSize = HostAcc[0];
+  }
+  assert(ReadSubGroupSize == SGSize && "Failed check for function.");
+
+  ReadSubGroupSize = 0;
+  {
+    buffer ReadSubGroupSizeBuf(&ReadSubGroupSize, range(1));
+    ReadSubGroupSizeBuf.set_write_back(false);
+
+    {
+      exp_ext::command_graph Graph{
+          Queue.get_context(),
+          Queue.get_device(),
+          {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+      add_node(Graph, Queue, [&](handler &CGH) {
+        accessor ReadSubGroupSizeBufAcc{ReadSubGroupSizeBuf, CGH,
+                                        sycl::write_only, sycl::no_init};
+        KernelFunctorWithSGSizeProp<SGSize> KernelFunctor{
+            ReadSubGroupSizeBufAcc};
+
+        CGH.parallel_for<SubGroupKernel<Variant::Functor, SGSize>>(
+            NdRange, KernelFunctor);
+      });
+
+      auto ExecGraph = Graph.finalize();
+      Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+      Queue.wait_and_throw();
+    }
+
+    host_accessor HostAcc(ReadSubGroupSizeBuf);
+    ReadSubGroupSize = HostAcc[0];
+  }
+  assert(ReadSubGroupSize == SGSize && "Failed check for functor.");
+
+  ReadSubGroupSize = 0;
+  {
+    buffer ReadSubGroupSizeBuf(&ReadSubGroupSize, range(1));
+    ReadSubGroupSizeBuf.set_write_back(false);
+
+    {
+      exp_ext::command_graph Graph{
+          Queue.get_context(),
+          Queue.get_device(),
+          {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+      add_node(Graph, Queue, [&](handler &CGH) {
+        accessor ReadSubGroupSizeBufAcc{ReadSubGroupSizeBuf, CGH,
+                                        sycl::write_only, sycl::no_init};
+        KernelFunctorWithSGSizeProp<SGSize> KernelFunctor{
+            ReadSubGroupSizeBufAcc};
+
+        CGH.parallel_for<SubGroupKernel<Variant::Functor, SGSize>>(
+            NdRange, Props, KernelFunctor);
+      });
+
+      auto ExecGraph = Graph.finalize();
+      Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+      Queue.wait_and_throw();
+    }
+
+    host_accessor HostAcc(ReadSubGroupSizeBuf);
+    ReadSubGroupSize = HostAcc[0];
+  }
+  assert(ReadSubGroupSize == SGSize &&
+         "Failed check for functor and properties.");
+}
+
+int main() {
+  queue Queue({sycl::ext::intel::property::queue::no_immediate_command_list{}});
+  std::vector<size_t> SupportedSGSizes =
+      Queue.get_device().get_info<info::device::sub_group_sizes>();
+
+  test<1>(Queue, SupportedSGSizes);
+  test<8>(Queue, SupportedSGSizes);
+  test<16>(Queue, SupportedSGSizes);
+  test<32>(Queue, SupportedSGSizes);
+  test<64>(Queue, SupportedSGSizes);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Inputs/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/Inputs/work_group_size_prop.cpp
@@ -1,0 +1,209 @@
+// This test is adapted from "test-e2e/Basic/work_group_size_prop.cpp"
+
+#include "../graph_common.hpp"
+
+enum class Variant { Function, Functor, FunctorAndProperty };
+
+template <Variant KernelVariant, bool IsShortcut, size_t... Is>
+class ReqdWGSizePositiveA;
+template <Variant KernelVariant, bool IsShortcut, size_t... Is>
+class ReqdWGSizeNoLocalPositive;
+template <Variant KernelVariant, bool IsShortcut, size_t... Is>
+class ReqdWGSizeNegativeA;
+
+template <size_t Dims> range<Dims> repeatRange(size_t Val);
+template <> range<1> repeatRange<1>(size_t Val) { return range<1>{Val}; }
+template <> range<2> repeatRange<2>(size_t Val) { return range<2>{Val, Val}; }
+template <> range<3> repeatRange<3>(size_t Val) {
+  return range<3>{Val, Val, Val};
+}
+
+std::string rangeToString(range<1> Range) {
+  return "{1, 1, " + std::to_string(Range[0]) + "}";
+}
+std::string rangeToString(range<2> Range) {
+  return "{1, " + std::to_string(Range[0]) + ", " + std::to_string(Range[1]) +
+         "}";
+}
+std::string rangeToString(range<3> Range) {
+  return "{" + std::to_string(Range[0]) + ", " + std::to_string(Range[1]) +
+         ", " + std::to_string(Range[2]) + "}";
+}
+
+template <size_t... Is> struct KernelFunctorWithWGSizeProp {
+  void operator()(nd_item<sizeof...(Is)>) const {}
+  void operator()(item<sizeof...(Is)>) const {}
+
+  auto get(sycl::ext::oneapi::experimental::properties_tag) {
+    return sycl::ext::oneapi::experimental::properties{
+        sycl::ext::oneapi::experimental::work_group_size<Is...>};
+  }
+};
+
+template <Variant KernelVariant, size_t... Is, typename PropertiesT,
+          typename KernelType>
+int test(queue &Queue, PropertiesT Props, KernelType KernelFunc) {
+  constexpr size_t Dims = sizeof...(Is);
+
+  // Positive test case: Specify local size that matches required size.
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
+
+  try {
+
+    add_node(Graph, Queue, [&](handler &CGH) {
+      CGH.parallel_for<ReqdWGSizePositiveA<KernelVariant, false, Is...>>(
+          nd_range<Dims>(repeatRange<Dims>(8), range<Dims>(Is...)), Props,
+          KernelFunc);
+    });
+
+#ifdef GRAPH_E2E_RECORD_REPLAY
+    Graph.begin_recording(Queue);
+    Queue.parallel_for<ReqdWGSizePositiveA<KernelVariant, true, Is...>>(
+        nd_range<Dims>(repeatRange<Dims>(8), range<Dims>(Is...)), Props,
+        KernelFunc);
+    Graph.end_recording(Queue);
+#endif
+
+    auto ExecGraph = Graph.finalize();
+
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+    Queue.wait_and_throw();
+  } catch (nd_range_error &E) {
+    std::cerr << "Test case failed: unexpected "
+                 "nd_range_error exception: "
+              << E.what() << std::endl;
+    return 1;
+  } catch (runtime_error &E) {
+    std::cerr << "Test case failed: unexpected "
+                 "runtime_error exception: "
+              << E.what() << std::endl;
+    return 1;
+  } catch (...) {
+    std::cerr << "Test case failed: something unexpected "
+                 "has been caught"
+              << std::endl;
+    return 1;
+  }
+
+  return 0;
+
+  // Negative test case: Specify local size that does not match required size.
+  exp_ext::command_graph GraphN{Queue.get_context(), Queue.get_device()};
+  try {
+    add_node(GraphN, Queue, [&](handler &CGH) {
+      CGH.parallel_for<ReqdWGSizeNegativeA<KernelVariant, false, Is...>>(
+          nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)), Props,
+          KernelFunc);
+    });
+    auto ExecGraph = GraphN.finalize();
+
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+    Queue.wait_and_throw();
+
+    std::cerr << "Test case ReqdWGSizeNegativeA failed: no exception has been "
+                 "thrown\n";
+    return 1; // We shouldn't be here, exception is expected
+  } catch (nd_range_error &E) {
+    if (std::string(E.what()).find(
+            "The specified local size " + rangeToString(repeatRange<Dims>(8)) +
+            " doesn't match the required " +
+            "work-group size specified in the program source " +
+            rangeToString(range<Dims>(Is...))) == std::string::npos) {
+      std::cerr
+          << "Test case ReqdWGSizeNegativeA failed: unexpected nd_range_error "
+             "exception: "
+          << E.what() << std::endl;
+      return 1;
+    }
+  } catch (runtime_error &E) {
+    std::cerr << "Test case ReqdWGSizeNegativeA failed: unexpected "
+                 "nd_range_error exception: "
+              << E.what() << std::endl;
+    return 1;
+  } catch (...) {
+    std::cerr << "Test case ReqdWGSizeNegativeA failed: something unexpected "
+                 "has been caught"
+              << std::endl;
+    return 1;
+  }
+
+#ifdef GRAPH_E2E_RECORD_REPLAY
+  // Same as above but using the queue shortcuts.
+  try {
+    GraphN.begin_recording(Queue);
+
+    Queue.parallel_for<ReqdWGSizeNegativeA<KernelVariant, true, Is...>>(
+        nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)), Props,
+        KernelFunc);
+
+    GraphN.end_recording(Queue);
+    auto ExecGraph = GraphN.finalize();
+
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+    Queue.wait_and_throw();
+
+    std::cerr << "Test case ReqdWGSizeNegativeA shortcut failed: no exception "
+                 "has been "
+                 "thrown\n";
+    return 1; // We shouldn't be here, exception is expected
+  } catch (nd_range_error &E) {
+    if (std::string(E.what()).find(
+            "The specified local size " + rangeToString(repeatRange<Dims>(8)) +
+            " doesn't match the required " +
+            "work-group size specified in the program source " +
+            rangeToString(range<Dims>(Is...))) == std::string::npos) {
+      std::cerr << "Test case ReqdWGSizeNegativeA shortcut failed: unexpected "
+                   "nd_range_error "
+                   "exception: "
+                << E.what() << std::endl;
+      return 1;
+    }
+  } catch (runtime_error &E) {
+    std::cerr << "Test case ReqdWGSizeNegativeA shortcut failed: unexpected "
+                 "nd_range_error exception: "
+              << E.what() << std::endl;
+    return 1;
+  } catch (...) {
+    std::cerr << "Test case ReqdWGSizeNegativeA shortcut failed: something "
+                 "unexpected has been caught"
+              << std::endl;
+    return 1;
+  }
+#endif
+
+  return 0;
+}
+
+template <size_t... Is> int test(queue &Queue) {
+  auto Props = sycl::ext::oneapi::experimental::properties{
+      sycl::ext::oneapi::experimental::work_group_size<Is...>};
+  auto KernelFunction = [](auto) {};
+
+  auto EmptyProps = sycl::ext::oneapi::experimental::properties{};
+  KernelFunctorWithWGSizeProp<Is...> KernelFunctor;
+
+  int Res = 0;
+  Res += test<Variant::Function, Is...>(Queue, Props, KernelFunction);
+  Res += test<Variant::Functor, Is...>(Queue, EmptyProps, KernelFunctor);
+  Res += test<Variant::FunctorAndProperty, Is...>(Queue, Props, KernelFunctor);
+  return Res;
+}
+
+int main() {
+  queue Queue({sycl::ext::intel::property::queue::no_immediate_command_list{}});
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
+  int Res = 0;
+  Res += test<4>(Queue);
+  Res += test<4, 4>(Queue);
+  Res += test<8, 4>(Queue);
+  Res += test<4, 8>(Queue);
+  Res += test<4, 4, 4>(Queue);
+  Res += test<4, 4, 8>(Queue);
+  Res += test<8, 4, 4>(Queue);
+  Res += test<4, 8, 4>(Queue);
+  return Res;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/sub_group_prop.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_group_prop.cpp
@@ -1,0 +1,10 @@
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if ext_oneapi_level_zero %{env UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// CHECK-NOT: LEAK
+
+#define GRAPH_E2E_RECORD_REPLAY
+
+#include "../Inputs/sub_group_prop.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
@@ -1,0 +1,13 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if ext_oneapi_level_zero %{env UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// CHECK-NOT: LEAK
+
+// Failing negative test with HIP. Temporarily disabled for CUDA.
+// XFAIL: hip, cuda
+
+#define GRAPH_E2E_RECORD_REPLAY
+
+#include "../Inputs/work_group_size_prop.cpp"


### PR DESCRIPTION
Allows the use of sycl_ext_oneapi_kernel_properties extension in Sycl-Graph.
Kernel properties passed to the backend using the sycl kernel object.
Therefore, the graph implementation does not prevent the backend from accessing these properties. 
Removes exception throwing.
Adds tests.