### PR TITLE
[SYCL][Graph] Add spec wording for graph-owned memory allocations

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5757,27 +5757,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-Wno-sycl-strict");
       }
 
-      // If no optimization controlling flags (-O) are provided, check if
-      // any debug information flags(-g) are passed.
-      // "-fintelfpga" implies "-g" and we preserve the default optimization for
-      // this flow(-O2).
-      // if "-g" is explicitly passed from the command-line, set default
-      // optimization to -O0.
-
-      if (!Args.hasArgNoClaim(options::OPT_O_Group, options::OPT__SLASH_O)) {
-        StringRef OptLevel = "-O2";
-        const Arg *DebugInfoGroup = Args.getLastArg(options::OPT_g_Group);
-        // -fintelfpga -g case
-        if ((Args.hasArg(options::OPT_fintelfpga) &&
-             Args.hasMultipleArgs(options::OPT_g_Group)) ||
-            /* -fsycl -g case */ (!Args.hasArg(options::OPT_fintelfpga) &&
-                                  DebugInfoGroup)) {
-          if (!DebugInfoGroup->getOption().matches(options::OPT_g0)) {
-            OptLevel = "-O0";
-          }
-        }
-        CmdArgs.push_back(OptLevel.data());
-      }
+      // Set O2 optimization level by default
+      if (!Args.getLastArg(options::OPT_O_Group))
+        CmdArgs.push_back("-O2");
 
       // Add the integration header option to generate the header.
       StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
@@ -11083,25 +11065,7 @@ static std::string getSYCLPostLinkOptimizationLevel(const ArgList &Args) {
                     [=](char c) { return c == S[0]; }))
       return std::string("-O") + S[0];
   }
-  // If no optimization controlling flags (-O) are provided, check if
-  // any debug information flags(-g) are passed.
-  // "-fintelfpga" implies "-g" and we preserve the default optimization for
-  // this flow(-O2).
-  // if "-g" is explicitly passed from the command-line, set default
-  // optimization to -O0.
 
-  if (!Args.hasArg(options::OPT_O_Group)) {
-    const Arg *DebugInfoGroup = Args.getLastArg(options::OPT_g_Group);
-    // -fintelfpga -g case
-    if ((Args.hasArg(options::OPT_fintelfpga) &&
-         Args.hasMultipleArgs(options::OPT_g_Group)) ||
-        /* -fsycl -g case */
-        (!Args.hasArg(options::OPT_fintelfpga) && DebugInfoGroup)) {
-      if (!DebugInfoGroup->getOption().matches(options::OPT_g0)) {
-        return "-O0";
-      }
-    }
-  }
   // The default for SYCL device code optimization
   return "-O2";
 }

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -46,24 +46,4 @@
 // RUN:   | FileCheck -check-prefix=CHECK-NO-THRESH %s
 // CHECK-NO-THRESH-NOT: "-mllvm" "-inline-threshold
 
-/// Check that optimizations for sycl device are disabled with -g passed:
-// RUN:   %clang -### -fsycl -g %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DEBUG %s
-// RUN:   %clang_cl -### -fsycl -g %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DEBUG %s
-// CHECK-DEBUG: clang{{.*}} "-fsycl-is-device{{.*}}" "-O0"
-// CHECK-DEBUG: sycl-post-link{{.*}} "-O0"
-// CHECK-DEBUG-NOT: "-O2"
 
-/// Check that optimizations for sycl device are enabled with -g and O2 passed:
-// RUN:   %clang -### -fsycl -O2 -g %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-G-O2 %s
-// For clang_cl, -O2 maps to -O3
-// RUN:   %clang_cl -### -fsycl -O2 -g %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-G-O3 %s
-// CHECK-G-O2: clang{{.*}} "-fsycl-is-device{{.*}}" "-O2"
-// CHECK-G-O2: sycl-post-link{{.*}} "-O2"
-// CHECK-G-O2-NOT: "-O0"
-// CHECK-G-O3: clang{{.*}} "-fsycl-is-device{{.*}}" "-O3"
-// CHECK-G-O3: sycl-post-link{{.*}} "-O3"
-// CHECK-G-O3-NOT: "-O0"

--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -46,7 +46,7 @@ class ComputeBench(Suite):
         return "https://github.com/intel/compute-benchmarks.git"
 
     def git_hash(self) -> str:
-        return "27f158753caf8422e9f0d5a65ab304f21bc085c5"
+        return "420842fc3f0c01aac7b328bf192c25d3e7b9fd9e"
 
     def setup(self):
         if options.sycl is None:

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -315,13 +315,25 @@ if("native_cpu" IN_LIST SYCL_ENABLE_BACKENDS)
   endif()
   # Include NativeCPU UR adapter path to enable finding header file with state struct.
   # libsycl-nativecpu_utils is only needed as BC file by NativeCPU.
