### PR TITLE
Support `queue::ext_oneapi_get_state()` with native recording and fix `urQueueIsGraphCaptureEnabledExp`

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -76,6 +76,24 @@ template <> device queue_impl::get_info<info::queue::device>() const {
   return get_device();
 }
 
+ext::oneapi::experimental::queue_state
+queue_impl::ext_oneapi_get_state_impl() const {
+  // A graph may either be recording at the SYCL level or recording at a lower
+  // level API (e.g. L0)
+  if (hasCommandGraph()) {
+    return ext::oneapi::experimental::queue_state::recording;
+  }
+
+  bool IsGraphCaptureEnabled = false;
+  ur_result_t Result =
+      getAdapter().call_nocheck<UrApiKind::urQueueIsGraphCaptureEnabledExp>(
+          MQueue, &IsGraphCaptureEnabled);
+  if (Result == UR_RESULT_SUCCESS && IsGraphCaptureEnabled) {
+    return ext::oneapi::experimental::queue_state::recording;
+  }
+  return ext::oneapi::experimental::queue_state::executing;
+}
+
 static event
 prepareSYCLEventAssociatedWithQueue(detail::queue_impl &QueueImpl) {
   auto EventImpl = detail::event_impl::create_device_event(QueueImpl);

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -639,6 +639,8 @@ public:
 
   bool hasCommandGraph() const { return !MGraph.expired(); }
 
+  ext::oneapi::experimental::queue_state ext_oneapi_get_state_impl() const;
+
   EventImplPtr submit_command_to_graph(
       ext::oneapi::experimental::detail::graph_impl &GraphImpl,
       std::unique_ptr<detail::CG> CommandGroup, sycl::detail::CGType CGType,

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -76,9 +76,7 @@ context queue::get_context() const { return impl->get_context(); }
 device queue::get_device() const { return impl->get_device(); }
 
 ext::oneapi::experimental::queue_state queue::ext_oneapi_get_state() const {
-  return impl->hasCommandGraph()
-             ? ext::oneapi::experimental::queue_state::recording
-             : ext::oneapi::experimental::queue_state::executing;
+  return impl->ext_oneapi_get_state_impl();
 }
 
 ext::oneapi::experimental::command_graph<

--- a/sycl/test-e2e/Graph/RecordReplay/native_recording_multi_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/native_recording_multi_queue.cpp
@@ -84,7 +84,6 @@ int main() {
   Queue1.single_task({Join}, [=]() {
     FinalResult[0] = PartialResult1[0] + PartialResult2[0];
   });
-  assertQueueState(Recording, Executing);
 
   Graph.end_recording();
   assertQueueState(Executing, Executing);

--- a/sycl/test-e2e/Graph/RecordReplay/native_recording_multi_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/native_recording_multi_queue.cpp
@@ -28,6 +28,15 @@ int main() {
                {property::queue::in_order{},
                 ext::intel::property::queue::immediate_command_list{}}};
 
+  const exp_ext::queue_state Recording = exp_ext::queue_state::recording;
+  const exp_ext::queue_state Executing = exp_ext::queue_state::executing;
+
+  auto assertQueueState = [&](exp_ext::queue_state ExpectedQ1,
+                              exp_ext::queue_state ExpectedQ2) {
+    assert(Queue1.ext_oneapi_get_state() == ExpectedQ1);
+    assert(Queue2.ext_oneapi_get_state() == ExpectedQ2);
+  };
+
   // Create a graph - native recording is enabled via
   // SYCL_GRAPH_ENABLE_NATIVE_RECORDING environment variable
   exp_ext::command_graph Graph{Ctx, Dev};
@@ -41,8 +50,11 @@ int main() {
   int *PartialResult2 = malloc_device<int>(1, Dev, Ctx);
   int *FinalResult = malloc_device<int>(1, Dev, Ctx);
 
+  assertQueueState(Executing, Executing);
+
   // Begin graph recording on Queue1 only
   Graph.begin_recording(Queue1);
+  assertQueueState(Recording, Executing);
 
   // Transform VecA
   event Fork =
@@ -57,6 +69,7 @@ int main() {
     }
     PartialResult1[0] = sum;
   });
+  assertQueueState(Recording, Recording);
 
   // Record partial dot product on second half (Queue1)
   exp_ext::single_task(Queue1, [=]() {
@@ -71,8 +84,10 @@ int main() {
   Queue1.single_task({Join}, [=]() {
     FinalResult[0] = PartialResult1[0] + PartialResult2[0];
   });
+  assertQueueState(Recording, Executing);
 
   Graph.end_recording();
+  assertQueueState(Executing, Executing);
 
   // Finalize and execute the graph
   auto ExecutableGraph = Graph.finalize();

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -1375,7 +1375,12 @@ ur_result_t ur_command_list_manager::isGraphCaptureActive(bool *pResult) {
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  *pResult = graphCapture.isActive();
+  ze_result_t ZeResult = hContext.get()
+                             ->getPlatform()
+                             ->ZeGraphExt.zeCommandListIsGraphCaptureEnabledExp(
+                                 getZeCommandList());
+
+  *pResult = (ZeResult == ZE_RESULT_QUERY_TRUE);
 
   return UR_RESULT_SUCCESS;
 }


### PR DESCRIPTION
`queue::ext_oneapi_get_state()` does not work for two reasons:

- The implementation only considers the case where the command graph is set. To support native recording, we can call `urQueueIsGraphCaptureEnabledExp`. If the result is not success, we know we are not recording as the API is unsupported. Otherwise, we check the result.
- `urQueueIsGraphCaptureEnabledExp` does not function properly as it does not handle command list fork-join. We should fix this by querying the L0 API instead of duplicating the logic throughout UR to track queue state transition.