### PR TITLE
Add non immediate flag to cb event provider for graph compatibility

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/event_provider_counter.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event_provider_counter.cpp
@@ -52,9 +52,9 @@ static zex_counter_based_event_exp_flags_t createZeFlags(queue_type queueType,
 
   if (queueType == QUEUE_IMMEDIATE) {
     zeFlags |= ZEX_COUNTER_BASED_EVENT_FLAG_IMMEDIATE;
-  } else {
-    zeFlags |= ZEX_COUNTER_BASED_EVENT_FLAG_NON_IMMEDIATE;
   }
+  // Always set non immediate flag for compatibility with graph record & replay
+  zeFlags |= ZEX_COUNTER_BASED_EVENT_FLAG_NON_IMMEDIATE;
 
   return zeFlags;
 }


### PR DESCRIPTION
Looking at [level-zero tests](https://github.com/intel/compute-runtime/blob/fa7c5916505fba19113740da7970f6538c619e54/level_zero/core/test/black_box_tests/zello_graph.cpp#L664), counter based events with graphs always set `ZEX_COUNTER_BASED_EVENT_FLAG_NON_IMMEDIATE` even though we record over an immediate command list. This seems to be a requirement to use counter based events with graphs. Adding this fixes my reproducers and `enable_native_recording.cpp` in this branch.

This flag is compatible with `ZEX_COUNTER_BASED_EVENT_FLAG_IMMEDIATE`, so we may want to directly upstream this change once checking it has no downsides.

There is also a `ZEX_COUNTER_BASED_EVENT_FLAG_EXTERNAL` flag that may also be needed for external synchronization.