-  # Todo: add versions for other targets (for cross-compilation)
-  compile_lib(libsycl-nativecpu_utils
-    FILETYPE bc
-    SRC nativecpu_utils.cpp
-    DEPENDENCIES ${itt_obj_deps}
-    EXTRA_OPTS -I ${NATIVE_CPU_DIR} -fsycl-targets=native_cpu -fsycl-device-only
-               -fsycl-device-obj=llvmir)
+  add_custom_command(
+    OUTPUT ${bc_binary_dir}/nativecpu_utils.bc
+    COMMAND ${clang_exe} ${compile_opts} ${bc_device_compile_opts} -fsycl-targets=native_cpu
+      -I ${NATIVE_CPU_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/nativecpu_utils.cpp
+      -o ${bc_binary_dir}/nativecpu_utils.bc
+    MAIN_DEPENDENCY nativecpu_utils.cpp
+    DEPENDS ${sycl-compiler_deps}
+    VERBATIM)
+  add_custom_target(nativecpu_utils-bc DEPENDS ${bc_binary_dir}/nativecpu_utils.bc)
+  process_bc(libsycl-nativecpu_utils.bc
+    LIB_TGT libsycl-nativecpu_utils
+    IN_FILE ${bc_binary_dir}/nativecpu_utils.bc
+    OUT_DIR ${bc_binary_dir})
+  add_custom_target(libsycl-nativecpu_utils-bc DEPENDS ${bc_binary_dir}/libsycl-nativecpu_utils.bc)
+  add_dependencies(libsycldevice-bc libsycl-nativecpu_utils-bc)
+  install(FILES ${bc_binary_dir}/libsycl-nativecpu_utils.bc
+          DESTINATION ${install_dest_bc}
+          COMPONENT libsycldevice)
 endif()
 
 # Add all device libraries for each filetype except for the Intel math function

--- a/libdevice/nativecpu_utils.cpp
+++ b/libdevice/nativecpu_utils.cpp
@@ -29,6 +29,11 @@ using __nativecpu_state = native_cpu::state;
 #define DEVICE_EXTERNAL_C DEVICE_EXTERN_C __attribute__((always_inline))
 #define DEVICE_EXTERNAL SYCL_EXTERNAL __attribute__((always_inline))
 
+// Several functions are used implicitly by WorkItemLoopsPass and
+// PrepareSYCLNativeCPUPass and need to be marked as used to prevent them being
+// removed early.
+#define USED __attribute__((used))
+
 #define OCL_LOCAL __attribute__((opencl_local))
 #define OCL_GLOBAL __attribute__((opencl_global))
 #define OCL_PRIVATE __attribute__((opencl_private))
@@ -360,7 +365,7 @@ using MakeGlobalType = typename sycl::detail::DecoratedType<
     T, sycl::access::address_space::global_space>::type;
 
 #define DefStateSetWithType(name, field, type)                                 \
-  DEVICE_EXTERNAL_C void __dpcpp_nativecpu_##name(                             \
+  DEVICE_EXTERNAL_C USED void __dpcpp_nativecpu_##name(                        \
       type value, MakeGlobalType<__nativecpu_state> *s) {                      \
     s->field = value;                                                          \
   }                                                                            \
@@ -372,7 +377,7 @@ DefStateSetWithType(set_sub_group_id, SubGroup_id, uint32_t);
 DefStateSetWithType(set_max_sub_group_size, SubGroup_size, uint32_t);
 
 #define DefineStateGetWithType(name, field, type)                              \
-  DEVICE_EXTERNAL_C GET_PROPS type __dpcpp_nativecpu_##name(                   \
+  DEVICE_EXTERNAL_C GET_PROPS USED type __dpcpp_nativecpu_##name(              \
       MakeGlobalType<const __nativecpu_state> *s) {                            \
     return s->field;                                                           \
   }                                                                            \
@@ -388,7 +393,7 @@ DefineStateGet_U32(get_max_sub_group_size, SubGroup_size);
 DefineStateGet_U32(get_num_sub_groups, NumSubGroups);
 
 #define DefineStateGetWithType2(name, field, rtype, ptype)                     \
-  DEVICE_EXTERNAL_C GET_PROPS rtype __dpcpp_nativecpu_##name(                  \
+  DEVICE_EXTERNAL_C GET_PROPS USED rtype __dpcpp_nativecpu_##name(             \
       ptype dim, MakeGlobalType<const __nativecpu_state> *s) {                 \
     return s->field[dim];                                                      \
   }                                                                            \
@@ -406,9 +411,9 @@ DefineStateGet_U64(get_num_groups, MNumGroups);
 DefineStateGet_U64(get_wg_size, MWorkGroup_size);
 DefineStateGet_U64(get_wg_id, MWorkGroup_id);
 
