### PR TITLE
[SYCL][Graph] Enable L0 optimizations (no profiling mode)

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -342,10 +342,6 @@ class assume_buffer_outlives_graph {
     assume_buffer_outlives_graph() = default;
 };
 
-class enable_profiling {
-  public:
-    enable_profiling() = default;
-};
 } // namespace graph
 
 namespace node {
@@ -359,6 +355,11 @@ class depends_on {
 class depends_on_all_leaves {
   public:
     depends_on_all_leaves() = default;
+};
+
+class enable_profiling {
+  public:
+    enable_profiling() = default;
 };
 
 } // namespace node
@@ -585,6 +586,31 @@ class depends_on_all_leaves {
 }
 ----
 
+===== Enable-Profiling Property [[enable-profiling]]
+
+The `property::graph::enable_profiling` property can be passed to a
+`command_graph::add()` function and enables profiling support 
+for the node in the `command_graph<graph_state::executable>`.
+Passing this property implies disabling certain optimizations.
+This is why profiling is by default disabled on graphs, unless users
+explicitly require it using either the `property::graph::enable_profiling` 
+property in building mode or the `property::queue::enable_profiling` on 
+the recorded queue (Record&Replay API).
+As a result, the execution time of a graph finalized with profiling enabled 
+is longer than that of a graph without profiling capability.
+An error will be thrown when attempting to profile an event 
+from a graph submission that was created without this property.
+
+[source,c++]
+----
+namespace sycl::ext::oneapi::experimental::property::node {
+class enable_profiling {
+  public:
+    enable_profiling() = default;
+};
+}
+----
+
 === Graph
 
 This extension adds a new `command_graph` object which follows the
@@ -650,18 +676,6 @@ parameter. This property represents a promise from the user that any buffer
 which is used in a graph will be kept alive on the host for the lifetime of the
 graph. Destroying that buffer during the lifetime of a `command_graph`
 constructed with this property results in undefined behavior.
-
-===== Enable-Profiling Property [[enable-profiling]]
-
-The `property::graph::enable_profiling` property can be passed to the 
-`command_graph::finalize()` function and enables profiling support 
-for the returned `command_graph<graph_state::executable>`.
-Passing this property to the finalize function implies disabling 
-certain optimizations to enable graph profiling.
-As a result, the execution time of a graph finalized with profiling enabled 
-is longer than that of a graph without profiling capability.
-An error will be thrown when attempting to profile an event 
-from a graph submission that was created without this property.
 
 ==== Graph Member Functions
 
@@ -761,6 +775,8 @@ Parameters:
 * `propList` - Zero or more properties can be provided to the constructed node
   via an instance of `property_list`. The `property::node::depends_on` property
   can be passed here with a list of nodes to create dependency edges on.
+  The `enable_profiling` property enables the profiling of this node. 
+  See <<enable-profiling, Enable-Profiling>> for more details.
 
 
 Returns: The empty node which has been added to the graph.
@@ -798,6 +814,9 @@ Parameters:
 * `propList` - Zero or more properties can be provided to the constructed node
   via an instance of `property_list`. The `property::node::depends_on` property
   can be passed here with a list of nodes to create dependency edges on.
+  The `enable_profiling` property enables the profiling of this node. 
+  See <<enable-profiling, Enable-Profiling>> for more details.
+
 
 Returns: The command-group function object node which has been added to the graph.
 
@@ -866,9 +885,8 @@ Preconditions:
 
 Parameters:
 
-* `propList` - Optional parameter for passing properties. The only defined 
-property is `enable_profiling`. See <<enable-profiling, Enable-Profiling>>
-for more details.
+* `propList` - Optional parameter for passing properties. No finalization
+  properties are defined by this extension.
 
 Returns: A new executable graph object which can be submitted to a queue.
 
@@ -1091,10 +1109,12 @@ ways:
    an implicit dependency before and after the graph execution, as if the graph
    execution is one command-group submitted to the in-order queue.
 
-2. `property::queue::enable_profiling` - This property has no effect on graph
-   recording. When set on the queue a graph is submitted to however, it allows
-   profiling information to be obtained from the event returned by a graph
-   submission. As it is not defined how a submitted graph will be split up for
+2. `property::queue::enable_profiling` - This property must be set on the queue
+   in recording mode if users want to profile the commands recorded to 
+   the graph.This property must also be set on the queue the queue a graph is 
+   submitted to. It allows profiling information to be obtained from the event 
+   returned by a graph submission. 
+   As it is not defined how a submitted graph will be split up for
    scheduling at runtime, the `uint64_t` timestamp reported from a profiling
    query on a graph execution event has the following semantics, which may be
    pessimistic about execution time on device.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -659,7 +659,7 @@ Passing this property to the finalize function implies disabling
 certain optimizations to enable graph profiling.
 As a result, the execution time of a graph finalized with profiling enabled 
 is longer than that of a graph without profiling capability.
-In this case, an error will be thrown when attempting to profiling an event 
+An error will be thrown when attempting to profile an event 
 from a graph submission that was created without this property.
 
 ==== Graph Member Functions

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -342,8 +342,9 @@ class assume_buffer_outlives_graph {
     assume_buffer_outlives_graph() = default;
 };
 
-public:
-  enable_profiling() = default;
+class enable_profiling {
+  public:
+    enable_profiling() = default;
 };
 } // namespace graph
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -652,9 +652,9 @@ constructed with this property results in undefined behavior.
 
 ===== Enable-Profiling Property [[enable-profiling]]
 
