### PR TITLE
pytorch integration fixes

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph/modifiable_graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph/modifiable_graph.hpp
@@ -159,6 +159,8 @@ public:
   /// Get a list of all root nodes (nodes without dependencies) in this graph.
   std::vector<node> get_root_nodes() const;
 
+  bool empty() const;
+
   /// Common Reference Semantics
   friend bool operator==(const modifiable_command_graph &LHS,
                          const modifiable_command_graph &RHS) {

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -623,9 +623,10 @@ void graph_impl::clearQueues(bool NeedsLock) {
     std::swap(MRecordingQueues, SwappedQueues);
   }
 
+  const bool UseNativeRecording = MEnableNativeRecording && MNativeGraphHandle;
   for (auto &Queue : SwappedQueues) {
     if (auto ValidQueue = Queue.lock(); ValidQueue) {
-      if (MEnableNativeRecording && MNativeGraphHandle) {
+      if (UseNativeRecording) {
         // End native UR graph capture
         auto UrQueue = ValidQueue->getHandleRef();
         ur_exp_graph_handle_t CapturedGraph = nullptr;
@@ -635,13 +636,28 @@ void graph_impl::clearQueues(bool NeedsLock) {
                                 "Failed to end native graph capture");
         }
         // CapturedGraph should be the same as MNativeGraphHandle
-      } else {
-        // Only call setCommandGraph for traditional recording
-        ValidQueue->setCommandGraph(nullptr);
       }
+
+      ValidQueue->setCommandGraph(nullptr, UseNativeRecording);
       // AnyQueuesCleared = true;
     }
   }
+}
+
+bool graph_impl::empty() const {
+
+  const bool UseNativeRecording = MEnableNativeRecording && MNativeGraphHandle;
+  if (!UseNativeRecording) {
+    return MNodeStorage.empty();
+  }
+
+  bool IsEmptyResult = true;
+  ur_result_t Result = urGraphIsEmptyExp(MNativeGraphHandle, &IsEmptyResult);
+  if (Result != UR_RESULT_SUCCESS) {
+    throw sycl::exception(sycl::make_error_code(errc::runtime),
+                          "Failed to check if graph is empty");
+  }
+  return IsEmptyResult;
 }
 
 bool graph_impl::checkForCycles() {
@@ -763,7 +779,9 @@ void graph_impl::beginRecordingImpl(sycl::detail::queue_impl &Queue,
   if (!Queue.hasCommandGraph()) {
 
     // Use native UR graph recording if enabled
-    if (MEnableNativeRecording && MNativeGraphHandle) {
+    const bool UseNativeRecording =
+        MEnableNativeRecording && MNativeGraphHandle;
+    if (UseNativeRecording) {
       // Native recording only works with immediate command lists
       // Check if the queue is actually using immediate command lists
       ur_queue_flags_t queueFlags = 0;
@@ -787,14 +805,14 @@ void graph_impl::beginRecordingImpl(sycl::detail::queue_impl &Queue,
         throw sycl::exception(sycl::make_error_code(errc::runtime),
                               "Failed to begin native UR graph capture");
       }
-    } else {
-      // Only set command graph for non-native recording
-      if (LockQueue) {
-        Queue.setCommandGraph(shared_from_this());
-      } else {
-        Queue.setCommandGraphUnlocked(shared_from_this());
-      }
     }
+      // Only set command graph for non-native recording
+    if (LockQueue) {
+      Queue.setCommandGraph(shared_from_this(), UseNativeRecording);
+    } else {
+      Queue.setCommandGraphUnlocked(shared_from_this(), UseNativeRecording);
+    }
+
     addQueue(Queue);
   }
 }
@@ -2160,11 +2178,13 @@ void modifiable_command_graph::end_recording(queue &RecordingQueue) {
         // CapturedGraph should be the same as MNativeGraphHandle
       }
       impl->removeQueue(QueueImpl);
+      QueueImpl.setCommandGraph(nullptr, true);
     }
+
   } else {
     // Traditional recording path
     if (QueueImpl.getCommandGraph() == impl) {
-      QueueImpl.setCommandGraph(nullptr);
+      QueueImpl.setCommandGraph(nullptr, false);
       graph_impl::WriteLock Lock(impl->MMutex);
       impl->removeQueue(QueueImpl);
       IsRecordingToThisGraph = true;
@@ -2204,6 +2224,11 @@ std::vector<node> modifiable_command_graph::get_nodes() const {
 std::vector<node> modifiable_command_graph::get_root_nodes() const {
   graph_impl::ReadLock Lock(impl->MMutex);
   return impl->roots().to<std::vector<node>>();
+}
+
+bool modifiable_command_graph::empty() const {
+  graph_impl::ReadLock Lock(impl->MMutex);
+  return impl->empty();
 }
 
 void modifiable_command_graph::checkNodePropertiesAndThrow(

--- a/sycl/source/detail/graph/graph_impl.hpp
+++ b/sycl/source/detail/graph/graph_impl.hpp
@@ -299,6 +299,7 @@ public:
 
   nodes_range roots() const { return MRoots; }
   nodes_range nodes() const { return MNodeStorage; }
+  bool empty() const;
 
   /// Find the last node added to this graph from an in-order queue.
   /// @param Queue In-order queue to find the last node added to the graph from.

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -614,7 +614,13 @@ public:
 
   void setCommandGraphUnlocked(
       const std::shared_ptr<ext::oneapi::experimental::detail::graph_impl>
-          &Graph) {
+          &Graph,
+      bool native) {
+    if (native) {
+      MGraphNative = Graph;
+      return;
+    }
+
     MGraph = Graph;
     MExtGraphDeps.reset();
 
@@ -627,9 +633,10 @@ public:
 
   void setCommandGraph(
       const std::shared_ptr<ext::oneapi::experimental::detail::graph_impl>
-          &Graph) {
+          &Graph,
+      bool native) {
     std::lock_guard<std::mutex> Lock(MMutex);
-    setCommandGraphUnlocked(Graph);
+    setCommandGraphUnlocked(Graph, native);
   }
 
   std::shared_ptr<ext::oneapi::experimental::detail::graph_impl>
@@ -638,6 +645,8 @@ public:
   }
 
   bool hasCommandGraph() const { return !MGraph.expired(); }
+
+  bool hasNativeCommandGraph() const { return !MGraphNative.expired(); }
 
   EventImplPtr submit_command_to_graph(
       ext::oneapi::experimental::detail::graph_impl &GraphImpl,
@@ -1103,6 +1112,9 @@ protected:
   // Command graph which is associated with this queue for the purposes of
   // recording commands to it.
   std::weak_ptr<ext::oneapi::experimental::detail::graph_impl> MGraph{};
+
+  // Native Command graph, used to determine state of the queue.
+  std::weak_ptr<ext::oneapi::experimental::detail::graph_impl> MGraphNative{};
 
   unsigned long long MQueueID;
   static std::atomic<unsigned long long> MNextAvailableQueueID;

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -76,7 +76,8 @@ context queue::get_context() const { return impl->get_context(); }
 device queue::get_device() const { return impl->get_device(); }
 
 ext::oneapi::experimental::queue_state queue::ext_oneapi_get_state() const {
-  return impl->hasCommandGraph()
+
+  return (impl->hasCommandGraph() || impl->hasNativeCommandGraph())
              ? ext::oneapi::experimental::queue_state::recording
              : ext::oneapi::experimental::queue_state::executing;
 }


### PR DESCRIPTION
fix ext_oneapi_get_state to work with native graph
add empty method to graph that also supports native graphs path

This will resolve two integration issues

non working `queue::ext_oneapi_get_state()` showing up as:
```
Traceback (most recent call last):
  File "/home/lslusarczyk/src/pytorch/benchmarks/dynamo/microbenchmarks/xpu/xpu_graph_launch_overhead.py", line 106, in <module>
    main()
    ~~~~^^
  File "/home/lslusarczyk/src/pytorch/benchmarks/dynamo/microbenchmarks/xpu/xpu_graph_launch_overhead.py", line 99, in main
    graph_t = run_xpu_graph(model, x, args.iters, args.fine_grain_itt)
  File "/home/lslusarczyk/src/pytorch/benchmarks/dynamo/microbenchmarks/xpu/xpu_graph_launch_overhead.py", line 65, in run_xpu_graph
    with torch.xpu.graph(g):
         ~~~~~~~~~~~~~~~^^^
  File "/home/lslusarczyk/src/pytorch/torch/xpu/graphs.py", line 198, in __enter__
    self.xpu_graph.capture_begin(*self.pool)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/lslusarczyk/src/pytorch/torch/xpu/graphs.py", line 85, in capture_begin
    super().capture_begin(pool=pool)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
RuntimeError: capture_stream_.queue().ext_oneapi_get_state() == queue_state::recording INTERNAL ASSERT FAILED at "/home/lslusarczyk/src/pytorch/aten/src/ATen/xpu/XPUGraph.cpp":83, please report a bug to PyTorch.
```

and then not working `get_nodes()` showing up as
```
pytorch/torch/xpu/graphs.py:95: UserWarning: The XPU Graph is empty.
This usually means that the graph was attempted to be captured on wrong device or stream.
(Triggered internally at pytorch/aten/src/ATen/xpu/XPUGraph.cpp:106.)
  super().capture_end()
```