-DEVICE_EXTERNAL_C
-void __dpcpp_nativecpu_set_local_id(uint32_t dim, uint64_t value,
-                                    MakeGlobalType<__nativecpu_state> *s) {
+DEVICE_EXTERNAL_C USED void
+__dpcpp_nativecpu_set_local_id(uint32_t dim, uint64_t value,
+                               MakeGlobalType<__nativecpu_state> *s) {
   s->MLocal_id[dim] = value;
   s->MGlobal_id[dim] = s->MWorkGroup_size[dim] * s->MWorkGroup_id[dim] +
                        s->MLocal_id[dim] + s->MGlobalOffset[dim];

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -338,6 +338,8 @@ enum class node_type {
   memadvise,
   ext_oneapi_barrier,
   host_task,
+  async_malloc,
+  async_free
 };
 
 class node {
@@ -765,6 +767,8 @@ public:
     void update(node& node);
     void update(const std::vector<node>& nodes);
     void update(const command_graph<graph_state::modifiable>& graph);
+
+    size_t get_required_mem_size() const;
 };
 
 }  // namespace sycl::ext::oneapi::experimental
@@ -987,7 +991,8 @@ conditions:
 ** Nodes must be added in the same order in the two graphs. Nodes may be added
    via `command_graph::add`, or for a recorded queue via `queue::submit` or
    queue shortcut functions.
-** Corresponding nodes in each graph must be kernels that have the same type:
+** Corresponding kernel nodes in each graph must be kernels that have the same
+type:
 
 *** When the kernel is defined as a lambda, the lambda must be the same.
 *** When the kernel is defined as a named function object, the kernel class
@@ -1010,6 +1015,148 @@ It is valid to use nodes that contain dynamic parameters in whole graph updates.
 If a node containing a dynamic parameter is updated through the whole graph
 update API, then any previous updates to the dynamic parameter will be reflected
 in the new graph.
+
+==== Graph-Owned Memory Allocations [[graph-memory-allocations]]
+
+It can be desirable for a graph to own and manage memory allocations for memory
+associated with commands in the graph. This is made possible by using the
+`async_<malloc/malloc_from_pool>` and `async_free` commands from the
+link:../experimental/sycl_ext_oneapi_async_memory_alloc.asciidoc[sycl_ext_oneapi_async_memory_alloc
+] extension. These commands can be added to a graph either via queue recording
+or explicit graph creation, which will create allocations which are owned and
+managed by that specific `command_graph`, and who's lifetimes are tied to the
+lifetime of that graph.
+
+Pointers returned from allocation nodes can be used in other graph nodes in the
+same way as regular USM pointers.
+
+===== API Usage
+
+Malloc and free nodes can be added to a graph via both the explicit and queue
+recording graph APIs using the `async_<malloc/malloc_from_pool/free>` free
+functions inside a command-group:
+
+[source,c++]
+----
+void* Ptr = nullptr;
+size_t AllocSize = 1024;
+auto CGF = [&](handler &CGH){
+  Ptr = async_malloc(CGH, usm::alloc::device, AllocSize);
+}
+
+// Explicit graph creation
+Graph.add(CGF);
+
+Graph.add([&](handler &CGH){
+  async_free(CGH, Ptr);
+});
+
+// Queue recording
+Graph.begin_recording(Queue);
+Queue.submit(CGF);
+Queue.submit([&](handler &CGH){
+  async_free(CGH, Ptr);
+});
+----
+
+The `async_*` commands which take a queue can also be used with queue
+recording, particularly when recording an in-order queue to specify dependencies
+as no SYCL event is returned.
+
+[source,c++]
+----
+void* Ptr = nullptr;
+size_t AllocSize = 1024;
+queue Queue {syclContext, syclDevice, {property::queue::in_order{}}};
+
+Graph.begin_recording(Queue);
+Ptr = async_malloc(Queue, usm::alloc::device, AllocSize);
+async_free(Queue, Ptr);
+----
+
+===== Supported Features [[allocation-supported-features]]
+
+Currently only device allocations are supported in graphs. Attempting to
+add allocations of any other type to a graph will result in synchronous errors
+being thrown with error code `feature_not_supported`.
+
+===== Restrictions
+
+The following restrictions apply to any graph containing async malloc or free
+nodes:
+
+* Only one executable graph instance (created by finalizing the modifiable
+graph) can be alive at any time, and all copies of that instance (created via
+the {crs}[common reference semantics] of the `command_graph` class) must be
+destroyed before the graph can be finalized again. Failing to do so will result
+in a sychronous error being thrown with error code `invalid` when attempting to
+finalize the graph again.
+* The graph cannot be used as a sub-graph in another graph.
+* Graph memory allocation nodes cannot be updated, and graphs containing these
+nodes cannot be updated via <<whole-graph-update, Whole Graph Update>>.
+
+===== Allocation Lifetime
+
+The lifetime of graph-owned allocations are tied to the lifetime of the graph
+itself.
+
+It is only valid to use the pointers returned from graph allocation nodes inside
+the graph in which they were allocated. Any nodes using these allocations must
+be ordered after the allocation node and before the free node for that
+allocation.
+
+It is invalid to use these pointers outside of the owning graph and doing so
+will result in undefined behavior.
+
+===== Behaviour 
+
+The semantics of `async_malloc` and `async_free` within a graph differ from the
+eager SYCL usage described in the
+link:../experimental/sycl_ext_oneapi_async_memory_alloc.asciidoc[sycl_ext_oneapi_async_memory_alloc]
+extension.
+
+* Graph memory allocations are not made directly from any default or
+user-provided Memory Pool. Each graph containing alloc/free nodes maintains its
+own pool of memory from which allocations are made. The following properties of
+a default or user-provided memory pool provided in calls to
+`async_<malloc/malloc_from_pool>` will be respected for the associated graph
+allocations, all other properties will be ignored:
+
+** The allocation type specified when creating the pool with
+`usm::alloc::<host/device/shared>`, subject to the limitations in the
+<<allocation-supported-features, supported features>> section.
+
+** `property::memory_pool::read_only` - Guarantee from the user that memory is
+only being read from, the implementation may be able to optimize in this case.
+
+** `property::memory_pool::zero_init` - Allocated memory will be
+zero-initialized only once when first allocated. It will not be zero-initialized
+again before or during any subsequent executions of the graph. If that is
+required by the application it is the responsibility of the user to add the
+appropriate commands to the graph to do this.
+
+* `node_type::async_malloc` nodes within a graph will return a pointer to an
+allocation of the provided size. This pointer can then be used in other graph
+nodes ordered after that node in the same way any USM pointer would be. 
++
+[Note: Returned pointers are not guaranteed to be unique. An implementation may
+return the same pointer as a previous `async_malloc` nodes if that pointer was
+previously freed via `async_free` at that point in the graph. -- end note]
+
+* `node_type::async_free` nodes within a graph indicate that a given allocation
+is no longer in use. They must be ordered after the associated allocation node.
+Attempting to add a free node for an allocation which does not exist in the
+graph will result in a synchronous error being thrown with error code `invalid`.
+
+* Other nodes which use a given graph allocation must be ordered via
+dependencies such that they are ordered after the allocation node and before the
+free node for a given allocation. It is the user's responsibility to ensure that
+dependencies are correct. Using a pointer in a graph command ordered after it
+has been freed via an `async_free` node results in undefined behavior.
+
+The total amount of memory required for graph allocations by an executable graph
+can be queried using the `command_graph::get_required_mem_size()` member
+function.
 
 ==== Graph Properties [[graph-properties]]
 
@@ -1242,6 +1389,9 @@ Exceptions:
   property for more information.
 * Throws with error code `invalid` if the type of the command-group is not a
   kernel execution and a `dynamic_parameter` was registered inside `cgf`.
+* Throws with error code `invalid` if the type of the command-group is
+`async_malloc` and the `usm::alloc` type of the associated memory pool is not
+`usm::alloc::device`.
 
 |
 [source,c++]
@@ -1329,10 +1479,12 @@ finalize(const property_list& propList = {}) const;
 
 |Synchronous operation that creates a new graph in the executable state with a
 fixed topology that can be submitted for execution on any queue sharing the
-context associated with the graph. It is valid to call this method multiple times
-to create subsequent executable graphs. It is also valid to continue to add new
-nodes to the modifiable graph instance after calling this function. It is valid
-to finalize an empty graph instance with no recorded commands.
+context associated with the graph. It is valid to call this member function
+multiple times to create subsequent executable graphs, unless the graph contains
+<<graph-memory-allocations, graph-owned memory allocations>>. It is also valid
+to continue to add new nodes to the modifiable graph instance after calling this
+function. It is valid to finalize an empty graph instance with no recorded
+commands.
 
 Constraints:
 
@@ -1353,6 +1505,12 @@ Exceptions:
   contains a command that is not supported by the device.
 
 Returns: A new executable graph object which can be submitted to a queue.
+
+Exceptions:
+
+* Throws with error code `invalid` if the graph contains
+<<graph-memory-allocations, graph-owned memory allocations>> and the graph has
+previously been finalized.
 
 |
 [source,c++]
@@ -1394,6 +1552,19 @@ were added.
 std::vector<node> get_root_nodes() const;
 ----
 |Returns a list of all nodes in the graph which have no dependencies.
+
+|
+[source,c++]
+----
+size_t get_required_mem_size() const;
+----
+|Returns the total size in bytes of the memory required for
+<<graph-memory-allocations, graph-owned memory allocations>> in this graph.
+
+Constraints:
+
+* This member function is only available when the `command_graph` state is
+  `graph_state::executable`.
 
 |===
 
@@ -1524,6 +1695,9 @@ Exceptions:
 * Throws synchronously with error code `invalid` if
   `property::graph::updatable` was not set when the executable graph was
   created.
+
+* Throws synchronously with error code `invalid` if the graph contains any
+  <<graph-memory-allocations, graph-owned memory allocations>>.
 
 * If any other exception is thrown the state of the graph nodes is undefined.
 |===
@@ -2121,6 +2295,13 @@ recording mode, as opposed to throwing.
 
 This section defines the interaction of `sycl_ext_oneapi_graph` with other
 extensions.
+
+==== sycl_ext_oneapi_async_memory_alloc
+
+The APIs defined in
+link:../experimental/sycl_ext_oneapi_async_memory_alloc.asciidoc[sycl_ext_oneapi_async_memory_alloc]
+are supported for use in graphs. For further details see the section on
+<<graph-memory-allocations, Graph-owned memory allocations>>.
 
 ==== sycl_ext_codeplay_enqueue_native_command
 

--- a/sycl/doc/syclgraph/SYCLGraphUsageGuide.md
+++ b/sycl/doc/syclgraph/SYCLGraphUsageGuide.md
@@ -222,6 +222,90 @@ q.submit([&](sycl::handler &CGH) {
 });
 ```
 
+### Guidance For Library Authors
+
+In addition to the general SYCL-graph compatibility guidelines there are some
+considerations that are more relevant to library authors to be compatible with
+SYCL-Graph and allow seamless capturing of library calls in a graph.
+
+#### Graph-owned Memory Allocations For Temporary Memory
+
+A common pattern in libraries with specialized SYCL kernels can involve the
+allocation and use of temporary memory for those kernels. One approach is custom
+allocators which rely on SYCL events to control the lifetime and re-use of this
+temporary memory, but these are not compatible with events returned from queue
+submissions which are recorded to a graph. Instead the
+[sycl_ext_oneapi_async_memory_alloc](../extensions/experimental/sycl_ext_oneapi_async_memory_alloc.asciidoc)
+extension can be used which provides similar functionality for eager SYCL usage
+as well as compatibility with graphs.
+
+When captured in a graph calls to these extension functions create graph-owned
+memory allocations which are tied to the lifetime of the graph. These
+allocations can be created as needed for library kernels and the SYCL runtime
+may be able to re-use memory where appropriate to minimize the memory footprint
+of the graph. This can avoid the need for a library to manage the lifetime of
+these allocations themselves, or be aware of the library calls being recorded to
+a graph.
+
+It is important to set correct dependencies between allocation commands, kernels
+that use those allocations, and the calls to free the memory. This allows the
+graph to determine when allocations are in-use at a given point in the graph,
+and allow for re-using memory for subsequent allocation nodes if those nodes are
+ordered after a free command which is no longer in use. It is important to note
+that calling `async_free` will not deallocate memory but simply mark it as free
+for re-use.
+
+The following shows a simple example of how these allocations can be used in a 
+library function which is recorded to a graph:
+
+```c++
+using namespace sycl;
+
+// Library code, this example is assuming an out of order SYCL queue
+void launchLibraryKernel(queue& SyclQueue){
+    size_t TempMemSize = 1024;
+    void* Ptr = nullptr;
+
+    // Get a pointer to some temporary memory for use in the kernel
+    // This call creates an allocation node in the graph if this call is being
+    // recorded.
+    event AllocEvent = SyclQueue.submit([&](handler& CGH){
+        Ptr = sycl_ext::async_malloc(CGH, usm::alloc::device, TempMemSize);
+    });
+
+    // Submit the actual library kernel
+    event KernelEvent = SyclQueue.submit([&](handler& CGH){
+        // Mark the allocation as a dependency so that the temporary memory
+        // is available
+        CGH.depends_on(AllocEvent);
+        // Submit a kernel that uses the temp memory in Ptr
+        CGH.parallel_for(...);
+    });
+
+    // Free the memory back to the pool or graph, indicating that it is free to
+    // be re-used. Memory will not actually be released back to the OS.
+    SyclQueue.submit([&](handler& CGH){
+        // Mark the kernel as a dependency before freeing
+        CGH.depends_on(KernelEvent);
+        sycl_ext::async_free(CGH, Ptr);
+    });
+}
+
+// Application code
+void recordLibraryCall(queue& SyclQueue, sycl_ext::command_graph& Graph){
+    Graph.begin_recording(SyclQueue);
+    // Call into library to record queue commands to the graph
+    launchLibraryKernel(SyclQueue);
+
+    Graph.end_recording(SyclQueue);
+}
+```
+
+Please see "graph-owned memory allocations" section of the
+[sycl_ext_oneapi_graph
+specification](../extensions/experimental/sycl_ext_oneapi_graph.asciidoc) for a
+complete description of the feature.
+
 ## Code Examples
 
 The examples below demonstrate intended usage of the extension, but may not be
@@ -679,4 +763,78 @@ execMainGraph.update(updateGraph);
 // Execute execMainGraph again, which will now be operating on ptrB instead of
 // ptrA
 myQueue.ext_oneapi_graph(execMainGraph);
+```
+
+### Graph-Owned Memory Allocations
+
+#### Explicit Graph Example
+
+Using default memory pool.
+
+```c++
+using namespace sycl;
+namespace sycl_ext = sycl::ext::oneapi::experimental;
+
+void* Ptr = nullptr;
+size_t AllocSize = 1024;
+// Add an async_malloc node and capturing the returned pointer in Ptr
+auto AllocNode = Graph.add([&](handler& CGH){
+  Ptr = sycl_ext::async_malloc(CGH, usm::alloc::device, AllocSize);
+});
+
+// Use Ptr in another graph node which depends on AllocNode
+auto OtherNodeA = Graph.add(..., {property::graph::depends_on{AllocNode}});
+// Use Ptr in another node which has an indirect dependency on AllocNode
+auto OtherNodeB = Graph.add(..., {property::graph::depends_on{OtherNodeA}});
+
+// Free Ptr, indicating it is no longer in use at this point in the graph,
+// with a dependency on any leaf nodes using Ptr
+Graph.add([&](handler& CGH){
+  sycl_ext::async_free(CGH, Ptr);
+}, {property::graph::depends_on{OtherNodeB}});
+```
+
+#### Queue Recording Example
+
+Using user-provided memory pool.
+
+```c++
+using namespace sycl;
+namespace sycl_ext = sycl::ext::oneapi::experimental;
+
+void* Ptr = nullptr;
+size_t AllocSize = 1024;
+queue Queue {syclContext, syclDevice};
+
+// Device memory pool with zero init property
+sycl_ext::memory_pool MemPool{syclContext, syclDevice, usm::alloc::device,
+                             {sycl_ext::property::memory_pool::zero_init{}}};
+Graph.begin_recording(Queue);
+// Add an async_malloc node and capture the returned pointer in Ptr, 
+// zero_init property and usm::alloc kind of pool will be respected but pool
+// is otherwise ignored
+event AllocEvent = Queue.submit([&](handler& CGH){
+  Ptr = sycl_ext::async_malloc_from_pool(CGH, AllocSize, MemPool);
+});
+
+// Use Ptr in another graph node which depends on AllocNode
+event OtherEventA = Queue.submit([&](handler& CGH){
+  CGH.depends_on(AllocEvent);
+  // Do something with Ptr
+  CGH.parallel_for(...);
+});
+// Use Ptr in another node which has an indirect dependency on AllocNode
+event OtherEventB = Queue.submit([&](handler& CGH){
+  CGH.depends_on(OtherEventA);
+  // Do something with Ptr
+  CGH.parallel_for(...);
+});
+
+// Free Ptr, indicating it is no longer in use at this point in the graph,
+// with a dependency on any leaf nodes using Ptr
+Queue.submit([&](handler& CGH){
+  sycl_ext::async_free(CGH, Ptr);
+});
+
+Graph.end_recording(Queue);
 ```

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -2186,8 +2186,8 @@ void ProgramManager::removeImages(sycl_device_binaries DeviceBinary) {
 
       if (auto It = m_KernelName2KernelIDs.find(EntriesIt->GetName());
           It != m_KernelName2KernelIDs.end()) {
-        m_KernelName2KernelIDs.erase(It);
         m_KernelIDs2BinImage.erase(It->second);
+        m_KernelName2KernelIDs.erase(It);
       }
     }
 

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/debug_symbols.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/debug_symbols.cpp
@@ -1,5 +1,5 @@
 // Check that full compilation works:
-// RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g -O2 %S/../debug_symbols.cpp -o %t.out
+// RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g %S/../debug_symbols.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //
 // VISALTO enable run

--- a/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
@@ -1,5 +1,5 @@
 // Check that full compilation works:
-// RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g -O2 -o %t.out
+// RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //
 // VISALTO enable run

--- a/unified-runtime/source/adapters/hip/CMakeLists.txt
+++ b/unified-runtime/source/adapters/hip/CMakeLists.txt
@@ -203,6 +203,12 @@ else()
     message(FATAL_ERROR "Unspecified UR HIP platform please set UR_HIP_PLATFORM to 'AMD' or 'NVIDIA'")
 endif()
 
+if(UMF_ENABLE_POOL_TRACKING)
+  target_compile_definitions(${TARGET_NAME} PRIVATE UMF_ENABLE_POOL_TRACKING)
+else()
+  message(WARNING "HIP adapter USM pools are disabled, set UMF_ENABLE_POOL_TRACKING to enable them")
+endif()
+
 target_include_directories(${TARGET_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/../../"
 )

--- a/unified-runtime/source/adapters/hip/usm.cpp
+++ b/unified-runtime/source/adapters/hip/usm.cpp
@@ -37,7 +37,13 @@ urUSMHostAlloc(ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
     return USMHostAllocImpl(ppMem, hContext, /* flags */ 0, size, alignment);
   }
 
-  return umfPoolMallocHelper(hPool, ppMem, size, alignment);
+  auto UMFPool = hPool->HostMemPool.get();
+  *ppMem = umfPoolAlignedMalloc(UMFPool, size, alignment);
+  if (*ppMem == nullptr) {
+    auto umfErr = umfPoolGetLastAllocationError(UMFPool);
+    return umf::umf2urResult(umfErr);
+  }
+  return UR_RESULT_SUCCESS;
 }
 
 /// USM: Implements USM device allocations using a normal HIP device pointer
@@ -54,7 +60,13 @@ urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
                               alignment);
   }
 