-The `property::graph::enable_profiling` property enable profiling
-the executable_graph.
-This property is passed to the `command_graph::finalize()` function.
+The `property::graph::enable_profiling` property can be passed to the 
+`command_graph::finalize()` function and enables profiling support 
+for the returned `command_graph<graph_state::executable>`.
 If this property is not passed to the finalize function, certain optimizations,
 which prevent graph profiling, may be applied to this executable graph.
 In this case, an error will be thrown when attempting to profiling an event from 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -659,6 +659,7 @@ If this property is not passed to the finalize function, certain optimizations,
 which prevent graph profiling, may be applied to this executable graph.
 In this case, an error will be thrown when attempting to profiling an event from 
 a graph submission that was created without this property.
+Note that this limitation currently only applies to the zero-level backend. 
 
 ==== Graph Member Functions
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -342,9 +342,8 @@ class assume_buffer_outlives_graph {
     assume_buffer_outlives_graph() = default;
 };
 
-class disable_in_order_optimization {
 public:
-  disable_in_order_optimization() = default;
+  enable_profiling() = default;
 };
 } // namespace graph
 
@@ -651,14 +650,15 @@ which is used in a graph will be kept alive on the host for the lifetime of the
 graph. Destroying that buffer during the lifetime of a `command_graph`
 constructed with this property results in undefined behavior.
 
-===== Disable-In-Order-Optimization Property [[disable-in-order-optimization]]
+===== Enable-Profiling Property [[enable-profiling]]
 
-The `property::graph::disable_in_order_optimization` property disables 
-an optimization which can be applied to in-order graph to 
-reduce its execution time.
+The `property::graph::enable_profiling` property enable profiling
+the executable_graph.
 This property is passed to the `command_graph::finalize()` function.
-Note that this property must be passed to the finalize function if users 
-want to profile the exec_graph execution.
+If this property is not passed to the finalize function, certain optimizations,
+which prevent graph profiling, may be applied to this executable graph.
+In this case, an error will be thrown when attempting to profiling an event from 
+a graph submission that was created without this property.
 
 ==== Graph Member Functions
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -655,11 +655,12 @@ constructed with this property results in undefined behavior.
 The `property::graph::enable_profiling` property can be passed to the 
 `command_graph::finalize()` function and enables profiling support 
 for the returned `command_graph<graph_state::executable>`.
-If this property is not passed to the finalize function, certain optimizations,
-which prevent graph profiling, may be applied to this executable graph.
-In this case, an error will be thrown when attempting to profiling an event from 
-a graph submission that was created without this property.
-Note that this limitation currently only applies to the zero-level backend. 
+Passing this property to the finalize function implies disabling 
+certain optimizations to enable graph profiling.
+As a result, the execution time of a graph finalized with profiling enabled 
+is longer than that of a graph without profiling capability.
+In this case, an error will be thrown when attempting to profiling an event 
+from a graph submission that was created without this property.
 
 ==== Graph Member Functions
 
@@ -865,7 +866,7 @@ Preconditions:
 Parameters:
 
 * `propList` - Optional parameter for passing properties. The only defined 
-property is `disable_in_order_optimization`. See <<disable_in_order_optimization, Disable-In-Order-Optimization>>
+property is `enable_profiling`. See <<enable-profiling, Enable-Profiling>>
 for more details.
 
 Returns: A new executable graph object which can be submitted to a queue.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -341,6 +341,11 @@ class assume_buffer_outlives_graph {
   public:
     assume_buffer_outlives_graph() = default;
 };
+
+class disable_in_order_optimization {
+public:
+  disable_in_order_optimization() = default;
+};
 } // namespace graph
 
 namespace node {
@@ -646,6 +651,15 @@ which is used in a graph will be kept alive on the host for the lifetime of the
 graph. Destroying that buffer during the lifetime of a `command_graph`
 constructed with this property results in undefined behavior.
 
+===== Disable-In-Order-Optimization Property [[disable-in-order-optimization]]
+
+The `property::graph::disable_in_order_optimization` property disables 
+an optimization which can be applied to in-order graph to 
+reduce its execution time.
+This property is passed to the `command_graph::finalize()` function.
+Note that this property must be passed to the finalize function if users 
+want to profile the exec_graph execution.
+
 ==== Graph Member Functions
 
 Table {counter: tableNumber}. Constructor of the `command_graph` class.
@@ -849,8 +863,9 @@ Preconditions:
 
 Parameters:
 
-* `propList` - Optional parameter for passing properties. No finalization
-  properties are defined by this extension.
+* `propList` - Optional parameter for passing properties. The only defined 
+property is `disable_in_order_optimization`. See <<disable_in_order_optimization, Disable-In-Order-Optimization>>
+for more details.
 
 Returns: A new executable graph object which can be submitted to a queue.
 

--- a/sycl/include/sycl/detail/pi.h
+++ b/sycl/include/sycl/detail/pi.h
@@ -2304,7 +2304,7 @@ typedef enum {
 struct pi_ext_command_buffer_desc final {
   pi_ext_structure_type stype;
   const void *pNext;
-  pi_queue_properties *properties;
+  pi_bool is_in_order;
 };
 
 /// API to create a command-buffer.

--- a/sycl/include/sycl/detail/pi.h
+++ b/sycl/include/sycl/detail/pi.h
@@ -2305,6 +2305,7 @@ struct pi_ext_command_buffer_desc final {
   pi_ext_structure_type stype;
   const void *pNext;
   pi_bool is_in_order;
+  pi_bool enable_profiling;
 };
 
 /// API to create a command-buffer.

--- a/sycl/include/sycl/detail/property_helper.hpp
+++ b/sycl/include/sycl/detail/property_helper.hpp
@@ -47,7 +47,7 @@ enum DataLessPropKind {
   GraphAssumeDataOutlivesBuffer = 22,
   GraphAssumeBufferOutlivesGraph = 23,
   GraphDependOnAllLeaves = 24,
-  DisableInOrderOptimization = 25,
+  GraphEnableProfiling = 25,
   // Indicates the last known dataless property.
   LastKnownDataLessPropKind = 25,
   // Exceeding 32 may cause ABI breaking change on some of OSes.

--- a/sycl/include/sycl/detail/property_helper.hpp
+++ b/sycl/include/sycl/detail/property_helper.hpp
@@ -47,8 +47,9 @@ enum DataLessPropKind {
   GraphAssumeDataOutlivesBuffer = 22,
   GraphAssumeBufferOutlivesGraph = 23,
   GraphDependOnAllLeaves = 24,
+  DisableInOrderOptimization = 25,
   // Indicates the last known dataless property.
-  LastKnownDataLessPropKind = 24,
+  LastKnownDataLessPropKind = 25,
   // Exceeding 32 may cause ABI breaking change on some of OSes.
   DataLessPropKindSize = 32
 };

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -146,15 +146,6 @@ class assume_buffer_outlives_graph
 public:
   assume_buffer_outlives_graph() = default;
 };
-
-/// Property used to enable graph profiling.
-/// Passing this property to the `command_graph::finalize()` function
-/// ensures that profiling can be used on the generated graph.
-class enable_profiling : public ::sycl::detail::DataLessProperty<
-                             ::sycl::detail::GraphEnableProfiling> {
-public:
-  enable_profiling() = default;
-};
 } // namespace graph
 
 namespace node {
@@ -183,6 +174,15 @@ public:
   depends_on_all_leaves() = default;
 };
 
+/// Property used to enable node profiling.
+/// Passing this property to the `command_graph::add()` function
+/// ensures that profiling can be queried on this node.
+class enable_profiling : public ::sycl::detail::DataLessProperty<
+                             ::sycl::detail::GraphEnableProfiling> {
+public:
+  enable_profiling() = default;
+};
+
 } // namespace node
 } // namespace property
 
@@ -209,15 +209,17 @@ public:
   /// @param PropList Property list used to pass [0..n] predecessor nodes.
   /// @return Constructed empty node which has been added to the graph.
   node add(const property_list &PropList = {}) {
+    bool EnableProfiling =
+        PropList.has_property<property::node::enable_profiling>();
     if (PropList.has_property<property::node::depends_on>()) {
       auto Deps = PropList.get_property<property::node::depends_on>();
-      node Node = addImpl(Deps.get_dependencies());
+      node Node = addImpl(Deps.get_dependencies(), EnableProfiling);
       if (PropList.has_property<property::node::depends_on_all_leaves>()) {
         addGraphLeafDependencies(Node);
       }
       return Node;
     }
-    node Node = addImpl({});
+    node Node = addImpl({}, EnableProfiling);
     if (PropList.has_property<property::node::depends_on_all_leaves>()) {
       addGraphLeafDependencies(Node);
     }
@@ -229,15 +231,17 @@ public:
   /// @param PropList Property list used to pass [0..n] predecessor nodes.
   /// @return Constructed node which has been added to the graph.
   template <typename T> node add(T CGF, const property_list &PropList = {}) {
+    bool EnableProfiling =
+        PropList.has_property<property::node::enable_profiling>();
     if (PropList.has_property<property::node::depends_on>()) {
       auto Deps = PropList.get_property<property::node::depends_on>();
-      node Node = addImpl(CGF, Deps.get_dependencies());
+      node Node = addImpl(CGF, Deps.get_dependencies(), EnableProfiling);
       if (PropList.has_property<property::node::depends_on_all_leaves>()) {
         addGraphLeafDependencies(Node);
       }
       return Node;
     }
-    node Node = addImpl(CGF, {});
+    node Node = addImpl(CGF, {}, EnableProfiling);
     if (PropList.has_property<property::node::depends_on_all_leaves>()) {
       addGraphLeafDependencies(Node);
     }
@@ -312,14 +316,16 @@ protected:
   /// Template-less implementation of add() for CGF nodes.
   /// @param CGF Command-group function to add.
   /// @param Dep List of predecessor nodes.
+  /// @param EnableProfiling Enable node profiling.
   /// @return Node added to the graph.
-  node addImpl(std::function<void(handler &)> CGF,
-               const std::vector<node> &Dep);
+  node addImpl(std::function<void(handler &)> CGF, const std::vector<node> &Dep,
+               const bool EnableProfiling);
 
   /// Template-less implementation of add() for empty nodes.
   /// @param Dep List of predecessor nodes.
+  /// @param EnableProfiling Enable node profiling.
   /// @return Node added to the graph.
-  node addImpl(const std::vector<node> &Dep);
+  node addImpl(const std::vector<node> &Dep, const bool EnableProfiling);
 
   /// Adds all graph leaves as dependencies
   /// @param Node Destination node to which the leaves of the graph will be
@@ -352,8 +358,7 @@ protected:
   /// @param PropList Optional list of properties to pass.
   executable_command_graph(const std::shared_ptr<detail::graph_impl> &Graph,
                            const sycl::context &Ctx,
-			   const property_list &PropList = {});
-
+                           const property_list &PropList = {});
 
   template <class Obj>
   friend decltype(Obj::impl)

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -147,8 +147,9 @@ public:
   assume_buffer_outlives_graph() = default;
 };
 