-  return umfPoolMallocHelper(hPool, ppMem, size, alignment);
+  auto UMFPool = hPool->DeviceMemPool.get();
+  *ppMem = umfPoolAlignedMalloc(UMFPool, size, alignment);
+  if (*ppMem == nullptr) {
+    auto umfErr = umfPoolGetLastAllocationError(UMFPool);
+    return umf::umf2urResult(umfErr);
+  }
+  return UR_RESULT_SUCCESS;
 }
 
 /// USM: Implements USM Shared allocations using HIP Managed Memory
@@ -71,7 +83,13 @@ urUSMSharedAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
                               /*device flags*/ 0, size, alignment);
   }
 
-  return umfPoolMallocHelper(hPool, ppMem, size, alignment);
+  auto UMFPool = hPool->SharedMemPool.get();
+  *ppMem = umfPoolAlignedMalloc(UMFPool, size, alignment);
+  if (*ppMem == nullptr) {
+    auto umfErr = umfPoolGetLastAllocationError(UMFPool);
+    return umf::umf2urResult(umfErr);
+  }
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -330,15 +348,25 @@ ur_result_t USMHostMemoryProvider::allocateImpl(void **ResultPtr, size_t Size,
 ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t Context,
                                              ur_usm_pool_desc_t *PoolDesc)
     : Context(Context) {
-  if (PoolDesc) {
-    if (auto *Limits = find_stype_node<ur_usm_pool_limits_desc_t>(PoolDesc)) {
+
+  const void *pNext = PoolDesc->pNext;
+  while (pNext != nullptr) {
+    const ur_base_desc_t *BaseDesc = static_cast<const ur_base_desc_t *>(pNext);
+    switch (BaseDesc->stype) {
+    case UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC: {
+      const ur_usm_pool_limits_desc_t *Limits =
+          reinterpret_cast<const ur_usm_pool_limits_desc_t *>(BaseDesc);
       for (auto &config : DisjointPoolConfigs.Configs) {
         config.MaxPoolableSize = Limits->maxPoolableSize;
         config.SlabMinSize = Limits->minDriverAllocSize;
       }
-    } else {
+      break;
+    }
+    default: {
       throw UsmAllocationException(UR_RESULT_ERROR_INVALID_ARGUMENT);
     }
+    }
+    pNext = BaseDesc->pNext;
   }
 
   auto MemProvider =
@@ -466,17 +494,6 @@ bool checkUSMAlignment(uint32_t &alignment, const ur_usm_desc_t *pUSMDesc) {
 bool checkUSMImplAlignment(uint32_t Alignment, void **ResultPtr) {
   return Alignment == 0 ||
          reinterpret_cast<std::uintptr_t>(*ResultPtr) % Alignment == 0;
-}
-
-ur_result_t umfPoolMallocHelper(ur_usm_pool_handle_t hPool, void **ppMem,
-                                size_t size, uint32_t alignment) {
-  auto UMFPool = hPool->DeviceMemPool.get();
-  *ppMem = umfPoolAlignedMalloc(UMFPool, size, alignment);
-  if (*ppMem == nullptr) {
-    auto umfErr = umfPoolGetLastAllocationError(UMFPool);
-    return umf::umf2urResult(umfErr);
-  }
-  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolCreateExp(ur_context_handle_t,

--- a/unified-runtime/source/adapters/hip/usm.hpp
+++ b/unified-runtime/source/adapters/hip/usm.hpp
@@ -140,6 +140,3 @@ ur_result_t USMHostAllocImpl(void **ResultPtr, ur_context_handle_t Context,
 bool checkUSMAlignment(uint32_t &alignment, const ur_usm_desc_t *pUSMDesc);
 
 bool checkUSMImplAlignment(uint32_t Alignment, void **ResultPtr);
-
-ur_result_t umfPoolMallocHelper(ur_usm_pool_handle_t hPool, void **ppMem,
-                                size_t size, uint32_t alignment);

--- a/unified-runtime/source/adapters/opencl/device.hpp
+++ b/unified-runtime/source/adapters/opencl/device.hpp
@@ -28,6 +28,8 @@ struct ur_device_handle_t_ {
     RefCount = 1;
     if (Parent) {
       Type = Parent->Type;
+      [[maybe_unused]] auto Res = clRetainDevice(CLDevice);
+      assert(Res == CL_SUCCESS);
     } else {
       [[maybe_unused]] auto Res = clGetDeviceInfo(
           CLDevice, CL_DEVICE_TYPE, sizeof(cl_device_type), &Type, nullptr);
@@ -41,6 +43,8 @@ struct ur_device_handle_t_ {
       // exactly once. However, to prevent issues with the OpenCL handle being
       // reused, CLDevice must still be alive here.
       Platform->SubDevices.erase(CLDevice);
+      [[maybe_unused]] auto Res = clReleaseDevice(CLDevice);
+      assert(Res == CL_SUCCESS);
     }
     if (ParentDevice && IsNativeHandleOwned) {
       clReleaseDevice(CLDevice);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -527,7 +527,8 @@ struct urEnqueueKernelLaunchMultiDeviceTest
     auto kernelName =
         uur::KernelsEnvironment::instance->GetEntryPointNames("foo")[0];
 
-    uur::KernelsEnvironment::instance->LoadSource("foo", platform, il_binary);
+    UUR_RETURN_ON_FATAL_FAILURE(uur::KernelsEnvironment::instance->LoadSource(
+        "foo", platform, il_binary));
 
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::KernelsEnvironment::instance->CreateProgram(

--- a/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunchAndMemcpyInOrder.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunchAndMemcpyInOrder.cpp
@@ -34,9 +34,6 @@ struct urMultiQueueLaunchMemcpyTest
   using uur::urMultiQueueMultiDeviceTestWithParam<minDevices, T>::queues;
 
   void SetUp() override {
-    // We haven't got device code tests working on native cpu yet.
-    UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::urMultiQueueMultiDeviceTestWithParam<minDevices, T>::SetUp());
 
@@ -49,14 +46,13 @@ struct urMultiQueueLaunchMemcpyTest
     kernels.resize(devices.size());
     SharedMem.resize(devices.size());
 
-    KernelName =
-        uur::KernelsEnvironment::instance->GetEntryPointNames(ProgramName)[0];
-
     std::shared_ptr<std::vector<char>> il_binary;
     std::vector<ur_program_metadata_t> metadatas{};
 
-    uur::KernelsEnvironment::instance->LoadSource(ProgramName, platform,
-                                                  il_binary);
+    UUR_RETURN_ON_FATAL_FAILURE(uur::KernelsEnvironment::instance->LoadSource(
+        ProgramName, platform, il_binary));
+    KernelName =
+        uur::KernelsEnvironment::instance->GetEntryPointNames(ProgramName)[0];
 
     for (size_t i = 0; i < devices.size(); i++) {
       const ur_program_properties_t properties = {

--- a/unified-runtime/test/conformance/kernel/urKernelCreate.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelCreate.cpp
@@ -66,7 +66,8 @@ TEST_P(urMultiDeviceKernelCreateTest, WithProgramBuild) {
       uur::KernelsEnvironment::instance->GetEntryPointNames("foo")[0];
 
   std::shared_ptr<std::vector<char>> il_binary;
-  uur::KernelsEnvironment::instance->LoadSource("foo", platform, il_binary);
+  UUR_RETURN_ON_FATAL_FAILURE(uur::KernelsEnvironment::instance->LoadSource(
+      "foo", platform, il_binary));
 
   for (size_t i = 0; i < devices.size(); i++) {
     uur::raii::Program program;
@@ -101,7 +102,8 @@ TEST_P(urMultiDeviceKernelCreateTest, WithProgramCompileAndLink) {
       uur::KernelsEnvironment::instance->GetEntryPointNames("foo")[0];
 
   std::shared_ptr<std::vector<char>> il_binary;
-  uur::KernelsEnvironment::instance->LoadSource("foo", platform, il_binary);
+  UUR_RETURN_ON_FATAL_FAILURE(uur::KernelsEnvironment::instance->LoadSource(
+      "foo", platform, il_binary));
 
   for (size_t i = 0; i < devices.size(); i++) {
     uur::raii::Program program;

--- a/unified-runtime/test/conformance/program/urProgramBuild.cpp
+++ b/unified-runtime/test/conformance/program/urProgramBuild.cpp
@@ -34,8 +34,8 @@ TEST_P(urProgramBuildTest, BuildFailure) {
 
   ur_program_handle_t program = nullptr;
   std::shared_ptr<std::vector<char>> il_binary;
-  uur::KernelsEnvironment::instance->LoadSource("build_failure", platform,
-                                                il_binary);
+  UUR_RETURN_ON_FATAL_FAILURE(uur::KernelsEnvironment::instance->LoadSource(
+      "build_failure", platform, il_binary));
   if (!il_binary) {
     // The build failure we are testing for happens at SYCL compile time on
     // AMD and Nvidia, so no binary exists to check for a build failure

--- a/unified-runtime/test/conformance/program/urProgramCreateWithIL.cpp
+++ b/unified-runtime/test/conformance/program/urProgramCreateWithIL.cpp
@@ -9,9 +9,6 @@
 
 struct urProgramCreateWithILTest : uur::urContextTest {
   void SetUp() override {
-    // We haven't got device code tests working on native cpu yet.
-    UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-
     UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
     // TODO: This should use a query for urProgramCreateWithIL support or
     // rely on UR_RESULT_ERROR_UNSUPPORTED_FEATURE being returned.
@@ -22,7 +19,8 @@ struct urProgramCreateWithILTest : uur::urContextTest {
     if (backend == UR_PLATFORM_BACKEND_HIP) {
       GTEST_SKIP();
     }
-    uur::KernelsEnvironment::instance->LoadSource("foo", platform, il_binary);
+    UUR_RETURN_ON_FATAL_FAILURE(uur::KernelsEnvironment::instance->LoadSource(
+        "foo", platform, il_binary));
   }
 
   void TearDown() override {

--- a/unified-runtime/test/conformance/program/urProgramLink.cpp
+++ b/unified-runtime/test/conformance/program/urProgramLink.cpp
@@ -82,9 +82,6 @@ struct urProgramLinkErrorTest : uur::urQueueTest {
   const std::string linker_error_program_name = "linker_error";
 
   void SetUp() override {
-    // We haven't got device code tests working on native cpu yet.
-    UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-
     UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
     // TODO: This should use a query for urProgramCreateWithIL support or
     // rely on UR_RESULT_ERROR_UNSUPPORTED_FEATURE being returned.

--- a/unified-runtime/test/conformance/source/environment.cpp
+++ b/unified-runtime/test/conformance/source/environment.cpp
@@ -243,6 +243,9 @@ KernelsEnvironment::getKernelSourcePath(const std::string &kernel_name,
 void KernelsEnvironment::LoadSource(
     const std::string &kernel_name, ur_platform_handle_t platform,
     std::shared_ptr<std::vector<char>> &binary_out) {
+  // We don't have a way to build device code for native cpu yet.
+  UUR_KNOWN_FAILURE_ON_PARAM(platform, uur::NativeCPU{});
+
   std::string source_path =
       instance->getKernelSourcePath(kernel_name, platform);
 

--- a/unified-runtime/test/conformance/testing/include/uur/fixtures.h
+++ b/unified-runtime/test/conformance/testing/include/uur/fixtures.h
@@ -367,9 +367,6 @@ struct urQueueTest : urContextTest {
 
 struct urHostPipeTest : urQueueTest {
   void SetUp() override {
-    // We haven't got device code tests working on native cpu yet.
-    UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-
     // The host pipe support query isn't implement on l0
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
 
@@ -1215,9 +1212,6 @@ std::string deviceTestWithParamPrinter<SamplerCreateParamT>(
 
 struct urProgramTest : urQueueTest {
   void SetUp() override {
-    // We haven't got device code tests working on native cpu yet.
-    UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-
     UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
 
     ur_platform_backend_t backend;
@@ -1254,9 +1248,6 @@ struct urProgramTest : urQueueTest {
 
 template <class T> struct urProgramTestWithParam : urQueueTestWithParam<T> {
   void SetUp() override {
-    // We haven't got device code tests working on native cpu yet.
-    UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-
     UUR_RETURN_ON_FATAL_FAILURE(urQueueTestWithParam<T>::SetUp());
 
     ur_platform_backend_t backend;
@@ -1303,9 +1294,6 @@ template <class T> struct urProgramTestWithParam : urQueueTestWithParam<T> {
 // instead.
 struct urBaseKernelTest : urProgramTest {
   void SetUp() override {
-    // We haven't got device code tests working on native cpu yet.
-    UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-
     UUR_RETURN_ON_FATAL_FAILURE(urProgramTest::SetUp());
     auto kernel_names =
         uur::KernelsEnvironment::instance->GetEntryPointNames(program_name);

--- a/unified-runtime/test/conformance/usm/urUSMPoolCreate.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMPoolCreate.cpp
@@ -29,7 +29,7 @@ TEST_P(urUSMPoolCreateTest, Success) {
 }
 
 TEST_P(urUSMPoolCreateTest, SuccessWithFlag) {
-  UUR_KNOWN_FAILURE_ON(uur::CUDA{});
+  UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
 
   ur_usm_pool_desc_t pool_desc{UR_STRUCTURE_TYPE_USM_POOL_DESC, nullptr,
                                UR_USM_POOL_FLAG_ZERO_INITIALIZE_BLOCK};


### PR DESCRIPTION
- Using sycl_ext_codeplay_async_memory_alloc extension
- Spec wording for graph support of the feature
- Usage guide examples of explicit and queue recording usage