-/// Property used to to add all previous graph leaves as dependencies when
-/// creating a new node with command_graph::add().
+/// Property used to enable graph profiling.
+/// Passing this property to the `command_graph::finalize()` function
+/// ensures that profiling can be used on the generated graph.
 class enable_profiling : public ::sycl::detail::DataLessProperty<
                              ::sycl::detail::GraphEnableProfiling> {
 public:

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -146,6 +146,15 @@ class assume_buffer_outlives_graph
 public:
   assume_buffer_outlives_graph() = default;
 };
+
+/// Property used to to add all previous graph leaves as dependencies when
+/// creating a new node with command_graph::add().
+class disable_in_order_optimization
+    : public ::sycl::detail::DataLessProperty<
+          ::sycl::detail::DisableInOrderOptimization> {
+public:
+  disable_in_order_optimization() = default;
+};
 } // namespace graph
 
 namespace node {
@@ -340,8 +349,10 @@ protected:
   /// Constructor used by internal runtime.
   /// @param Graph Detail implementation class to construct with.
   /// @param Ctx Context to use for graph.
+  /// @param DisableInOrderOptimization Disable the In Order graph opimization
   executable_command_graph(const std::shared_ptr<detail::graph_impl> &Graph,
-                           const sycl::context &Ctx);
+                           const sycl::context &Ctx,
+                           const bool DisableInOrderOptimization = false);
 
   template <class Obj>
   friend decltype(Obj::impl)

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -149,11 +149,10 @@ public:
 
 /// Property used to to add all previous graph leaves as dependencies when
 /// creating a new node with command_graph::add().
-class disable_in_order_optimization
-    : public ::sycl::detail::DataLessProperty<
-          ::sycl::detail::DisableInOrderOptimization> {
+class enable_profiling : public ::sycl::detail::DataLessProperty<
+                             ::sycl::detail::GraphEnableProfiling> {
 public:
-  disable_in_order_optimization() = default;
+  enable_profiling() = default;
 };
 } // namespace graph
 
@@ -349,10 +348,10 @@ protected:
   /// Constructor used by internal runtime.
   /// @param Graph Detail implementation class to construct with.
   /// @param Ctx Context to use for graph.
-  /// @param DisableInOrderOptimization Disable the In Order graph opimization
+  /// @param EnableProfiling Enable graph profiling.
   executable_command_graph(const std::shared_ptr<detail::graph_impl> &Graph,
                            const sycl::context &Ctx,
-                           const bool DisableInOrderOptimization = false);
+                           const bool EnableProfiling = false);
 
   template <class Obj>
   friend decltype(Obj::impl)

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -349,10 +349,11 @@ protected:
   /// Constructor used by internal runtime.
   /// @param Graph Detail implementation class to construct with.
   /// @param Ctx Context to use for graph.
-  /// @param EnableProfiling Enable graph profiling.
+  /// @param PropList Optional list of properties to pass.
   executable_command_graph(const std::shared_ptr<detail::graph_impl> &Graph,
                            const sycl::context &Ctx,
-                           const bool EnableProfiling = false);
+			   const property_list &PropList = {});
+
 
   template <class Obj>
   friend decltype(Obj::impl)

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -56,14 +56,9 @@ endif()
 if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 3487672ceba0fd3575b5f3f15a832b100dc5fbad
-  # Author: Artur Gainullin <artur.gainullin@intel.com>
-  # Date:   Fri Feb 16 09:59:50 2024 -0800
-  #
-  #     [UR] Provide flexibility to replace unified-memory-framework repo and tag
-  set(UNIFIED_RUNTIME_TAG 3487672ceba0fd3575b5f3f15a832b100dc5fbad)
-
+  set(UNIFIED_RUNTIME_REPO "https://github.com/bensuo/unified-runtime.git")
+  set(UNIFIED_RUNTIME_TAG maxime/in-order-cmd-list)
+  
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")
   endif()

--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -4425,13 +4425,14 @@ piextCommandBufferCreate(pi_context Context, pi_device Device,
   ur_context_handle_t UrContext =
       reinterpret_cast<ur_context_handle_t>(Context);
   ur_device_handle_t UrDevice = reinterpret_cast<ur_device_handle_t>(Device);
-  const ur_exp_command_buffer_desc_t *UrDesc =
-      reinterpret_cast<const ur_exp_command_buffer_desc_t *>(Desc);
+  ur_exp_command_buffer_desc_t UrDesc;
+  UrDesc.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;
+  UrDesc.isInOrder = Desc->is_in_order;
   ur_exp_command_buffer_handle_t *UrCommandBuffer =
       reinterpret_cast<ur_exp_command_buffer_handle_t *>(RetCommandBuffer);
 
   HANDLE_ERRORS(
-      urCommandBufferCreateExp(UrContext, UrDevice, UrDesc, UrCommandBuffer));
+      urCommandBufferCreateExp(UrContext, UrDevice, &UrDesc, UrCommandBuffer));
 
   return PI_SUCCESS;
 }

--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -4428,6 +4428,7 @@ piextCommandBufferCreate(pi_context Context, pi_device Device,
   ur_exp_command_buffer_desc_t UrDesc;
   UrDesc.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;
   UrDesc.isInOrder = Desc->is_in_order;
+  UrDesc.enableProfiling = Desc->enable_profiling;
   ur_exp_command_buffer_handle_t *UrCommandBuffer =
       reinterpret_cast<ur_exp_command_buffer_handle_t *>(RetCommandBuffer);
 

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -290,6 +290,8 @@ public:
     return MEventFromSubmittedExecCommandBuffer;
   }
 
+  void setProfilingEnabled(bool Value) { MIsProfilingEnabled = Value; }
+
 protected:
   // When instrumentation is enabled emits trace event for event wait begin and
   // returns the telemetry event generated for the wait
@@ -313,7 +315,7 @@ protected:
   std::unique_ptr<HostProfilingInfo> MHostProfilingInfo;
   void *MCommand = nullptr;
   std::weak_ptr<queue_impl> MQueue;
-  const bool MIsProfilingEnabled = false;
+  bool MIsProfilingEnabled = false;
   const bool MFallbackProfiling = false;
 
   std::weak_ptr<queue_impl> MWorkerQueue;

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -683,7 +683,8 @@ void exec_graph_impl::createCommandBuffers(
   sycl::detail::pi::PiExtCommandBuffer OutCommandBuffer;
   sycl::detail::pi::PiExtCommandBufferDesc Desc{
       pi_ext_structure_type::PI_EXT_STRUCTURE_TYPE_COMMAND_BUFFER_DESC, nullptr,
-      pi_bool(Partition->MIsInOrderGraph & UseInOrderCommandList)};
+      pi_bool(Partition->MIsInOrderGraph & MUseInOrderCommandList),
+      pi_bool(MEnableProfiling)};
   auto ContextImpl = sycl::detail::getSyclObjImpl(MContext);
   const sycl::detail::PluginPtr &Plugin = ContextImpl->getPlugin();
   auto DeviceImpl = sycl::detail::getSyclObjImpl(Device);

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -683,7 +683,7 @@ void exec_graph_impl::createCommandBuffers(
   sycl::detail::pi::PiExtCommandBuffer OutCommandBuffer;
   sycl::detail::pi::PiExtCommandBufferDesc Desc{
       pi_ext_structure_type::PI_EXT_STRUCTURE_TYPE_COMMAND_BUFFER_DESC, nullptr,
-      pi_bool(Partition->MIsInOrderGraph & MUseInOrderCommandList),
+      pi_bool(Partition->MIsInOrderGraph & !MEnableProfiling),
       pi_bool(MEnableProfiling)};
   auto ContextImpl = sycl::detail::getSyclObjImpl(MContext);
   const sycl::detail::PluginPtr &Plugin = ContextImpl->getPlugin();
@@ -945,6 +945,9 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
     if (Elem.second != NewEvent) {
       NewEvent->attachEventToComplete(Elem.second);
     }
+  }
+  if (!MEnableProfiling) {
+    NewEvent->setProfilingEnabled(false);
   }
   sycl::event QueueEvent =
       sycl::detail::createSyclObjFromImpl<sycl::event>(NewEvent);

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -94,6 +94,9 @@ public:
   /// Used for tracking visited status during cycle checks.
   bool MVisited = false;
 
+  /// If true, the graph profiling is enabled for this node.
+  bool MProfilingEnabled = false;
+
   /// Partition number needed to assign a Node to a a partition.
   /// Note : This number is only used during the partitionning process and
   /// cannot be used to find out the partion of a node outside of this process.
@@ -152,7 +155,8 @@ public:
   node_impl(node_impl &Other)
       : MSuccessors(Other.MSuccessors), MPredecessors(Other.MPredecessors),
         MCGType(Other.MCGType), MNodeType(Other.MNodeType),
-        MCommandGroup(Other.getCGCopy()), MSubGraphImpl(Other.MSubGraphImpl) {}
+        MCommandGroup(Other.getCGCopy()), MSubGraphImpl(Other.MSubGraphImpl),
+        MProfilingEnabled(Other.MProfilingEnabled) {}
 
   /// Checks if this node has a given requirement.
   /// @param Requirement Requirement to lookup.
@@ -540,6 +544,9 @@ private:
     default:
       Stream << "Other \\n";
       break;
+    }
+    if (MProfilingEnabled) {
+      Stream << "Profiling Enabled \\n";
     }
     Stream << "\"];" << std::endl;
   }
@@ -1066,9 +1073,7 @@ public:
                   const std::shared_ptr<graph_impl> &GraphImpl,
                   const property_list &PropList)
       : MSchedule(), MGraphImpl(GraphImpl), MPiSyncPoints(), MContext(Context),
-        MRequirements(), MExecutionEvents(),
-        MEnableProfiling(
-            PropList.has_property<property::graph::enable_profiling>()) {
+        MRequirements(), MExecutionEvents() {
     // Copy nodes from GraphImpl and merge any subgraph nodes into this graph.
     duplicateNodes();
   }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -568,8 +568,8 @@ public:
       MPiCommandBuffers;
   /// List of predecessors to this partition.
   std::vector<std::shared_ptr<partition>> MPredecessors;
-  /// True is the graph of this partition is a single path graph
-  /// and InOrder optmization can be applied on it.
+  /// True if the graph of this partition is a single path graph
+  /// and in-order optmization can be applied on it.
   bool MIsInOrderGraph = false;
 
   /// @return True if the partition contains a host task
@@ -1061,12 +1061,14 @@ public:
   /// nodes).
   /// @param Context Context to create graph with.
   /// @param GraphImpl Modifiable graph implementation to create with.
-  /// @param EnableProfiling Enable graph profiling.
+  /// @param PropList List of properties for constructing this object.
   exec_graph_impl(sycl::context Context,
                   const std::shared_ptr<graph_impl> &GraphImpl,
-                  const bool EnableProfiling = false)
+                  const property_list &PropList)
       : MSchedule(), MGraphImpl(GraphImpl), MPiSyncPoints(), MContext(Context),
-        MRequirements(), MExecutionEvents(), MEnableProfiling(EnableProfiling) {
+        MRequirements(), MExecutionEvents(),
+        MEnableProfiling(
+            PropList.has_property<property::graph::enable_profiling>()) {
     // Copy nodes from GraphImpl and merge any subgraph nodes into this graph.
     duplicateNodes();
   }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -333,7 +333,7 @@ public:
 
   /// Test is the node contains a N-D copy
   /// @return true is the op is a N-D copy
-  bool is2DCopyNode() {
+  bool is2DCopyNode() const {
     if ((MCGType == sycl::detail::CG::CGTYPE::CopyAccToAcc) ||
         (MCGType == sycl::detail::CG::CGTYPE::CopyAccToPtr) ||
         (MCGType == sycl::detail::CG::CGTYPE::CopyPtrToAcc)) {
@@ -588,7 +588,7 @@ public:
       MIsInOrderGraph = false;
       return;
     }
-    for (auto Node : MSchedule) {
+    for (const auto &Node : MSchedule) {
       // In version 1.3.28454 of the L0 driver, 2D Copy ops cannot not
       // be enqueued in an in-order cmd-list (causing execution to stall).
       // The 2D Copy test should be removed from here when the bug is fixed.
@@ -1063,14 +1063,13 @@ public:
   /// nodes).
   /// @param Context Context to create graph with.
   /// @param GraphImpl Modifiable graph implementation to create with.
-  /// @param DisableInOrderOptimization Disable the In Order Command-List
-  /// optimization
+  /// @param EnableProfiling Enable graph profiling.
   exec_graph_impl(sycl::context Context,
                   const std::shared_ptr<graph_impl> &GraphImpl,
-                  const bool DisableInOrderOptimization = false)
+                  const bool EnableProfiling = false)
       : MSchedule(), MGraphImpl(GraphImpl), MPiSyncPoints(), MContext(Context),
         MRequirements(), MExecutionEvents(),
-        UseInOrderCommandList(!DisableInOrderOptimization) {
+        UseInOrderCommandList(!EnableProfiling) {
     // Copy nodes from GraphImpl and merge any subgraph nodes into this graph.
     duplicateNodes();
   }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -1069,7 +1069,8 @@ public:
                   const bool EnableProfiling = false)
       : MSchedule(), MGraphImpl(GraphImpl), MPiSyncPoints(), MContext(Context),
         MRequirements(), MExecutionEvents(),
-        UseInOrderCommandList(!EnableProfiling) {
+        MUseInOrderCommandList(!EnableProfiling),
+        MEnableProfiling(EnableProfiling) {
     // Copy nodes from GraphImpl and merge any subgraph nodes into this graph.
     duplicateNodes();
   }
@@ -1241,7 +1242,9 @@ private:
   /// Storage for copies of nodes from the original modifiable graph.
   std::vector<std::shared_ptr<node_impl>> MNodeStorage;
   /// If true, the L0 backend In-order CommandList optimization is enabled.
-  bool UseInOrderCommandList = true;
+  bool MUseInOrderCommandList = true;
+  /// If true, the graph profiling is enabled.
+  bool MEnableProfiling = false;
 };
 
 } // namespace detail

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -1068,9 +1068,7 @@ public:
                   const std::shared_ptr<graph_impl> &GraphImpl,
                   const bool EnableProfiling = false)
       : MSchedule(), MGraphImpl(GraphImpl), MPiSyncPoints(), MContext(Context),
-        MRequirements(), MExecutionEvents(),
-        MUseInOrderCommandList(!EnableProfiling),
-        MEnableProfiling(EnableProfiling) {
+        MRequirements(), MExecutionEvents(), MEnableProfiling(EnableProfiling) {
     // Copy nodes from GraphImpl and merge any subgraph nodes into this graph.
     duplicateNodes();
   }
@@ -1241,8 +1239,6 @@ private:
       MPartitionsExecutionEvents;
   /// Storage for copies of nodes from the original modifiable graph.
   std::vector<std::shared_ptr<node_impl>> MNodeStorage;
-  /// If true, the L0 backend In-order CommandList optimization is enabled.
-  bool MUseInOrderCommandList = true;
   /// If true, the graph profiling is enabled.
   bool MEnableProfiling = false;
 };

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -331,9 +331,9 @@ public:
     }
   }
 
-  /// Test is the node contains a N-D copy
-  /// @return true is the op is a N-D copy
-  bool is2DCopyNode() const {
+  /// Test if the node contains a N-D copy
+  /// @return true if the op is a N-D copy
+  bool isNDCopyNode() const {
     if ((MCGType == sycl::detail::CG::CGTYPE::CopyAccToAcc) ||
         (MCGType == sycl::detail::CG::CGTYPE::CopyAccToPtr) ||
         (MCGType == sycl::detail::CG::CGTYPE::CopyPtrToAcc)) {
@@ -581,8 +581,6 @@ public:
   /// Checks if the graph is single path, i.e. each node has a single successor.
   /// If so, the MIsInOrderGraph flag is set.
   void checkIfGraphIsSinglePath() {
-    // Is the graph of this partition a single path graph?
-    // If so, we can optimize its execution using InOrder optimizations
     MIsInOrderGraph = true;
     if (MRoots.size() > 1) {
       MIsInOrderGraph = false;
@@ -592,7 +590,7 @@ public:
       // In version 1.3.28454 of the L0 driver, 2D Copy ops cannot not
       // be enqueued in an in-order cmd-list (causing execution to stall).
       // The 2D Copy test should be removed from here when the bug is fixed.
-      if ((Node->MSuccessors.size() > 1) || (Node->is2DCopyNode())) {
+      if ((Node->MSuccessors.size() > 1) || (Node->isNDCopyNode())) {
         MIsInOrderGraph = false;
         return;
       }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -543,7 +543,7 @@ event handler::finalize() {
     } else {
       NodeImpl = GraphImpl->add(NodeType, std::move(CommandGroup));
     }
-
+    NodeImpl->MProfilingEnabled = MQueue->MIsProfilingEnabled;
     // Associate an event with this new node and return the event.
     GraphImpl->addEventForNode(GraphImpl, EventImpl, NodeImpl);
 

--- a/sycl/test-e2e/Graph/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/event_profiling_info.cpp
@@ -81,6 +81,8 @@ bool compareProfiling(event Event1, event Event2) {
 // event to complete execution.
 int main() {
   device Dev;
+  // The queue on which the graph is recorded must have the `enable_profiling`
+  // set to enable graph profiling.
   queue Queue{Dev, {sycl::property::queue::enable_profiling()}};
 
   const size_t Size = 100000;
@@ -107,17 +109,16 @@ int main() {
         Queue.get_context(),
         Queue.get_device(),
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
-    CopyGraph.begin_recording(Queue);
 
-    Queue.submit([&](sycl::handler &Cgh) {
-      accessor<int, 1, access::mode::read, access::target::device> AccessorFrom(
-          BufferFrom, Cgh, range<1>(Size));
-      accessor<int, 1, access::mode::write, access::target::device> AccessorTo(
-          BufferTo, Cgh, range<1>(Size));
-      Cgh.copy(AccessorFrom, AccessorTo);
-    });
-
-    CopyGraph.end_recording(Queue);
+    CopyGraph.add(
+        ([&](sycl::handler &Cgh) {
+          accessor<int, 1, access::mode::read, access::target::device>
+              AccessorFrom(BufferFrom, Cgh, range<1>(Size));
+          accessor<int, 1, access::mode::write, access::target::device>
+              AccessorTo(BufferTo, Cgh, range<1>(Size));
+          Cgh.copy(AccessorFrom, AccessorTo);
+        }),
+        {exp_ext::property::node::enable_profiling{}});
 
     // kernel launch
     exp_ext::command_graph KernelGraph{
@@ -130,12 +131,8 @@ int main() {
 
     KernelGraph.end_recording(Queue);
 
-    // The `enable_profiling` property must be passed to the finalize function
-    // in order to query profiling information.
-    auto CopyGraphExec =
-        CopyGraph.finalize(exp_ext::property::graph::enable_profiling{});
-    auto KernelGraphExec =
-        KernelGraph.finalize(exp_ext::property::graph::enable_profiling{});
+    auto CopyGraphExec = CopyGraph.finalize();
+    auto KernelGraphExec = KernelGraph.finalize();
 
     event CopyEvent, KernelEvent1, KernelEvent2;
     // Run graphs

--- a/sycl/test-e2e/Graph/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/event_profiling_info.cpp
@@ -130,8 +130,12 @@ int main() {
 
     KernelGraph.end_recording(Queue);
 
-    auto CopyGraphExec = CopyGraph.finalize();
-    auto KernelGraphExec = KernelGraph.finalize();
+    // The profiling is not available with the In-Order optimization.
+    // We therefore disable this optimization.
+    auto CopyGraphExec = CopyGraph.finalize(
+        exp_ext::property::graph::disable_in_order_optimization{});
+    auto KernelGraphExec = KernelGraph.finalize(
+        exp_ext::property::graph::disable_in_order_optimization{});
 
     event CopyEvent, KernelEvent1, KernelEvent2;
     // Run graphs

--- a/sycl/test-e2e/Graph/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/event_profiling_info.cpp
@@ -130,8 +130,8 @@ int main() {
 
     KernelGraph.end_recording(Queue);
 
-    // The profiling is not available with the in-order optimization.
-    // We therefore disable this optimization.
+    // The `enable_profiling` property must be passed to the finalize function
+    // in order to query profiling information.
     auto CopyGraphExec =
         CopyGraph.finalize(exp_ext::property::graph::enable_profiling{});
     auto KernelGraphExec =

--- a/sycl/test-e2e/Graph/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/event_profiling_info.cpp
@@ -182,6 +182,25 @@ int main() {
     assert(verifyProfiling(CopyEvent) && verifyProfiling(KernelEvent1) &&
            verifyProfiling(KernelEvent2) &&
            compareProfiling(KernelEvent1, KernelEvent2));
+
+    // Checks exception thrown if profiling is requested while in-order
+    // optimization enabled. Note that in-order cmd-list optmization is only
+    // available for level-zero backend.
+    auto Backend = Dev.get_backend();
+    if (Backend == backend::ext_oneapi_level_zero) {
+      auto CopyGraphExecInOrder = CopyGraph.finalize();
+      auto EventInOrder = Queue.submit(
+          [&](handler &CGH) { CGH.ext_oneapi_graph(CopyGraphExecInOrder); });
+      Queue.wait_and_throw();
+      bool Success = false;
+      try {
+        EventInOrder
+            .get_profiling_info<sycl::info::event_profiling::command_start>();
+      } catch (sycl::exception &E) {
+        Success = true;
+      }
+      assert(Success);
+    }
   }
 
   host_accessor HostData(BufferTo);

--- a/sycl/test-e2e/Graph/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/event_profiling_info.cpp
@@ -182,21 +182,6 @@ int main() {
     assert(verifyProfiling(CopyEvent) && verifyProfiling(KernelEvent1) &&
            verifyProfiling(KernelEvent2) &&
            compareProfiling(KernelEvent1, KernelEvent2));
-
-    // Checks exception thrown if profiling is requested while the
-    // enable_profiling property has not been passed to `finalize()`.
-    auto CopyGraphExecInOrder = CopyGraph.finalize();
-    auto EventInOrder = Queue.submit(
-        [&](handler &CGH) { CGH.ext_oneapi_graph(CopyGraphExecInOrder); });
-    Queue.wait_and_throw();
-    bool Success = false;
-    try {
-      EventInOrder
-          .get_profiling_info<sycl::info::event_profiling::command_start>();
-    } catch (sycl::exception &E) {
-      Success = true;
-    }
-    assert(Success);
   }
 
   host_accessor HostData(BufferTo);

--- a/sycl/test-e2e/Graph/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/event_profiling_info.cpp
@@ -132,10 +132,10 @@ int main() {
 
     // The profiling is not available with the In-Order optimization.
     // We therefore disable this optimization.
-    auto CopyGraphExec = CopyGraph.finalize(
-        exp_ext::property::graph::disable_in_order_optimization{});
-    auto KernelGraphExec = KernelGraph.finalize(
-        exp_ext::property::graph::disable_in_order_optimization{});
+    auto CopyGraphExec =
+        CopyGraph.finalize(exp_ext::property::graph::enable_profiling{});
+    auto KernelGraphExec =
+        KernelGraph.finalize(exp_ext::property::graph::enable_profiling{});
 
     event CopyEvent, KernelEvent1, KernelEvent2;
     // Run graphs

--- a/sycl/test-e2e/Graph/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/event_profiling_info.cpp
@@ -183,24 +183,20 @@ int main() {
            verifyProfiling(KernelEvent2) &&
            compareProfiling(KernelEvent1, KernelEvent2));
 
-    // Checks exception thrown if profiling is requested while in-order
-    // optimization enabled. Note that in-order cmd-list optmization is only
-    // available for level-zero backend.
-    auto Backend = Dev.get_backend();
-    if (Backend == backend::ext_oneapi_level_zero) {
-      auto CopyGraphExecInOrder = CopyGraph.finalize();
-      auto EventInOrder = Queue.submit(
-          [&](handler &CGH) { CGH.ext_oneapi_graph(CopyGraphExecInOrder); });
-      Queue.wait_and_throw();
-      bool Success = false;
-      try {
-        EventInOrder
-            .get_profiling_info<sycl::info::event_profiling::command_start>();
-      } catch (sycl::exception &E) {
-        Success = true;
-      }
-      assert(Success);
+    // Checks exception thrown if profiling is requested while the
+    // enable_profiling property has not been passed to `finalize()`.
+    auto CopyGraphExecInOrder = CopyGraph.finalize();
+    auto EventInOrder = Queue.submit(
+        [&](handler &CGH) { CGH.ext_oneapi_graph(CopyGraphExecInOrder); });
+    Queue.wait_and_throw();
+    bool Success = false;
+    try {
+      EventInOrder
+          .get_profiling_info<sycl::info::event_profiling::command_start>();
+    } catch (sycl::exception &E) {
+      Success = true;
     }
+    assert(Success);
   }
 
   host_accessor HostData(BufferTo);

--- a/sycl/test-e2e/Graph/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/event_profiling_info.cpp
@@ -130,7 +130,7 @@ int main() {
 
     KernelGraph.end_recording(Queue);
 
-    // The profiling is not available with the In-Order optimization.
+    // The profiling is not available with the in-order optimization.
     // We therefore disable this optimization.
     auto CopyGraphExec =
         CopyGraph.finalize(exp_ext::property::graph::enable_profiling{});

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -2271,8 +2271,8 @@ TEST_F(CommandGraphTest, ProfilingExceptionProperty) {
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   Graph.end_recording(Queue);
 
-  // Checks exception thrown if profiling is requested while the
-  // enable_profiling property has not been passed to `finalize()`.
+  // Checks exception thrown if profiling is requested while profiling has
+  // not be enabled during the graph building.
   auto GraphExecInOrder = Graph.finalize();
   queue QueueProfile{Dev, {sycl::property::queue::enable_profiling()}};
   auto EventInOrder = QueueProfile.submit(

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -2265,6 +2265,34 @@ TEST_F(CommandGraphTest, ProfilingException) {
   }
 }
 
+TEST_F(CommandGraphTest, ProfilingExceptionProperty) {
+  Graph.begin_recording(Queue);
+  auto Event1 = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  Graph.end_recording(Queue);
+
+  // Checks exception thrown if profiling is requested while the
+  // enable_profiling property has not been passed to `finalize()`.
+  auto GraphExecInOrder = Graph.finalize();
+  queue QueueProfile{Dev, {sycl::property::queue::enable_profiling()}};
+  auto EventInOrder = QueueProfile.submit(
+      [&](handler &CGH) { CGH.ext_oneapi_graph(GraphExecInOrder); });
+  QueueProfile.wait_and_throw();
+  bool Success = true;
+  try {
+    EventInOrder
+        .get_profiling_info<sycl::info::event_profiling::command_start>();
+  } catch (sycl::exception &Exception) {
+    ASSERT_FALSE(std::string(Exception.what())
+                     .find("Profiling information is unavailable as the queue "
+                           "associated with the event does not have the "
+                           "'enable_profiling' property.") ==
+                 std::string::npos);
+    Success = false;
+  }
+  ASSERT_EQ(Success, false);
+}
+
 class MultiThreadGraphTest : public CommandGraphTest {
 public:
   MultiThreadGraphTest()


### PR DESCRIPTION
- Enable in-order cmd-list
Analyze the graph and apply enable the use of in-order command-list for linear graph. 
- Add a property to finalize function to enable graph profiling. 
- Update the specification.